### PR TITLE
Support Kafka dynamic partitioning: docs

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -698,9 +698,41 @@ DESC:		Defines the Kafka broker topic partition ID. RD_KAFKA_PARTITION_UA or ((i
 		partition). See also kafka_broker_host. 
 DEFAULT:	-1
 
+KEY:		kafka_partition_dynamic
+VALUES          [ true | false ]
+DESC:		Enables dynamic Kafka partitioning, ie data is partitioned according to the value
+                of the Kafka broker topic partition key.
+                See kafka_partition_key.
+DEFAULT:	false
+
 KEY:            kafka_partition_key
 DESC:           Defines the Kafka broker topic partition key. A string of printable characters is
-		expected as value.
+		expected as value. Dynamic names are supported through the use of variables, which
+		are computed at the moment data is purged to the backend. The list of supported
+		variables follows:
+		$peer_src_ip	Record value for peer_src_ip primitive (if primitive is not part of
+				the aggregation method then this will be set to a null value).
+
+		$tag		Record value for tag primitive (if primitive is not part of the
+				aggregation method then this will be set to a null value).
+
+		$tag2		Record value for tag2 primitive (if primitive is not part of the
+				aggregation method then this will be set to a null value).
+
+		$src_host	Record value for src_host primitive (if primitive is not part of
+                                the aggregation method then this will be set to a null value).
+
+		$dst_host	Record value for dst_host primitive (if primitive is not part of
+                                the aggregation method then this will be set to a null value).
+
+		$src_port	Record value for src_port primitive (if primitive is not part of
+                                the aggregation method then this will be set to a null value).
+
+		$dst_port	Record value for dst_port primitive (if primitive is not part of
+                                the aggregation method then this will be set to a null value).
+
+		$proto		Record value for proto primitive (if primitive is not part of the
+				aggregation method then this will be set to a null value).
 DEFAULT:	none
 
 KEY:            [ bgp_daemon_msglog_kafka_broker_host | bgp_table_dump_kafka_broker_host |


### PR DESCRIPTION
This commit includes changes to the documentation. It is part of a
set of changes which purpose is to support dynamic Kafka partitioning.