### PR TITLE
Compatibility with Jansson 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: required
 
 install:
   - sudo apt-get install libtool autoconf cmake
-  - git clone https://github.com/akheron/jansson
-  - cd jansson && autoreconf -i && ./configure && make && sudo make install && cd ..
   - git clone https://github.com/edenhill/librdkafka
   - cd librdkafka && ./configure && make && sudo make install && cd ..
   - git clone https://github.com/alanxz/rabbitmq-c
@@ -27,4 +25,5 @@ addons:
       - libpq-dev
       - libsqlite3-dev
       - libmysqlclient-dev
+      - libjansson-dev
       - mysql-client

--- a/configure.in
+++ b/configure.in
@@ -1548,7 +1548,7 @@ dnl Checks for library functions.
 AC_TYPE_SIGNAL
 
 dnl AC_CHECK_FUNCS(inet_ntoa socket)
-AC_CHECK_FUNCS([strlcpy vsnprintf setproctitle mallopt])
+AC_CHECK_FUNCS([strlcpy vsnprintf setproctitle mallopt json_object_update_missing])
 
 dnl final checks
 dnl trivial solution to portability issue 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,4 +35,4 @@ uacctd_SOURCES = uacctd.c signals.c util.c strlcpy.c plugin_hooks.c \
 	plugin_common.c preprocess.c
 uacctd_LDFLAGS = $(DEFS) 
 uacctd_LDADD = $(pmacctd_PLUGINS)
-pmacct_SOURCES = pmacct.c strlcpy.c addr.c
+pmacct_SOURCES = pmacct.c strlcpy.c addr.c jansson.c

--- a/src/amqp_plugin.c
+++ b/src/amqp_plugin.c
@@ -27,9 +27,7 @@
 #include "plugin_hooks.h"
 #include "plugin_common.h"
 #include "amqp_plugin.h"
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#else
+#ifndef WITH_JANSSON
 #error "--enable-rabbitmq requires --enable-jansson"
 #endif
 

--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -32,9 +32,6 @@
 #ifdef WITH_KAFKA
 #include "kafka_common.h"
 #endif
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 
 /* variables to be exported away */
 thread_pool_t *bgp_pool;

--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -33,9 +33,6 @@
 #ifdef WITH_KAFKA
 #include "kafka_common.h"
 #endif
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 
 int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, safi_t safi, char *event_type, int output, int log_type)
 {

--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -33,9 +33,6 @@
 #ifdef WITH_KAFKA
 #include "kafka_common.h"
 #endif
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 #include <search.h>
 
 /* variables to be exported away */

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -33,9 +33,6 @@
 #ifdef WITH_KAFKA
 #include "kafka_common.h"
 #endif
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 
 int bmp_log_msg(struct bgp_peer *peer, struct bmp_data *bdata, void *log_data, char *event_type, int output, int log_type)
 {

--- a/src/jansson.c
+++ b/src/jansson.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2009-2014 Petri Lehtinen <petri@digip.org>
+ *
+ * Jansson is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#if (defined WITH_JANSSON) && (!defined HAVE_JANSSON_OBJECT_UPDATE_MISSING)
+#include <jansson.h>
+
+/* Introduced in Jansson 2.3. Rewritten to not use
+ * json_object_foreach() macro. */
+int json_object_update_missing(json_t *object, json_t *other)
+{
+    void *iter;
+
+    if(!json_is_object(object) || !json_is_object(other))
+        return -1;
+
+    iter = json_object_iter(other);
+    while(iter) {
+        const char *key;
+        json_t *value;
+
+        key = json_object_iter_key(iter);
+        if(!json_object_get(object, key)) {
+            value = json_object_iter_value(iter);
+            if(json_object_set_nocheck(object, key, value))
+                return -1;
+        }
+
+        iter = json_object_iter_next(other, iter);
+    }
+
+    return 0;
+}
+#endif

--- a/src/kafka_plugin.c
+++ b/src/kafka_plugin.c
@@ -27,9 +27,7 @@
 #include "plugin_hooks.h"
 #include "plugin_common.h"
 #include "kafka_plugin.h"
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#else
+#ifndef WITH_JANSSON
 #error "--enable-kafka requires --enable-jansson"
 #endif
 

--- a/src/pmacct.c
+++ b/src/pmacct.c
@@ -27,9 +27,6 @@
 #include "imt_plugin.h"
 #include "bgp/bgp_packet.h"
 #include "bgp/bgp.h"
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 
 /* prototypes */
 int Recv(int, unsigned char **);

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -346,6 +346,11 @@ EXT struct child_ctl sql_writers;
 size_t strlcpy(char *, const char *, size_t);
 #endif
 
+#if (defined WITH_JANSSON) && (!defined HAVE_JANSSON_OBJECT_UPDATE_MISSING)
+#include <jansson.h>
+int json_object_update_missing(json_t *, json_t *);
+#endif
+
 /* global variables */
 pcap_t *glob_pcapt;
 struct pcap_stat ps;

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -43,9 +43,6 @@
 #include "classifier.h"
 #include "net_aggr.h"
 #include "crc32.c"
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 
 /* variables to be exported away */
 int debug;

--- a/src/util.c
+++ b/src/util.c
@@ -27,9 +27,6 @@
 #include "ip_flow.h"
 #include "classifier.h"
 #include "plugin_hooks.h"
-#ifdef WITH_JANSSON
-#include <jansson.h>
-#endif
 #include <search.h>
 
 static const char pkt_len_distrib_unknown[] = "unknown";


### PR DESCRIPTION
Hi Paolo!

I wanted to make pmacct compile on Precise which only ships with Jansson 2.2. It doesn't feature `json_object_update_missing()` function. Like for `strlcpy()`, I test for the presence of such a function and include its definition when absent.

The second commit also makes Travis use it.

I didn't run `autoreconf -i` as I have a widely different version of autotools than you have and this would pull so many changes. Moreover, for some reasons left to be investigated, this doesn't compile as expected unless I run the `bin/fix_autotools_timestamps.sh` but in this case, the `.deps` directory doesn't get created and the compilation fails. Before trying to investigate more, maybe you have some hints? I also notice that there are some missing `Makefile.am` in `src/*` directories. (insert an emoticon of someone being perplex)