### PR TITLE
a rather heavy handed fix to stop random memory scribbles

### DIFF
--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -736,6 +736,12 @@ void bgp_prepare_thread()
   bgp_misc_db = &inter_domain_misc_dbs[FUNC_TYPE_BGP];
   memset(bgp_misc_db, 0, sizeof(struct bgp_misc_structs));
 
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_init(&attr);
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&bgp_misc_db->table_mutex, &attr);
+  pthread_mutexattr_destroy(&attr);
+
   bgp_misc_db->is_thread = TRUE;
   bgp_misc_db->log_str = malloc(strlen("core/BGP") + 1);
   strcpy(bgp_misc_db->log_str, "core/BGP");

--- a/src/bgp/bgp.h
+++ b/src/bgp/bgp.h
@@ -20,6 +20,7 @@
 */
 
 /* includes */
+#include <pthread.h>
 #include <sys/poll.h>
 #include "bgp_prefix.h"
 #include "bgp_packet.h"
@@ -133,6 +134,7 @@ struct bgp_misc_structs {
   int msglog_kafka_topic_rr;
   void (*bgp_peer_log_msg_extras)(struct bgp_peer *, int, void *);
 
+  pthread_mutex_t table_mutex;
   int table_peer_buckets;
   int table_per_peer_buckets;
   int table_attr_hash_buckets;

--- a/src/bgp/bgp_util.c
+++ b/src/bgp/bgp_util.c
@@ -539,7 +539,11 @@ void bgp_peer_info_delete(struct bgp_peer *peer)
         struct bgp_info *ri;
         struct bgp_info *ri_next;
 
-        for (peer_buckets = 0; peer_buckets < bms->table_per_peer_buckets; peer_buckets++) {
+	if (bms->is_thread) pthread_mutex_lock(&bms->table_mutex);
+	u_int32_t per_peer_buckets = bms->table_per_peer_buckets;
+	if (bms->is_thread) pthread_mutex_unlock(&bms->table_mutex);
+
+        for (peer_buckets = 0; peer_buckets < per_peer_buckets; peer_buckets++) {
           for (ri = node->info[modulo+peer_buckets]; ri; ri = ri_next) {
             if (ri->peer == peer) {
 	      if (bms->msglog_backend_methods) {


### PR DESCRIPTION
Adds mutexing around some of the data values in bgp_misc_db, which are being temporarily set on the main thread around line 128 of bgp_lookup.c and referenced in the worker thread in many places.

The impact of the bug was that if you happened to create a bgp_node while the main thread had set table_per_peer_buckets to 1 it had a significantly smaller info table than the rest of the code expected resulting in seg faults touching out of bounds memory (this could happen in the memset immediately following the malloc if you were unlucky)

I don’t really understand *why* the main thread needs to twiddle these variables, so there’s very possibly a more elegant fix.