### PR TITLE
Rename unused variable __unused to _unused to silence 100+ warnings.

### DIFF
--- a/src/network.h
+++ b/src/network.h
@@ -230,7 +230,7 @@ struct my_icmphdr
     u_int32_t   gateway;        /* gateway address */
     struct
     {
-      u_int16_t __unused;
+      u_int16_t _unused;
       u_int16_t mtu;
     } frag;                     /* path mtu discovery */
   } un;


### PR DESCRIPTION
It turns out that __unused is a compiler directive for clang, so
    a structure element named __unused is an empty declaration, which triggers
    a warning:
    
    ./../network.h:233:7: warning: declaration does not declare anything [-Wmissing-declarations]
          u_int16_t __unused;
          ^~~~~~~~~
    
    Since network.h is included in many files, this warning is emitted 100+
    times on a MacOS build.
