### PR TITLE
Add support for Apache Avro to the build system

### DIFF
--- a/bin/configure-help-replace.txt
+++ b/bin/configure-help-replace.txt
@@ -25,6 +25,8 @@
   GEOIPV2_LIBS			linker flags for GEOIPV2, overriding pkg-config
   JANSSON_CFLAGS		C compiler flags for JANSSON, overriding pkg-config
   JANSSON_LIBS			linker flags for JANSSON, overriding pkg-config
+  AVRO_CFLAGS			C compiler flags for AVRO, overriding pkg-config
+  AVRO_LIBS			linker flags for AVRO, overriding pkg-config
   NFLOG_CFLAGS			C compiler flags for NFLOG, overriding pkg-config
   NFLOG_LIBS			linker flags for NFLOG, overriding pkg-config
 

--- a/configure.ac
+++ b/configure.ac
@@ -824,6 +824,28 @@ AC_ARG_ENABLE(jansson,
 )
 dnl finish: Jansson handling
 
+dnl start: Avro handling
+AC_MSG_CHECKING(whether to enable Avro support)
+AC_ARG_ENABLE(avro,
+  [  --enable-avro                 Enable avro support (default: no)],
+  [ case "$enableval" in
+  yes)
+    AC_MSG_RESULT(yes)
+    PKG_CHECK_MODULES([AVRO], [avro-c >= 1.8])
+    USING_AVRO="yes"
+    AC_DEFINE(WITH_AVRO, 1)
+    AC_CHECK_LIB(avro, avro_record_get, [], [])
+    ;;
+  no)
+    AC_MSG_RESULT(no)
+    ;;
+  esac ],
+  [
+    AC_MSG_RESULT(no)
+  ]
+)
+dnl finish: Avro handling
+
 if test x"$USING_DLOPEN" = x"yes"; then
 	AC_DEFINE(HAVE_DLOPEN, 1)
 else
@@ -965,6 +987,7 @@ AM_CONDITIONAL([WITH_KAFKA], [test x"$USING_KAFKA" = x"yes"])
 AM_CONDITIONAL([USING_SQL], [test x"$USING_SQL" = x"yes"])
 AM_CONDITIONAL([USING_THREADPOOL], [test x"$USING_THREADPOOL" = x"yes"])
 AM_CONDITIONAL([WITH_NFLOG], [test x"$USING_NFLOG" = x"yes"])
+AM_CONDITIONAL([WITH_AVRO], [test x"$USING_AVRO" = x"yes"])
 AC_OUTPUT([ Makefile \
 	    src/Makefile src/nfprobe_plugin/Makefile \
 	    src/sfprobe_plugin/Makefile src/bgp/Makefile \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,8 +3,8 @@ sbin_PROGRAMS = pmacctd nfacctd sfacctd pmtelemetryd pmbgpd pmbmpd
 bin_PROGRAMS = pmacct @EXTRABIN@
 EXTRA_PROGRAMS =
 
-AM_LDFLAGS = @GEOIP_LIBS@ @GEOIPV2_LIBS@ @JANSSON_LIBS@
-AM_CFLAGS  = @GEOIP_CFLAGS@ @GEOIPV2_CFLAGS@ @JANSSON_CFLAGS@
+AM_LDFLAGS = @GEOIP_LIBS@ @GEOIPV2_LIBS@ @JANSSON_LIBS@ @AVRO_LIBS@
+AM_CFLAGS  = @GEOIP_CFLAGS@ @GEOIPV2_CFLAGS@ @JANSSON_CFLAGS@ @AVRO_CFLAGS@
 
 noinst_LTLIBRARIES = libdaemons.la libcommon.la
 libcommon_la_SOURCES = strlcpy.c addr.c jansson.c addr.h pmacct.h	\


### PR DESCRIPTION
This is the first PR of a series aiming to introduce [Avro] support to pmacct, breaking up #41 into smaller, easier to merge changes.
This first PR focuses on changes to the build system.

[Avro]: https://avro.apache.org/