### PR TITLE
Expose support for Apache Avro in the AMQP and Kafka consumer examples

### DIFF
--- a/examples/kafka/kafka_consumer.py
+++ b/examples/kafka/kafka_consumer.py
@@ -12,8 +12,18 @@
 # messages produced by the Core Process to a specific plugin; the messages are
 # in binary format, first quad being the sequence number.
 
-import sys, getopt
+import sys, os, getopt, StringIO
 from kafka import KafkaConsumer
+
+try:
+	import avro.io
+	import avro.schema
+	import avro.datafile
+	avro_available = True
+except ImportError:
+	avro_available = False
+
+avro_schema = None
 
 def usage(tool):
     print ""
@@ -27,10 +37,13 @@ def usage(tool):
     print "Optional Args:"
     print "  -h, --help".ljust(25) + "Print this help"
     print "  -H, --host".ljust(25) + "Define Kafka broker host [default: '127.0.0.1:9092']"
+    print "  -d, --decode-with-avro".ljust(25) + "Define the file with the " \
+		                "schema to use for decoding Avro messages"
 
 def main():
 	try:
-		opts, args = getopt.getopt(sys.argv[1:], "ht:g:H:", ["help", "topic=", "group_id=", "host="])
+		opts, args = getopt.getopt(sys.argv[1:], "ht:g:H:d:", ["help", "topic=",
+				"group_id=", "host=", "decode-with-avro="])
 	except getopt.GetoptError as err:
 		# print help information and exit:
 		print str(err) # will print something like "option -a not recognized"
@@ -55,6 +68,17 @@ def main():
             		kafka_group_id = a
 		elif o in ("-H", "--host"):
             		kafka_host = a
+                elif o in ("-d", "--decode-with-avro"):
+			if not avro_available:
+				sys.stderr.write("ERROR: `--decode-with-avro` given but Avro package was "
+					"not found\n")
+				sys.exit(1)
+			if not os.path.isfile(a):
+				sys.stderr.write("ERROR: '%s' does not exist or is not a file\n" % (a,))
+				sys.exit(1)
+		        global avro_schema
+		        with open(a) as f:
+				avro_schema = avro.schema.parse(f.read())
 		else:
 			assert False, "unhandled option"
 
@@ -66,8 +90,19 @@ def main():
 	consumer = KafkaConsumer(kafka_topic, group_id=kafka_group_id, bootstrap_servers=[kafka_host])
 
 	for message in consumer:
-		print("%s:%d:%d: key=%s value=%s" % (message.topic, message.partition,
-			message.offset, message.key, message.value))
+		if avro_schema:
+			inputio = StringIO.StringIO(message.value)
+			decoder = avro.io.BinaryDecoder(inputio)
+			datum_reader = avro.io.DatumReader(avro_schema)
+			avro_data = []
+			while inputio.tell() < len(inputio.getvalue()):
+				x = datum_reader.read(decoder)
+				avro_data.append(str(x))
+			print("%s:%d:%d: key=%s value=%s" % (message.topic, message.partition,
+					message.offset, message.key, (",".join(avro_data))))
+		else:
+			print("%s:%d:%d: key=%s value=%s" % (message.topic, message.partition,
+					message.offset, message.key, message.value))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is the eighth and hopefully last PR of a series aiming to introduce [Avro] support to pmacct, breaking up #41 into smaller, easier to merge changes.
This PR focuses on exposing newly available features to the Python AMQP and Kafka consumer examples. It should therefore be reviewed after #58.

[Avro]: https://avro.apache.org/