### PR TITLE
pmtelemetryd: Add port number to telemetry data.

### DIFF
--- a/src/telemetry/telemetry_logdump.c
+++ b/src/telemetry/telemetry_logdump.c
@@ -88,6 +88,10 @@ int telemetry_log_msg(telemetry_peer *peer, struct telemetry_data *t_data, void 
     json_object_update_missing(obj, kv);
     json_decref(kv);
 
+    kv = json_pack("{sI}", "telemetry_port", (json_int_t)peer->tcp_port);
+    json_object_update_missing(obj, kv);
+    json_decref(kv);
+
     if (data_decoder == TELEMETRY_DATA_DECODER_JSON) {
       kv = json_pack("{ss}", "telemetry_data", log_data);
       json_object_update_missing(obj, kv);


### PR DESCRIPTION
Include the sender's port number along with their IP address.
This allows easy tracking of multiple streams per host, for
e.g., testing purposes.