### PR TITLE
fflush stdout before releasing lock

### DIFF
--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -1244,6 +1244,7 @@ void P_cache_purge(struct chained_cache *queue[], int index)
   }
   else {
     /* writing to stdout: releasing lock */
+    fflush(f);
     close_output_file(lockf);
   }
 


### PR DESCRIPTION
Since stdout is buffered, we need to make sure to flush the buffer before releasing the lock.