### PR TITLE
* build: use more modern form for AM_INIT_AUTOMAKE

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 dnl configuration file for pmacct 
 
 AC_INIT([src/pmacctd.c], [1.6.0-git], [paolo@pmacct.net])
-AM_INIT_AUTOMAKE([pmacctd], [1.6.0-git])
+AM_INIT_AUTOMAKE([foreign])
 AC_PREFIX_DEFAULT([/usr/local])
 
 COMPILE_ARGS="${ac_configure_args}"


### PR DESCRIPTION
With recent automake versions, the macro AM_INIT_AUTOMAKE only takes a
list of flags as first argument. The version and project name should be
specified in AC_INIT and this was already the case. Moreover, we specify
we are not a GNU project (so we don't require some mandatory files).

**I didn't regenerate all files!**

I think it would be better to provide an "autogen" script and to remove autogenerated files from git. Released tarballs would still be able to include the generated files. I can do a PR to demonstrate this.