### PR TITLE
Fix build issue in mac os x

### DIFF
--- a/src/bmp/bmp.h
+++ b/src/bmp/bmp.h
@@ -160,7 +160,7 @@ struct bmp_data {
 #include "bmp_logdump.h"
 
 /* prototypes */
-#if (!defined __BMP_C)
+#if !defined(__BMP_C) && !defined(__BMP_LOGDUMP_C)
 #define EXT extern
 #else
 #define EXT


### PR DESCRIPTION
In my enviroment(mac os x), pmacctd and uacctd has error for build.

````
Undefined symbols for architecture x86_64:
  "_bmp_dump_backend_methods", referenced from:
      _bmp_handle_dump_event in libbmp.a(bmp_logdump.o)
  "_bmp_peers", referenced from:
      _bmp_handle_dump_event in libbmp.a(bmp_logdump.o)
     (maybe you meant: _bmp_peers_log)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
````
