### PR TITLE
json: promote integers to json_int_t before packing

### DIFF
--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -75,7 +75,7 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, safi_t safi, c
 
     /* no need for seq and timestamp for "dump" event_type */
     if (etype == BGP_LOGDUMP_ET_LOG) {
-      kv = json_pack("{sI}", "seq", bms->log_seq);
+      kv = json_pack("{sI}", "seq", (json_int_t)bms->log_seq);
       json_object_update_missing(obj, kv);
       json_decref(kv);
       bgp_peer_log_seq_increment(&bms->log_seq);
@@ -95,7 +95,7 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, safi_t safi, c
 	kv = json_pack("{ss}", "log_type", "delete");
 	break;
       default:
-	kv = json_pack("{sI}", "log_type", log_type);
+	kv = json_pack("{sI}", "log_type", (json_int_t)log_type);
 	break;
       }
       json_object_update_missing(obj, kv);
@@ -122,7 +122,7 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, safi_t safi, c
     }
 
     if (ri && ri->extra && ri->extra->path_id) {
-      kv = json_pack("{sI}", "as_path_id", ri->extra->path_id);
+      kv = json_pack("{sI}", "as_path_id", (json_int_t)ri->extra->path_id);
       json_object_update_missing(obj, kv);
       json_decref(kv);
     }
@@ -152,16 +152,16 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, safi_t safi, c
         json_decref(kv);
       }
 
-      kv = json_pack("{sI}", "origin", attr->origin);
+      kv = json_pack("{sI}", "origin", (json_int_t)attr->origin);
       json_object_update_missing(obj, kv);
       json_decref(kv);
 
-      kv = json_pack("{sI}", "local_pref", attr->local_pref);
+      kv = json_pack("{sI}", "local_pref", (json_int_t)attr->local_pref);
       json_object_update_missing(obj, kv);
       json_decref(kv);
 
       if (attr->med) {
-        kv = json_pack("{sI}", "med", attr->med);
+        kv = json_pack("{sI}", "med", (json_int_t)attr->med);
         json_object_update_missing(obj, kv);
         json_decref(kv);
       }
@@ -276,7 +276,7 @@ int bgp_peer_log_init(struct bgp_peer *peer, int output, int type)
       char ip_address[INET6_ADDRSTRLEN];
       json_t *obj = json_object(), *kv;
 
-      kv = json_pack("{sI}", "seq", bms->log_seq);
+      kv = json_pack("{sI}", "seq", (json_int_t)bms->log_seq);
       json_object_update_missing(obj, kv);
       json_decref(kv);
       bgp_peer_log_seq_increment(&bms->log_seq);
@@ -350,7 +350,7 @@ int bgp_peer_log_close(struct bgp_peer *peer, int output, int type)
     char ip_address[INET6_ADDRSTRLEN];
     json_t *obj = json_object(), *kv;
 
-    kv = json_pack("{sI}", "seq", bms->log_seq);
+    kv = json_pack("{sI}", "seq", (json_int_t)bms->log_seq);
     json_object_update_missing(obj, kv);
     json_decref(kv);
     bgp_peer_log_seq_increment(&bms->log_seq);
@@ -558,11 +558,11 @@ int bgp_peer_dump_close(struct bgp_peer *peer, struct bgp_dump_stats *bds, int o
     json_decref(kv);
 
     if (bds) {
-      kv = json_pack("{sI}", "entries", bds->entries);
+      kv = json_pack("{sI}", "entries", (json_int_t)bds->entries);
       json_object_update_missing(obj, kv);
       json_decref(kv);
 
-      kv = json_pack("{sI}", "tables", bds->tables);
+      kv = json_pack("{sI}", "tables", (json_int_t)bds->tables);
       json_object_update_missing(obj, kv);
       json_decref(kv);
     }

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -67,7 +67,7 @@ int bmp_log_msg(struct bgp_peer *peer, struct bmp_data *bdata, void *log_data, c
 
     /* no need for seq for "dump" event_type */
     if (etype == BGP_LOGDUMP_ET_LOG) {
-      kv = json_pack("{sI}", "seq", bms->log_seq);
+      kv = json_pack("{sI}", "seq", (json_int_t)bms->log_seq);
       json_object_update_missing(obj, kv);
       json_decref(kv);
       bgp_peer_log_seq_increment(&bms->log_seq);
@@ -146,15 +146,15 @@ int bmp_log_msg_stats(struct bgp_peer *peer, struct bmp_data *bdata, struct bmp_
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "peer_asn", bdata->peer_asn);
+  kv = json_pack("{sI}", "peer_asn", (json_int_t)bdata->peer_asn);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "peer_type", bdata->peer_type);
+  kv = json_pack("{sI}", "peer_type", (json_int_t)bdata->peer_type);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "counter_type", blstats->cnt_type);
+  kv = json_pack("{sI}", "counter_type", (json_int_t)blstats->cnt_type);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
@@ -170,7 +170,7 @@ int bmp_log_msg_stats(struct bgp_peer *peer, struct bmp_data *bdata, struct bmp_
   }
 
   if (blstats->got_data) {
-    kv = json_pack("{sI}", "counter_value", blstats->cnt_data);
+    kv = json_pack("{sI}", "counter_value", (json_int_t)blstats->cnt_data);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -193,11 +193,11 @@ int bmp_log_msg_init(struct bgp_peer *peer, struct bmp_data *bdata, struct bmp_l
   json_decref(kv);
 
   if (blinit) {
-    kv = json_pack("{sI}", "bmp_init_data_type", blinit->type);
+    kv = json_pack("{sI}", "bmp_init_data_type", (json_int_t)blinit->type);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
-    kv = json_pack("{sI}", "bmp_init_data_len", blinit->len);
+    kv = json_pack("{sI}", "bmp_init_data_len", (json_int_t)blinit->len);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
@@ -226,11 +226,11 @@ int bmp_log_msg_term(struct bgp_peer *peer, struct bmp_data *bdata, struct bmp_l
   json_decref(kv);
 
   if (blterm) {
-    kv = json_pack("{sI}", "bmp_term_data_type", blterm->type);
+    kv = json_pack("{sI}", "bmp_term_data_type", (json_int_t)blterm->type);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
-    kv = json_pack("{sI}", "bmp_term_data_len", blterm->len);
+    kv = json_pack("{sI}", "bmp_term_data_len", (json_int_t)blterm->len);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
@@ -240,7 +240,7 @@ int bmp_log_msg_term(struct bgp_peer *peer, struct bmp_data *bdata, struct bmp_l
       json_decref(kv);
     }
     else if (blterm->type == BMP_TERM_INFO_REASON) {
-      kv = json_pack("{sI}", "bmp_term_data_val_reas_type", blterm->reas_type);
+      kv = json_pack("{sI}", "bmp_term_data_val_reas_type", (json_int_t)blterm->reas_type);
       json_object_update_missing(obj, kv);
       json_decref(kv);
 
@@ -275,11 +275,11 @@ int bmp_log_msg_peer_up(struct bgp_peer *peer, struct bmp_data *bdata, struct bm
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "peer_asn", bdata->peer_asn);
+  kv = json_pack("{sI}", "peer_asn", (json_int_t)bdata->peer_asn);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "peer_type", bdata->peer_type);
+  kv = json_pack("{sI}", "peer_type", (json_int_t)bdata->peer_type);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
@@ -287,11 +287,11 @@ int bmp_log_msg_peer_up(struct bgp_peer *peer, struct bmp_data *bdata, struct bm
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "local_port", blpu->loc_port);
+  kv = json_pack("{sI}", "local_port", (json_int_t)blpu->loc_port);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "remote_port", blpu->rem_port);
+  kv = json_pack("{sI}", "remote_port", (json_int_t)blpu->rem_port);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
@@ -323,20 +323,20 @@ int bmp_log_msg_peer_down(struct bgp_peer *peer, struct bmp_data *bdata, struct 
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "peer_asn", bdata->peer_asn);
+  kv = json_pack("{sI}", "peer_asn", (json_int_t)bdata->peer_asn);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "peer_type", bdata->peer_type);
+  kv = json_pack("{sI}", "peer_type", (json_int_t)bdata->peer_type);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "reason_type", blpd->reason);
+  kv = json_pack("{sI}", "reason_type", (json_int_t)blpd->reason);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
   if (blpd->reason == BMP_PEER_DOWN_LOC_CODE) {
-    kv = json_pack("{sI}", "reason_loc_code", blpd->loc_code);
+    kv = json_pack("{sI}", "reason_loc_code", (json_int_t)blpd->loc_code);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }

--- a/src/pmacct.c
+++ b/src/pmacct.c
@@ -3131,13 +3131,13 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   json_t *obj = json_object(), *kv;
   
   if (wtc & COUNT_TAG) {
-    kv = json_pack("{sI}", "tag", pbase->tag);
+    kv = json_pack("{sI}", "tag", (json_int_t)pbase->tag);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_TAG2) {
-    kv = json_pack("{sI}", "tag2", pbase->tag2);
+    kv = json_pack("{sI}", "tag2", (json_int_t)pbase->tag2);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3173,13 +3173,13 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (wtc & COUNT_VLAN) {
-    kv = json_pack("{sI}", "vlan", pbase->vlan_id);
+    kv = json_pack("{sI}", "vlan", (json_int_t)pbase->vlan_id);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_COS) {
-    kv = json_pack("{sI}", "cos", pbase->cos);
+    kv = json_pack("{sI}", "cos", (json_int_t)pbase->cos);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3193,13 +3193,13 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
 #endif
 
   if (wtc & COUNT_SRC_AS) {
-    kv = json_pack("{sI}", "as_src", pbase->src_as);
+    kv = json_pack("{sI}", "as_src", (json_int_t)pbase->src_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_DST_AS) {
-    kv = json_pack("{sI}", "as_dst", pbase->dst_as);
+    kv = json_pack("{sI}", "as_dst", (json_int_t)pbase->dst_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3252,25 +3252,25 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (wtc & COUNT_LOCAL_PREF) {
-    kv = json_pack("{sI}", "local_pref", pbgp->local_pref);
+    kv = json_pack("{sI}", "local_pref", (json_int_t)pbgp->local_pref);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_MED) {
-    kv = json_pack("{sI}", "med", pbgp->med);
+    kv = json_pack("{sI}", "med", (json_int_t)pbgp->med);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_PEER_SRC_AS) {
-    kv = json_pack("{sI}", "peer_as_src", pbgp->peer_src_as);
+    kv = json_pack("{sI}", "peer_as_src", (json_int_t)pbgp->peer_src_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_PEER_DST_AS) {
-    kv = json_pack("{sI}", "peer_as_dst", pbgp->peer_dst_as);
+    kv = json_pack("{sI}", "peer_as_dst", (json_int_t)pbgp->peer_dst_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3337,25 +3337,25 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (wtc & COUNT_SRC_LOCAL_PREF) {
-    kv = json_pack("{sI}", "src_local_pref", pbgp->src_local_pref);
+    kv = json_pack("{sI}", "src_local_pref", (json_int_t)pbgp->src_local_pref);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_SRC_MED) {
-    kv = json_pack("{sI}", "src_med", pbgp->src_med);
+    kv = json_pack("{sI}", "src_med", (json_int_t)pbgp->src_med);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_IN_IFACE) {
-    kv = json_pack("{sI}", "iface_in", pbase->ifindex_in);
+    kv = json_pack("{sI}", "iface_in", (json_int_t)pbase->ifindex_in);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_OUT_IFACE) {
-    kv = json_pack("{sI}", "iface_out", pbase->ifindex_out);
+    kv = json_pack("{sI}", "iface_out", (json_int_t)pbase->ifindex_out);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3398,25 +3398,25 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (wtc & COUNT_SRC_NMASK) {
-    kv = json_pack("{sI}", "mask_src", pbase->src_nmask);
+    kv = json_pack("{sI}", "mask_src", (json_int_t)pbase->src_nmask);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_DST_NMASK) {
-    kv = json_pack("{sI}", "mask_dst", pbase->dst_nmask);
+    kv = json_pack("{sI}", "mask_dst", (json_int_t)pbase->dst_nmask);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_SRC_PORT) {
-    kv = json_pack("{sI}", "port_src", pbase->src_port);
+    kv = json_pack("{sI}", "port_src", (json_int_t)pbase->src_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_DST_PORT) {
-    kv = json_pack("{sI}", "port_dst", pbase->dst_port);
+    kv = json_pack("{sI}", "port_dst", (json_int_t)pbase->dst_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3473,19 +3473,19 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
 
   if (wtc & COUNT_IP_PROTO) {
     if (!want_ipproto_num) kv = json_pack("{ss}", "ip_proto", _protocols[pbase->proto].name);
-    else kv = json_pack("{sI}", "ip_proto", _protocols[pbase->proto].number);
+    else kv = json_pack("{sI}", "ip_proto", (json_int_t)_protocols[pbase->proto].number);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_IP_TOS) {
-    kv = json_pack("{sI}", "tos", pbase->tos);
+    kv = json_pack("{sI}", "tos", (json_int_t)pbase->tos);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_SAMPLING_RATE) {
-    kv = json_pack("{sI}", "sampling_rate", pbase->sampling_rate);
+    kv = json_pack("{sI}", "sampling_rate", (json_int_t)pbase->sampling_rate);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3516,37 +3516,37 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (wtc_2 & COUNT_POST_NAT_SRC_PORT) {
-    kv = json_pack("{sI}", "post_nat_port_src", pnat->post_nat_src_port);
+    kv = json_pack("{sI}", "post_nat_port_src", (json_int_t)pnat->post_nat_src_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_POST_NAT_DST_PORT) {
-    kv = json_pack("{sI}", "post_nat_port_dst", pnat->post_nat_dst_port);
+    kv = json_pack("{sI}", "post_nat_port_dst", (json_int_t)pnat->post_nat_dst_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_NAT_EVENT) {
-    kv = json_pack("{sI}", "nat_event", pnat->nat_event);
+    kv = json_pack("{sI}", "nat_event", (json_int_t)pnat->nat_event);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_MPLS_LABEL_TOP) {
-    kv = json_pack("{sI}", "mpls_label_top", pmpls->mpls_label_top);
+    kv = json_pack("{sI}", "mpls_label_top", (json_int_t)pmpls->mpls_label_top);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_MPLS_LABEL_BOTTOM) {
-    kv = json_pack("{sI}", "mpls_label_bottom", pmpls->mpls_label_bottom);
+    kv = json_pack("{sI}", "mpls_label_bottom", (json_int_t)pmpls->mpls_label_bottom);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_MPLS_STACK_DEPTH) {
-    kv = json_pack("{sI}", "mpls_stack_depth", pmpls->mpls_stack_depth);
+    kv = json_pack("{sI}", "mpls_stack_depth", (json_int_t)pmpls->mpls_stack_depth);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3573,13 +3573,13 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (wtc_2 & COUNT_EXPORT_PROTO_SEQNO) {
-    kv = json_pack("{sI}", "export_proto_seqno", pbase->export_proto_seqno);
+    kv = json_pack("{sI}", "export_proto_seqno", (json_int_t)pbase->export_proto_seqno);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_EXPORT_PROTO_VERSION) {
-    kv = json_pack("{sI}", "export_proto_version", pbase->export_proto_version);
+    kv = json_pack("{sI}", "export_proto_version", (json_int_t)pbase->export_proto_version);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -3609,17 +3609,17 @@ char *pmc_compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struc
   }
 
   if (flow_type != NF9_FTYPE_EVENT && flow_type != NF9_FTYPE_OPTION) {
-    kv = json_pack("{sI}", "packets", packet_counter);
+    kv = json_pack("{sI}", "packets", (json_int_t)packet_counter);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
     if (wtc & COUNT_FLOWS) {
-      kv = json_pack("{sI}", "flows", flow_counter);
+      kv = json_pack("{sI}", "flows", (json_int_t)flow_counter);
       json_object_update_missing(obj, kv);
       json_decref(kv);
     }
 
-    kv = json_pack("{sI}", "bytes", bytes_counter);
+    kv = json_pack("{sI}", "bytes", (json_int_t)bytes_counter);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -3040,7 +3040,7 @@ int sf_cnt_log_msg(struct bgp_peer *peer, SFSample *sample, u_int32_t len, char 
 
     /* no need for seq and timestamp for "dump" event_type */
     if (etype == BGP_LOGDUMP_ET_LOG) {
-      kv = json_pack("{sI}", "seq", bms->log_seq);
+      kv = json_pack("{sI}", "seq", (json_int_t)bms->log_seq);
       json_object_update_missing(obj, kv);
       json_decref(kv);
       bgp_peer_log_seq_increment(&bms->log_seq);
@@ -3059,15 +3059,15 @@ int sf_cnt_log_msg(struct bgp_peer *peer, SFSample *sample, u_int32_t len, char 
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
-    kv = json_pack("{sI}", "source_id_index", sample->ds_index);
+    kv = json_pack("{sI}", "source_id_index", (json_int_t)sample->ds_index);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
-    kv = json_pack("{sI}", "sflow_seq", sample->sequenceNo);
+    kv = json_pack("{sI}", "sflow_seq", (json_int_t)sample->sequenceNo);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
-    kv = json_pack("{sI}", "sflow_cnt_seq", sample->cntSequenceNo);
+    kv = json_pack("{sI}", "sflow_cnt_seq", (json_int_t)sample->cntSequenceNo);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
@@ -3145,79 +3145,79 @@ int readCounters_generic(struct bgp_peer *peer, SFSample *sample, char *event_ty
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifIndex", sample->ifCounters.ifIndex);
+  kv = json_pack("{sI}", "ifIndex", (json_int_t)sample->ifCounters.ifIndex);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifType", sample->ifCounters.ifType);
+  kv = json_pack("{sI}", "ifType", (json_int_t)sample->ifCounters.ifType);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifSpeed", sample->ifCounters.ifSpeed);
+  kv = json_pack("{sI}", "ifSpeed", (json_int_t)sample->ifCounters.ifSpeed);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifDirection", sample->ifCounters.ifDirection);
+  kv = json_pack("{sI}", "ifDirection", (json_int_t)sample->ifCounters.ifDirection);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifStatus", sample->ifCounters.ifStatus);
+  kv = json_pack("{sI}", "ifStatus", (json_int_t)sample->ifCounters.ifStatus);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInOctets", sample->ifCounters.ifInOctets);
+  kv = json_pack("{sI}", "ifInOctets", (json_int_t)sample->ifCounters.ifInOctets);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInUcastPkts", sample->ifCounters.ifInUcastPkts);
+  kv = json_pack("{sI}", "ifInUcastPkts", (json_int_t)sample->ifCounters.ifInUcastPkts);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInMulticastPkts", sample->ifCounters.ifInMulticastPkts);
+  kv = json_pack("{sI}", "ifInMulticastPkts", (json_int_t)sample->ifCounters.ifInMulticastPkts);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInBroadcastPkts", sample->ifCounters.ifInBroadcastPkts);
+  kv = json_pack("{sI}", "ifInBroadcastPkts", (json_int_t)sample->ifCounters.ifInBroadcastPkts);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInDiscards", sample->ifCounters.ifInDiscards);
+  kv = json_pack("{sI}", "ifInDiscards", (json_int_t)sample->ifCounters.ifInDiscards);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInErrors", sample->ifCounters.ifInErrors);
+  kv = json_pack("{sI}", "ifInErrors", (json_int_t)sample->ifCounters.ifInErrors);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifInUnknownProtos", sample->ifCounters.ifInUnknownProtos);
+  kv = json_pack("{sI}", "ifInUnknownProtos", (json_int_t)sample->ifCounters.ifInUnknownProtos);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifOutOctets", sample->ifCounters.ifOutOctets);
+  kv = json_pack("{sI}", "ifOutOctets", (json_int_t)sample->ifCounters.ifOutOctets);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifOutUcastPkts", sample->ifCounters.ifOutUcastPkts);
+  kv = json_pack("{sI}", "ifOutUcastPkts", (json_int_t)sample->ifCounters.ifOutUcastPkts);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifOutMulticastPkts", sample->ifCounters.ifOutMulticastPkts);
+  kv = json_pack("{sI}", "ifOutMulticastPkts", (json_int_t)sample->ifCounters.ifOutMulticastPkts);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifOutBroadcastPkts", sample->ifCounters.ifOutBroadcastPkts);
+  kv = json_pack("{sI}", "ifOutBroadcastPkts", (json_int_t)sample->ifCounters.ifOutBroadcastPkts);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifOutDiscards", sample->ifCounters.ifOutDiscards);
+  kv = json_pack("{sI}", "ifOutDiscards", (json_int_t)sample->ifCounters.ifOutDiscards);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifOutErrors", sample->ifCounters.ifOutErrors);
+  kv = json_pack("{sI}", "ifOutErrors", (json_int_t)sample->ifCounters.ifOutErrors);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ifPromiscuousMode", sample->ifCounters.ifPromiscuousMode);
+  kv = json_pack("{sI}", "ifPromiscuousMode", (json_int_t)sample->ifCounters.ifPromiscuousMode);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 #endif
@@ -3258,55 +3258,55 @@ int readCounters_ethernet(struct bgp_peer *peer, SFSample *sample, char *event_t
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsAlignmentErrors", m32_1);
+  kv = json_pack("{sI}", "dot3StatsAlignmentErrors", (json_int_t)m32_1);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsFCSErrors", m32_2);
+  kv = json_pack("{sI}", "dot3StatsFCSErrors", (json_int_t)m32_2);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsSingleCollisionFrames", m32_3);
+  kv = json_pack("{sI}", "dot3StatsSingleCollisionFrames", (json_int_t)m32_3);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsMultipleCollisionFrames", m32_4);
+  kv = json_pack("{sI}", "dot3StatsMultipleCollisionFrames", (json_int_t)m32_4);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsSQETestErrors", m32_5);
+  kv = json_pack("{sI}", "dot3StatsSQETestErrors", (json_int_t)m32_5);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsDeferredTransmissions", m32_6);
+  kv = json_pack("{sI}", "dot3StatsDeferredTransmissions", (json_int_t)m32_6);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsLateCollisions", m32_7);
+  kv = json_pack("{sI}", "dot3StatsLateCollisions", (json_int_t)m32_7);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsExcessiveCollisions", m32_8);
+  kv = json_pack("{sI}", "dot3StatsExcessiveCollisions", (json_int_t)m32_8);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsInternalMacTransmitErrors", m32_9);
+  kv = json_pack("{sI}", "dot3StatsInternalMacTransmitErrors", (json_int_t)m32_9);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsCarrierSenseErrors", m32_10);
+  kv = json_pack("{sI}", "dot3StatsCarrierSenseErrors", (json_int_t)m32_10);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsFrameTooLongs", m32_11);
+  kv = json_pack("{sI}", "dot3StatsFrameTooLongs", (json_int_t)m32_11);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsInternalMacReceiveErrors", m32_12);
+  kv = json_pack("{sI}", "dot3StatsInternalMacReceiveErrors", (json_int_t)m32_12);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "dot3StatsSymbolErrors", m32_13);
+  kv = json_pack("{sI}", "dot3StatsSymbolErrors", (json_int_t)m32_13);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 #endif
@@ -3339,27 +3339,27 @@ int readCounters_vlan(struct bgp_peer *peer, SFSample *sample, char *event_type,
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "octets", m64_1);
+  kv = json_pack("{sI}", "octets", (json_int_t)m64_1);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "ucastPkts", m32_1);
+  kv = json_pack("{sI}", "ucastPkts", (json_int_t)m32_1);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "multicastPkts", m32_2);
+  kv = json_pack("{sI}", "multicastPkts", (json_int_t)m32_2);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "broadcastPkts", m32_3);
+  kv = json_pack("{sI}", "broadcastPkts", (json_int_t)m32_3);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "discards", m32_3);
+  kv = json_pack("{sI}", "discards", (json_int_t)m32_3);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 
-  kv = json_pack("{sI}", "vlan", sample->in_vlan);
+  kv = json_pack("{sI}", "vlan", (json_int_t)sample->in_vlan);
   json_object_update_missing(obj, kv);
   json_decref(kv);
 #endif

--- a/src/telemetry/telemetry_logdump.c
+++ b/src/telemetry/telemetry_logdump.c
@@ -70,7 +70,7 @@ int telemetry_log_msg(telemetry_peer *peer, struct telemetry_data *t_data, void 
 
     /* no need for seq for "dump" event_type */
     if (etype == BGP_LOGDUMP_ET_LOG) {
-      kv = json_pack("{sI}", "seq", tms->log_seq);
+      kv = json_pack("{sI}", "seq", (json_int_t)tms->log_seq);
       json_object_update_missing(obj, kv);
       json_decref(kv);
       bgp_peer_log_seq_increment(&tms->log_seq);

--- a/src/util.c
+++ b/src/util.c
@@ -1615,13 +1615,13 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   json_t *obj = json_object(), *kv;
 
   if (wtc & COUNT_TAG) {
-    kv = json_pack("{sI}", "tag", pbase->tag);
+    kv = json_pack("{sI}", "tag", (json_int_t)pbase->tag);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_TAG2) {
-    kv = json_pack("{sI}", "tag2", pbase->tag2);
+    kv = json_pack("{sI}", "tag2", (json_int_t)pbase->tag2);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1657,13 +1657,13 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (wtc & COUNT_VLAN) {
-    kv = json_pack("{sI}", "vlan", pbase->vlan_id);
+    kv = json_pack("{sI}", "vlan", (json_int_t)pbase->vlan_id);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_COS) {
-    kv = json_pack("{sI}", "cos", pbase->cos);
+    kv = json_pack("{sI}", "cos", (json_int_t)pbase->cos);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1677,13 +1677,13 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
 #endif
 
   if (wtc & (COUNT_SRC_AS|COUNT_SUM_AS)) {
-    kv = json_pack("{sI}", "as_src", pbase->src_as);
+    kv = json_pack("{sI}", "as_src", (json_int_t)pbase->src_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_DST_AS) {
-    kv = json_pack("{sI}", "as_dst", pbase->dst_as);
+    kv = json_pack("{sI}", "as_dst", (json_int_t)pbase->dst_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1736,25 +1736,25 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (wtc & COUNT_LOCAL_PREF) {
-    kv = json_pack("{sI}", "local_pref", pbgp->local_pref);
+    kv = json_pack("{sI}", "local_pref", (json_int_t)pbgp->local_pref);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_MED) {
-    kv = json_pack("{sI}", "med", pbgp->med);
+    kv = json_pack("{sI}", "med", (json_int_t)pbgp->med);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_PEER_SRC_AS) {
-    kv = json_pack("{sI}", "peer_as_src", pbgp->peer_src_as);
+    kv = json_pack("{sI}", "peer_as_src", (json_int_t)pbgp->peer_src_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_PEER_DST_AS) {
-    kv = json_pack("{sI}", "peer_as_dst", pbgp->peer_dst_as);
+    kv = json_pack("{sI}", "peer_as_dst", (json_int_t)pbgp->peer_dst_as);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1821,25 +1821,25 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (wtc & COUNT_SRC_LOCAL_PREF) {
-    kv = json_pack("{sI}", "src_local_pref", pbgp->src_local_pref);
+    kv = json_pack("{sI}", "src_local_pref", (json_int_t)pbgp->src_local_pref);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_SRC_MED) {
-    kv = json_pack("{sI}", "src_med", pbgp->src_med);
+    kv = json_pack("{sI}", "src_med", (json_int_t)pbgp->src_med);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_IN_IFACE) {
-    kv = json_pack("{sI}", "iface_in", pbase->ifindex_in);
+    kv = json_pack("{sI}", "iface_in", (json_int_t)pbase->ifindex_in);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_OUT_IFACE) {
-    kv = json_pack("{sI}", "iface_out", pbase->ifindex_out);
+    kv = json_pack("{sI}", "iface_out", (json_int_t)pbase->ifindex_out);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1882,25 +1882,25 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (wtc & COUNT_SRC_NMASK) {
-    kv = json_pack("{sI}", "mask_src", pbase->src_nmask);
+    kv = json_pack("{sI}", "mask_src", (json_int_t)pbase->src_nmask);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_DST_NMASK) {
-    kv = json_pack("{sI}", "mask_dst", pbase->dst_nmask);
+    kv = json_pack("{sI}", "mask_dst", (json_int_t)pbase->dst_nmask);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & (COUNT_SRC_PORT|COUNT_SUM_PORT)) {
-    kv = json_pack("{sI}", "port_src", pbase->src_port);
+    kv = json_pack("{sI}", "port_src", (json_int_t)pbase->src_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_DST_PORT) {
-    kv = json_pack("{sI}", "port_dst", pbase->dst_port);
+    kv = json_pack("{sI}", "port_dst", (json_int_t)pbase->dst_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1959,19 +1959,19 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
     if (!config.num_protos && (pbase->proto < protocols_number))
       kv = json_pack("{ss}", "ip_proto", _protocols[pbase->proto].name);
     else
-      kv = json_pack("{sI}", "ip_proto", pbase->proto);
+      kv = json_pack("{sI}", "ip_proto", (json_int_t)pbase->proto);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc & COUNT_IP_TOS) {
-    kv = json_pack("{sI}", "tos", pbase->tos);
+    kv = json_pack("{sI}", "tos", (json_int_t)pbase->tos);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_SAMPLING_RATE) {
-    kv = json_pack("{sI}", "sampling_rate", pbase->sampling_rate);
+    kv = json_pack("{sI}", "sampling_rate", (json_int_t)pbase->sampling_rate);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -1996,37 +1996,37 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (wtc_2 & COUNT_POST_NAT_SRC_PORT) {
-    kv = json_pack("{sI}", "post_nat_port_src", pnat->post_nat_src_port);
+    kv = json_pack("{sI}", "post_nat_port_src", (json_int_t)pnat->post_nat_src_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_POST_NAT_DST_PORT) {
-    kv = json_pack("{sI}", "post_nat_port_dst", pnat->post_nat_dst_port);
+    kv = json_pack("{sI}", "post_nat_port_dst", (json_int_t)pnat->post_nat_dst_port);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_NAT_EVENT) {
-    kv = json_pack("{sI}", "nat_event", pnat->nat_event);
+    kv = json_pack("{sI}", "nat_event", (json_int_t)pnat->nat_event);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_MPLS_LABEL_TOP) {
-    kv = json_pack("{sI}", "mpls_label_top", pmpls->mpls_label_top);
+    kv = json_pack("{sI}", "mpls_label_top", (json_int_t)pmpls->mpls_label_top);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_MPLS_LABEL_BOTTOM) {
-    kv = json_pack("{sI}", "mpls_label_bottom", pmpls->mpls_label_bottom);
+    kv = json_pack("{sI}", "mpls_label_bottom", (json_int_t)pmpls->mpls_label_bottom);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_MPLS_STACK_DEPTH) {
-    kv = json_pack("{sI}", "mpls_stack_depth", pmpls->mpls_stack_depth);
+    kv = json_pack("{sI}", "mpls_stack_depth", (json_int_t)pmpls->mpls_stack_depth);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -2065,13 +2065,13 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (wtc_2 & COUNT_EXPORT_PROTO_SEQNO) {
-    kv = json_pack("{sI}", "export_proto_seqno", pbase->export_proto_seqno);
+    kv = json_pack("{sI}", "export_proto_seqno", (json_int_t)pbase->export_proto_seqno);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
 
   if (wtc_2 & COUNT_EXPORT_PROTO_VERSION) {
-    kv = json_pack("{sI}", "export_proto_version", pbase->export_proto_version);
+    kv = json_pack("{sI}", "export_proto_version", (json_int_t)pbase->export_proto_version);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }
@@ -2119,17 +2119,17 @@ void *compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flow_type, struct pk
   }
 
   if (flow_type != NF9_FTYPE_EVENT && flow_type != NF9_FTYPE_OPTION) {
-    kv = json_pack("{sI}", "packets", packet_counter);
+    kv = json_pack("{sI}", "packets", (json_int_t)packet_counter);
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
     if (wtc & COUNT_FLOWS) {
-      kv = json_pack("{sI}", "flows", flow_counter);
+      kv = json_pack("{sI}", "flows", (json_int_t)flow_counter);
       json_object_update_missing(obj, kv);
       json_decref(kv);
     }
 
-    kv = json_pack("{sI}", "bytes", bytes_counter);
+    kv = json_pack("{sI}", "bytes", (json_int_t)bytes_counter);
     json_object_update_missing(obj, kv);
     json_decref(kv);
   }


### PR DESCRIPTION
Otherwise, promotion doesn't happen, like with printf, but without any warning. This needs to be tested on a big endian platform