### PR TITLE
Expose support for Apache Avro in the docs and UI

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -180,9 +180,10 @@ DESC:		Plugins to be enabled. memory, print, nfprobe, sfprobe and tee plugins ar
 		(requires installation of MongoDB API C driver which is shipped separatedly from the
 		main MongoDB package; read more in QUICKSTART in the "noSQL (MongoDB) setup examples"
 		section). print plugin prints output data to flat-files or stdout in JSON, CSV or
-		tab-spaced formats. amqp and kafka plugins allow to output data to RabbitMQ and Kafka
-		brokers respectively. All these plugins, SQL, no-SQL and messaging are good for
-		production solutions and/or larger scenarios. 
+		tab-spaced formats, or encodes it using the Apache Avro serialization system. amqp
+		and kafka plugins allow to output data to RabbitMQ and Kafka brokers respectively. All
+		these plugins, SQL, no-SQL and messaging are good for production solutions and/or
+		larger scenarios.
 		nfprobe acts as a NetFlow/IPFIX agent and exports collected data via NetFlow v1/v5/
 		v9 and IPFIX datagrams to a remote collector. sfprobe acts as a sFlow agent and 
 		exports collected data via sFlow v5 datagrams to a remote collector. Both nfprobe
@@ -1343,7 +1344,7 @@ DESC:		Enables the use of start/end markers each time data is purged to the back
 DEFAULT:	false
 
 KEY:		print_output
-VALUES:		[ formatted | csv | json | event_formatted | event_csv ]
+VALUES:		[ formatted | csv | json | event_formatted | event_csv | avro ]
 DESC:		Defines the print plugin output format. 'formatted' enables tabular output; 'csv' is to enable
 		comma-separated values format, suitable for injection into 3rd party tools. 'event' versions of
 		the output strips trailing bytes and packets counters. 'json' is to enable JavaScript Object
@@ -1352,10 +1353,15 @@ DESC:		Defines the print plugin output format. 'formatted' enables tabular outpu
 		cons, JSON serialization introduces some lag due to the extensive string manipulation (as an
 		example: 10M lines may be written to disk in 30 secs as CSV and 150 secs as JSON). The 'json'
 		format requires compiling the package against Jansson library (downloadable at the following
-		URL: http://www.digip.org/jansson/)
-NOTES:		* Jansson library does not seem to have concept of unsigned integers. integers up to 32 bits
-		  are packed as 'I', ie. 64 bits signed integers, working around the issue. No work around is
-		  possible for unsigned 64 bits integers instead (ie. tag, tag2, packets, bytes). 
+		URL: http://www.digip.org/jansson/). 'avro' enables storing the data using the Apache Avro
+		data serialization system. This format stores the data more compactly than JSON and thus is
+		more appropriate for intensive captures. The 'avro' format requires compiling the package
+		against the Apache Avro library (downloadable at the following URL: http://avro.apache.org/).
+NOTES:		* Jansson and Avro libraries don't have the concept of unsigned integers. integers up to 32
+		  bits are packed as 64 bits signed integers, working around the issue. No work around is
+		  possible for unsigned 64 bits integers instead (ie. tag, tag2, packets, bytes).
+		* If the output format is 'avro' and no print_output_file was specified, the Avro-based
+		  representation of the data will be converted to JSON and displayed on the standard output.
 DEFAULT:	formatted
 
 KEY:            print_output_separator
@@ -1363,6 +1369,34 @@ DESC:           Defines the print plugin output separator when print_output is s
 		is expected to be a single character and cannot be a spacing (if spacing separator is wanted
 		then 'formatted' output should be the natural choice instead)
 DEFAULT:	','
+
+KEY:		[ message_broker_output | amqp_output | kafka_output ]
+VALUES: 	[ json | avro ]
+DESC:		Defines the output format for messages sent to a message broker (amqp and kafka plugins).
+		'json' is to send the messages in the JavaScript Object Notation format. The 'json' format
+		requires compiling the package against the Jansson library (downloadable at the following URL
+		: http://www.digip.org/jansson/). 'avro' is to send the messages encoded with the Apache Avro
+		serialization system. The 'avro' format requires compiling the package against the Apache Avro
+		library (downloadable at the following URL: http://avro.apache.org/).
+NOTES:		* Jansson and Avro libraries don't have the concept of unsigned integers. integers up to 32
+		  bits are packed as 64 bits signed integers, working around the issue. No work around is
+		  possible for unsigned 64 bits integers instead (ie. tag, tag2, packets, bytes).
+DEFAULT:	json
+
+KEY:		avro_buffer_size
+DESC:		When the Avro format is used to encode the messages sent to a message broker (amqp and kafka
+		plugins), this option defines the size in bytes of the buffer used by the Avro data serialization
+		system. The buffer needs to be large enough to store at least a single Avro record. If the buffer
+		does not have enough capacity to store the number of records defined by the sql_multi_values
+		configuration directive, the current records stored in the buffer will be sent to the message
+		broker and the buffer will be cleared to accomodate subsequent records.
+DEFAULT:	4096
+
+KEY:		avro_schema_output_file
+DESC:		When the Avro format is used to encode the messages sent to a message broker (amqp and kafka
+		plugins), this option causes the schema used to encode the messages to be dumped to the file path
+		given. The schema can then be used by the receiving end to decode the messages. Note that the
+		schema will be dynamically built based on the aggregation primitives chosen.
 
 KEY:            [ print_num_protos | sql_num_protos | amqp_num_protos | mongo_num_protos | kafka_num_protos ]
 VALUES:         [ true | false ]

--- a/FAQS
+++ b/FAQS
@@ -33,12 +33,13 @@ Q4: What are pmacct main features?
 A: pmacct can collect, replicate and export network data. Collect in memory tables,
    store persistently to RDBMS (MySQL, PostgreSQL, SQLite 3.x), noSQL databases
    (key-value: BerkeleyDB 5.x via SQLite API or document-oriented: MongoDB) and
-   flat-files (csv, formatted, JSON output), publish to message exchanges via AMQP
-   (ie. to insert in ElasticSearch, Cassandra or CouchDB) and Kafka brokers. Export
-   speaking sFlow v5, NetFlow v1/v5/v9 and IPFIX. pmacct is able to perform data
-   aggregation, offering a rich set of primitives to choose from; it can also filter,
-   sample, renormalize, tag and classify at L7. pmacct integrates a BGP daemon join
-   routing visibility and network traffic information.
+   flat-files (csv, formatted, JSON output), data serialization systems (Apache
+   Avro), publish to message exchanges via AMQP (ie. to insert in ElasticSearch,
+   Cassandra or CouchDB) and Kafka brokers. Export speaking sFlow v5, NetFlow
+   v1/v5/v9 and IPFIX. pmacct is able to perform data aggregation, offering a rich
+   set of primitives to choose from; it can also filter, sample, renormalize, tag
+   and classify at L7. pmacct integrates a BGP daemon join routing visibility and
+   network traffic information.
 
 
 Q5: Does any of the pmacct daemons logs to flat files?

--- a/QUICKSTART
+++ b/QUICKSTART
@@ -561,12 +561,16 @@ VIII. Running the RabbitMQ/AMQP plugin
 The Advanced Message Queuing Protocol (AMQP) is an open standard for passing business
 messages between applications. RabbitMQ is a messaging broker, an intermediary for
 messaging, which implementes AMQP. pmacct RabbitMQ/AMQP plugin is designed to send
-aggregated network traffic data, in JSON format, through a RabbitMQ server to 3rd
-party applications. Requirements to use the plugin are:
+aggregated network traffic data, in JSON or Avro format, through a RabbitMQ server
+to 3rd party applications. Requirements to use the plugin are:
 
 * A working RabbitMQ server: http://www.rabbitmq.com/
 * RabbitMQ C API, rabbitmq-c: https://github.com/alanxz/rabbitmq-c/
 * Libjansson to cook JSON objects: http://www.digip.org/jansson/
+
+Additionally, the Apache Avro C library (http://avro.apache.org/) needs to be
+installed to be able to send messages packed using Avro (you will also need to
+pass --enable-avro to the configuration script).
 
 Once these elements are installed, pmacct can be configured for compiling. pmacct
 makes use of pkg-config for finding libraries and headers location and checks some
@@ -583,6 +587,12 @@ export RABBITMQ_LIBS="-L/usr/local/rabbitmq/lib -lrabbitmq"
 export RABBITMQ_CFLAGS="-I/usr/local/rabbitmq/include"
 ./configure --enable-rabbitmq --enable-jansson
 
+Ditto for the location of the Avro libraries:
+
+export AVRO_LIBS="-L/usr/local/avro/lib -lavro"
+export AVRO_CFLAGS="-I/usr/local/avro/include"
+./configure --enable-rabbitmq --enable-avro
+
 Then "make; make install" as usual. Following a configuration snippet showing a
 basic RabbitMQ/AMQP plugin configuration (assumes: RabbitMQ server is available
 at localhost; look all configurable directives up in the CONFIG-KEYS document):
@@ -591,6 +601,7 @@ at localhost; look all configurable directives up in the CONFIG-KEYS document):
 plugins: amqp
 !
 aggregate: src_host, dst_host, src_port, dst_port, proto, tos
+amqp_output: json
 amqp_exchange: pmacct
 amqp_routing_key: acct
 amqp_refresh_time: 300
@@ -615,9 +626,9 @@ languages are very welcome at this stage.
 IX. Running the Kafka plugin
 Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.
 Its qualities being: fast, scalable, durable and distributed by design. pmacct
-Kafka plugin is designed to send aggregated network traffic data, in JSON format,
-through a Kafka broker to 3rd party applications. Requirements to use the plugin
-are:
+Kafka plugin is designed to send aggregated network traffic data, in JSON or
+Avro format, through a Kafka broker to 3rd party applications. Requirements to
+use the plugin are:
 
 * A working Kafka broker (and Zookeper server): http://kafka.apache.org/
 * Librdkafka: https://github.com/edenhill/librdkafka/
@@ -627,6 +638,10 @@ Software combinations that have been tested working are:
 
 * librdkafka 0.9.1, Kafka 0.8.2.2 and Scala 2.9.2
 * librdkafka 0.9.1, Kafka 0.10.0 and Scala 2.11.8
+
+Additionally, the Apache Avro C library (http://avro.apache.org/) needs to be
+installed to be able to send messages packed using Avro (you will also need to
+pass --enable-avro to the configuration script).
 
 Once these elements are installed, pmacct can be configured for compiling. pmacct
 makes use of pkg-config for finding libraries and headers location and checks some
@@ -643,6 +658,12 @@ export KAFKA_LIBS="-L/usr/local/kafka/lib -lrdkafka"
 export KAFKA_CFLAGS="-I/usr/local/kafka/include"
 ./configure --enable-kafka --enable-jansson
 
+Ditto for the location of the Avro libraries:
+
+export AVRO_LIBS="-L/usr/local/avro/lib -lavro"
+export AVRO_CFLAGS="-I/usr/local/avro/include"
+./configure --enable-kafka --enable-avro
+
 Then "make; make install" as usual. Following a configuration snippet showing a
 basic Kafka plugin configuration (assumes: Kafka broker is available at 127.0.0.1
 on port 9092; look all configurable directives up in the CONFIG-KEYS document):
@@ -651,6 +672,7 @@ on port 9092; look all configurable directives up in the CONFIG-KEYS document):
 plugins: kafka
 !
 aggregate: src_host, dst_host, src_port, dst_port, proto, tos
+kafka_output: json
 kafka_topic: pmacct.acct
 kafka_refresh_time: 300
 kafka_history: 5m
@@ -1507,10 +1529,11 @@ XIX. Running the print plugin to write to flat-files
 Print plugin was originally conceived to display data on standard output; with
 pmacct 0.14 a new 'print_output_file' configuration directive is introduced to
 allow the plugin to write to flat-files aswell. Dynamic filenames are supported.
-Output is text-based (no binary proprietary format) and can be JSON, CSV or
-formatted ('print_output' directive). Interval between writes can be configured
-via the 'print_refresh_time' directive. An example follows on how to write to
-files on a 15 mins basis in CSV format:
+Output is either text-based using JSON, CSV or formatted outputs, or
+binary-based using the Apache Avro file container ('print_output' directive).
+Interval between writes can be configured via the 'print_refresh_time'
+directive. An example follows on how to write to files on a 15 mins basis in
+CSV format:
 
 print_refresh_time: 900
 print_history: 15m
@@ -1531,6 +1554,13 @@ configured for compilation against the library using the --enable-jansson
 switch. Please refer to the configure script help screen (and/or "Configuring
 pmacct for compilation and installing" section of this document) to supply
 custom locations of Jansson library and/or headers. 
+
+Avro output requires compiling pmacct against Apache Avro library, which can be
+found at the following URL: http://avro.apache.org/ . pmacct can be configured
+for compilation against the library using the --enable-avro switch. Please
+refer to the configure script help screen (and/or "Configuring pmacct for
+compilation and installing" section of this document) to supply custom
+locations of Avro library and/or headers.
 
 Splitting data into time bins is supported via print_history directive. When
 enabled, time-related variable substitutions of dynamic print_output_file names

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -69,7 +69,7 @@ void usage_daemon(char *prog_name)
   printf("  -s  \tMemory pool size\n");
   printf("\nPrint plugin (-P print) plugin options:\n");
   printf("  -r  \tRefresh time (in seconds)\n");
-  printf("  -O  \t[ formatted | csv | json ] \n\tOutput format\n");
+  printf("  -O  \t[ formatted | csv | json | avro ] \n\tOutput format\n");
   printf("  -o  \tPath to output file\n");
   printf("  -A  \tAppend output (applies to -o)\n");
   printf("  -E  \tCSV format serparator (applies to -O csv, DEFAULT: ',')\n");

--- a/src/pmacctd.c
+++ b/src/pmacctd.c
@@ -73,7 +73,7 @@ void usage_daemon(char *prog_name)
   printf("  -s  \tMemory pool size\n");
   printf("\nPrint plugin (-P print) plugin options:\n");
   printf("  -r  \tRefresh time (in seconds)\n");
-  printf("  -O  \t[ formatted | csv | json ] \n\tOutput format\n");
+  printf("  -O  \t[ formatted | csv | json | avro ] \n\tOutput format\n");
   printf("  -o  \tPath to output file\n");
   printf("  -A  \tAppend output (applies to -o)\n");
   printf("  -E  \tCSV format serparator (applies to -O csv, DEFAULT: ',')\n");

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -77,7 +77,7 @@ void usage_daemon(char *prog_name)
   printf("  -s  \tMemory pool size\n");
   printf("\nPrint plugin (-P print) plugin options:\n");
   printf("  -r  \tRefresh time (in seconds)\n");
-  printf("  -O  \t[ formatted | csv | json ] \n\tOutput format\n");
+  printf("  -O  \t[ formatted | csv | json | avro ] \n\tOutput format\n");
   printf("  -o  \tPath to output file\n");
   printf("  -A  \tAppend output (applies to -o)\n");
   printf("  -E  \tCSV format serparator (applies to -O csv, DEFAULT: ',')\n");

--- a/src/uacctd.c
+++ b/src/uacctd.c
@@ -137,7 +137,7 @@ void usage_daemon(char *prog_name)
   printf("  -s  \tMemory pool size\n");
   printf("\nPrint plugin (-P print) plugin options:\n");
   printf("  -r  \tRefresh time (in seconds)\n");
-  printf("  -O  \t[ formatted | csv | json ] \n\tOutput format\n");
+  printf("  -O  \t[ formatted | csv | json | avro ] \n\tOutput format\n");
   printf("  -o  \tPath to output file\n");
   printf("  -A  \tAppend output (applies to -o)\n");
   printf("  -E  \tCSV format serparator (applies to -O csv, DEFAULT: ',')\n");


### PR DESCRIPTION
This is the seventh PR of a series aiming to introduce [Avro] support to pmacct, breaking up #41 into smaller, easier to merge changes.
This PR focuses on exposing newly available features to the documentation and UI (ie. command-line parameters). It should therefore be reviewed after #53, #56 and #57.

[Avro]: https://avro.apache.org/