### PR TITLE
Support Kafka dynamic partitioning: config

### DIFF
--- a/src/cfg.h
+++ b/src/cfg.h
@@ -173,6 +173,7 @@ struct configuration {
   int amqp_avro_schema_refresh_time;
   int kafka_broker_port;
   int kafka_partition;
+  int kafka_partition_dynamic;
   char *kafka_partition_key;
   int kafka_partition_keylen;
   char *kafka_avro_schema_topic;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -1795,12 +1795,35 @@ int cfg_key_kafka_partition(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_kafka_partition_dynamic(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.kafka_partition_dynamic = value;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.kafka_partition_dynamic = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_kafka_partition_key(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;
   int value_len, changes = 0;
 
   value_len = strlen(value_ptr);
+  lower_string(value_ptr);
 
   if (!name) for (; list; list = list->next, changes++) {
     list->cfg.kafka_partition_key = value_ptr;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -101,6 +101,7 @@ EXT int cfg_key_amqp_avro_schema_routing_key(char *, char *, char *);
 EXT int cfg_key_amqp_avro_schema_refresh_time(char *, char *, char *);
 EXT int cfg_key_kafka_broker_port(char *, char *, char *);
 EXT int cfg_key_kafka_partition(char *, char *, char *);
+EXT int cfg_key_kafka_partition_dynamic(char *, char *, char *);
 EXT int cfg_key_kafka_partition_key(char *, char *, char *);
 EXT int cfg_key_kafka_avro_schema_topic(char *, char *, char *);
 EXT int cfg_key_kafka_avro_schema_refresh_time(char *, char *, char *);

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -476,6 +476,7 @@ static const struct _dictionary_line dictionary[] = {
   {"kafka_topic", cfg_key_sql_table},
   {"kafka_topic_rr", cfg_key_amqp_routing_key_rr},
   {"kafka_partition", cfg_key_kafka_partition},
+  {"kafka_partition_dynamic", cfg_key_kafka_partition_dynamic},
   {"kafka_partition_key", cfg_key_kafka_partition_key},
   {"kafka_cache_entries", cfg_key_print_cache_entries},
   {"kafka_max_writers", cfg_key_dump_max_writers},


### PR DESCRIPTION
This commit includes changes to the configuration system. It is part of a
set of changes which purpose is to support dynamic Kafka partitioning.