### PR TITLE
Change minimum dump time to 10 seconds

### DIFF
--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -6444,8 +6444,8 @@ int cfg_key_telemetry_dump_refresh_time(char *filename, char *name, char *value_
   }
 
   value = atoi(value_ptr);
-  if (value < 60 || value > 86400) {
-    Log(LOG_ERR, "WARN: [%s] 'telemetry_dump_refresh_time' value has to be >= 60 and <= 86400 secs.\n", filename);
+  if (value < 10 || value > 86400) {
+    Log(LOG_ERR, "WARN: [%s] 'telemetry_dump_refresh_time' value has to be >= 10 and <= 86400 secs.\n", filename);
     return ERR;
   }
 


### PR DESCRIPTION
Allow dumps to happen as often as once every ten seconds.