### PR TITLE
Serialize nfacctd templates: config

### DIFF
--- a/src/cfg.h
+++ b/src/cfg.h
@@ -191,6 +191,7 @@ struct configuration {
   char *nfacctd_allow_file;
   int nfacctd_time;
   int nfacctd_pro_rating;
+  char *nfacctd_templates_file;
   int nfacctd_account_options;
   int nfacctd_stitching;
   u_int32_t nfacctd_as;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -2429,6 +2429,25 @@ int cfg_key_nfacctd_pro_rating(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_nfacctd_templates_file(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int changes = 0;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.nfacctd_templates_file = value_ptr;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.nfacctd_templates_file = value_ptr;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_nfacctd_stitching(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -149,6 +149,7 @@ EXT int cfg_key_nfacctd_disable_checks(char *, char *, char *);
 EXT int cfg_key_nfacctd_mcast_groups(char *, char *, char *);
 EXT int cfg_key_nfacctd_pipe_size(char *, char *, char *);
 EXT int cfg_key_nfacctd_pro_rating(char *, char *, char *);
+EXT int cfg_key_nfacctd_templates_file(char *, char *, char *);
 EXT int cfg_key_nfacctd_account_options(char *, char *, char *);
 EXT int cfg_key_nfacctd_stitching(char *, char *, char *);
 EXT int cfg_key_pmacctd_force_frag_handling(char *, char *, char *);

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -502,6 +502,7 @@ static const struct _dictionary_line dictionary[] = {
   {"nfacctd_peer_as", cfg_key_nfprobe_peer_as},
   {"nfacctd_pipe_size", cfg_key_nfacctd_pipe_size},
   {"nfacctd_pro_rating", cfg_key_nfacctd_pro_rating},
+  {"nfacctd_templates_file", cfg_key_nfacctd_templates_file},
   {"nfacctd_account_options", cfg_key_nfacctd_account_options},
   {"nfacctd_stitching", cfg_key_nfacctd_stitching},
   {"nfacctd_ext_sampling_rate", cfg_key_pmacctd_ext_sampling_rate},


### PR DESCRIPTION
nfacctd templates can be cached to limit the amount of lost
Netflow/IPFIX packets due to unknown templates when nfacctd (re)starts.
This commit focuses on changes to the configuration system.