### PR TITLE
Serialize nfacctd templates: libraries

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -182,4 +182,5 @@ EXT void pm_scandir_free(struct dirent ***, int);
 EXT int pm_alphasort(const void *, const void *);
 
 EXT void replace_string(char *, int, char *, char *);
+EXT int delete_line_from_file(int, char *);
 #undef EXT


### PR DESCRIPTION
nfacctd templates can be cached to limit the amount of lost
Netflow/IPFIX packets due to unknown templates when nfacctd
(re)starts.
This commit focuses on changes to the library code.