### PR TITLE
pmtelemtryd: Fix off-by-one-error

### DIFF
--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -598,8 +598,6 @@ void telemetry_daemon(void *t_data_void)
       }
 
       if (!peer) {
-        int fd;
-
         /* We briefly accept the new connection to be able to drop it */
         Log(LOG_ERR, "ERROR ( %s/%s ): Insufficient number of telemetry peers has been configured by telemetry_max_peers (%d).\n",
                         config.name, t_data->log_str, config.telemetry_max_peers);

--- a/src/telemetry/telemetry_msg.c
+++ b/src/telemetry/telemetry_msg.c
@@ -85,7 +85,7 @@ void telemetry_basic_process_json(telemetry_peer *peer)
   }
 
   if (peer->buf.len >= (peer->msglen + 1)) {
-    peer->buf.base[peer->msglen + 1] = '\0';
+    peer->buf.base[peer->msglen] = '\0';
     peer->msglen++;
   }
 }


### PR DESCRIPTION
There is an off-by-one-error in the string termination code that
reads raw json telemetry data.

Also, a local variable fd hides a local in an outer scope in the
socket IO loop.