### PR TITLE
* log: use a format string when calling syslog()

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -43,7 +43,7 @@ void Log(short int level, char *msg, ...)
     vsnprintf(syslog_string, LOGSTRLEN, msg, ap);
     va_end(ap);
 
-    if (config.syslog) syslog(level, syslog_string);
+    if (config.syslog) syslog(level, "%s", syslog_string);
 
     if (config.logfile_fd) {
       char timebuf[SRVBUFLEN];


### PR DESCRIPTION
Passing directly a potentially uncontrolled string could crash the
program if the string contains formatting parameters. Instead, use
`"%s"` as a formatting string.