### PR TITLE
Serialize nfacctd templates: nfacctd

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -778,6 +778,10 @@ int main(int argc,char **argv, char **envp)
   memset(&tpl_cache, 0, sizeof(tpl_cache));
   tpl_cache.num = TEMPLATE_CACHE_ENTRIES;
 
+  if (config.nfacctd_templates_file) {
+    load_templates_from_file(config.nfacctd_templates_file);
+  }
+
   /* arranging static pointers to dummy packet; to speed up things into the
      main loop we mantain two packet_ptrs structures when IPv6 is enabled:
      we will sync here 'pptrs6' for common tables and pointers */
@@ -1377,7 +1381,7 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
     pkt += NfDataHdrV9Sz;
     flowoff += NfDataHdrV9Sz;
 
-    tpl = find_template(data_hdr->flow_id, pptrs, fid, SourceId);
+    tpl = find_template(data_hdr->flow_id, (struct host_addr *) pptrs->f_agent, fid, SourceId);
     if (!tpl) {
       sa_to_addr((struct sockaddr *)pptrs->f_agent, &debug_a, &debug_agent_port);
       addr_to_str(debug_agent_addr, &debug_a);

--- a/src/nfacctd.h
+++ b/src/nfacctd.h
@@ -795,7 +795,7 @@ EXT u_int16_t debug_agent_port;
 #define EXT
 #endif
 EXT struct template_cache_entry *handle_template(struct template_hdr_v9 *, struct packet_ptrs *, u_int16_t, u_int32_t, u_int16_t *, u_int16_t, u_int32_t);
-EXT struct template_cache_entry *find_template(u_int16_t, struct packet_ptrs *, u_int16_t, u_int32_t);
+EXT struct template_cache_entry *find_template(u_int16_t, struct host_addr *, u_int16_t, u_int32_t);
 EXT struct template_cache_entry *insert_template(struct template_hdr_v9 *, struct packet_ptrs *, u_int16_t, u_int32_t, u_int16_t *, u_int8_t, u_int16_t, u_int32_t);
 EXT struct template_cache_entry *refresh_template(struct template_hdr_v9 *, struct template_cache_entry *, struct packet_ptrs *, u_int16_t, u_int32_t, u_int16_t *, u_int8_t, u_int16_t, u_int32_t);
 EXT void log_template_header(struct template_cache_entry *, struct packet_ptrs *, u_int16_t, u_int32_t, u_int8_t);
@@ -809,6 +809,10 @@ EXT struct utpl_field *ext_db_get_next_ie(struct template_cache_entry *, u_int16
 
 EXT void resolve_vlen_template(char *, struct template_cache_entry *);
 EXT u_int8_t get_ipfix_vlen(char *, u_int16_t *);
+
+EXT struct template_cache_entry *nfacctd_offline_read_json_template(char *, char *, int);
+EXT void load_templates_from_file(char *);
+EXT void save_template(struct template_cache_entry *, char *);
 #undef EXT
 
 #if (!defined __PKT_HANDLERS_C)

--- a/src/nfv9_template.c
+++ b/src/nfv9_template.c
@@ -41,13 +41,13 @@ struct template_cache_entry *handle_template(struct template_hdr_v9 *hdr, struct
 
   /* 0 NetFlow v9, 2 IPFIX */
   if (tpl_type == 0 || tpl_type == 2) {
-    if (tpl = find_template(hdr->template_id, pptrs, tpl_type, sid))
+    if (tpl = find_template(hdr->template_id, (struct host_addr *) pptrs->f_agent, tpl_type, sid))
       tpl = refresh_template(hdr, tpl, pptrs, tpl_type, sid, pens, version, len, seq);
     else tpl = insert_template(hdr, pptrs, tpl_type, sid, pens, version, len, seq);
   }
   /* 1 NetFlow v9, 3 IPFIX */
   else if (tpl_type == 1 || tpl_type == 3) {
-    if (tpl = find_template(hdr->template_id, pptrs, tpl_type, sid))
+    if (tpl = find_template(hdr->template_id, (struct host_addr *) pptrs->f_agent, tpl_type, sid))
       tpl = refresh_opt_template(hdr, tpl, pptrs, tpl_type, sid, version, len, seq);
     else tpl = insert_opt_template(hdr, pptrs, tpl_type, sid, version, len, seq);
   }
@@ -55,7 +55,7 @@ struct template_cache_entry *handle_template(struct template_hdr_v9 *hdr, struct
   return tpl;
 }
 
-struct template_cache_entry *find_template(u_int16_t id, struct packet_ptrs *pptrs, u_int16_t tpl_type, u_int32_t sid)
+struct template_cache_entry *find_template(u_int16_t id, struct host_addr *agent, u_int16_t tpl_type, u_int32_t sid)
 {
   struct template_cache_entry *ptr;
   u_int16_t modulo = (ntohs(id)%tpl_cache.num);
@@ -63,7 +63,7 @@ struct template_cache_entry *find_template(u_int16_t id, struct packet_ptrs *ppt
   ptr = tpl_cache.c[modulo];
 
   while (ptr) {
-    if ((ptr->template_id == id) && (!sa_addr_cmp((struct sockaddr *)pptrs->f_agent, &ptr->agent)) &&
+    if ((ptr->template_id == id) && (!sa_addr_cmp((struct sockaddr *)agent, &ptr->agent)) &&
 	(ptr->source_id == sid))
       return ptr;
     else ptr = ptr->next;
@@ -196,8 +196,723 @@ struct template_cache_entry *insert_template(struct template_hdr_v9 *hdr, struct
 
   log_template_footer(ptr, ptr->len, version);
 
+#ifdef WITH_JANSSON
+  if (config.nfacctd_templates_file)
+    save_template(ptr, config.nfacctd_templates_file);
+#endif
+
   return ptr;
 }
+
+#ifdef WITH_JANSSON
+void load_templates_from_file(char *path)
+{
+  FILE *tmp_file = fopen(path, "r");
+  char errbuf[SRVBUFLEN], *tmpbuf;
+  int line = 1;
+  u_int16_t modulo;
+
+  tmpbuf = malloc(LARGEBUFLEN);
+  if (!tmpbuf) {
+    Log(LOG_ERR, "ERROR ( %s/core ): load_templates_from_file(): unable to malloc() tmpbuf. File skipped.\n",
+	config.name);
+    return;
+  }
+
+  if (!tmp_file) {
+    Log(LOG_ERR, "ERROR ( %s/core ): [%s] load_templates_from_file(): unable to fopen(). File skipped.\n",
+               config.name, path);
+    return;
+  }
+
+  struct template_cache_entry *tpl, *prev_ptr = NULL, *ptr = NULL;
+
+  while (fgets(tmpbuf, LARGEBUFLEN, tmp_file)) {
+    tpl = nfacctd_offline_read_json_template(tmpbuf, errbuf, SRVBUFLEN);
+    if (tpl == NULL) {
+      Log(LOG_WARNING, "WARN ( %s/core ): [%s:%u] %s\n", config.name, path, line, errbuf);
+    }
+    else {
+      /* We assume the cache is empty when templates are loaded */
+      if (find_template(tpl->template_id, &tpl->agent, tpl->template_type, tpl->source_id))
+        Log(LOG_DEBUG, "WARN ( %s/core ): Template %d already exists in cache. Skipping\n",
+                config.name, tpl->template_id);
+      else {
+        modulo = (ntohs(tpl->template_id)%tpl_cache.num);
+        ptr = tpl_cache.c[modulo];
+
+        while (ptr) {
+          prev_ptr = ptr;
+          ptr = ptr->next;
+        }
+
+        if (prev_ptr) prev_ptr->next = tpl;
+        else tpl_cache.c[modulo] = tpl;
+
+        Log(LOG_DEBUG, "DEBUG ( %s/core ): Loaded template %d into cache.\n",
+                config.name, tpl->template_id);
+      }
+    }
+
+    prev_ptr = NULL;
+    line++;
+  }
+
+  free(tmpbuf);
+  fclose(tmp_file);
+}
+
+void update_template_in_file(struct template_cache_entry *tpl, char *path)
+{
+  FILE *tmp_file = fopen(path, "r");
+  char *tmpbuf;
+  char tpl_agent_str[INET6_ADDRSTRLEN];
+  const char *addr;
+  int line = 0, tpl_found = 0;
+  u_int16_t tpl_id, tpl_type;
+  u_int32_t src_id;
+
+  tmpbuf = malloc(LARGEBUFLEN);
+  if (!tmpbuf) {
+    Log(LOG_ERR, "ERROR ( %s/core ): update_template_in_file(): unable to malloc() tmpbuf. Update skipped.\n",
+	config.name);
+    return;
+  }
+
+  if (!tmp_file) {
+    Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): unable to fopen(). Update skipped.\n",
+               config.name, path);
+    return;
+  }
+
+  /* Find line where our template is stored */
+  while (fgets(tmpbuf, LARGEBUFLEN, tmp_file)) {
+    json_error_t json_err;
+    json_t *json_obj;
+
+    json_obj = json_loads(tmpbuf, 0, &json_err);
+
+    if (!json_obj) {
+      Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): json_loads() error: %s. Line skipped.\n",
+              config.name, path, json_err.text);
+      continue;
+    }
+    else {
+      if (!json_is_object(json_obj)) {
+        Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): json_is_object() failed. Line skipped.\n",
+                config.name, path);
+        continue;
+      }
+      else {
+        json_t *json_tpl_id = json_object_get(json_obj, "template_id");
+        if (json_tpl_id == NULL) {
+          Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): template ID null. Line skipped.\n",
+                  config.name, path);
+          continue;
+        }
+        else {
+          tpl_id = json_integer_value(json_tpl_id);
+        }
+
+        free(json_tpl_id);
+
+        json_t *json_agent = json_object_get(json_obj, "agent");
+        if (json_agent == NULL) {
+          Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): agent null. Line skipped.\n",
+                  config.name, path);
+          continue;
+        }
+        else {
+          addr = json_string_value(json_agent);
+        }
+
+        free(json_agent);
+
+        json_t *json_src_id = json_object_get(json_obj, "source_id");
+        if (json_src_id == NULL) {
+          Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): source ID null. Line skipped.\n",
+                  config.name, path);
+          continue;
+        }
+        else {
+          src_id = json_integer_value(json_src_id);
+        }
+
+        free(json_src_id);
+
+        json_t *json_tpl_type = json_object_get(json_obj, "template_type");
+        if (json_tpl_type == NULL) {
+          Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): template type null. Line skipped.\n",
+                  config.name, path);
+          continue;
+        }
+        else {
+          tpl_type = json_integer_value(json_tpl_type);
+        }
+
+        free(json_tpl_type);
+      }
+
+      addr_to_str(tpl_agent_str, &tpl->agent);
+      if (tpl_id == tpl->template_id && tpl_type == tpl->template_type
+              && src_id == tpl->source_id && !strcmp(addr, tpl_agent_str)) {
+        tpl_found = 1;
+        break;
+      }
+    }
+    line++;
+  }
+
+  if (tpl_found == 0)
+    Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): Template %d not found.\n",
+            config.name, path, tpl->template_id);
+  else {
+    if (delete_line_from_file(line, path) != 0) {
+      Log(LOG_WARNING, "WARN ( %s/core ): [%s] update_template_in_file(): Error deleting old template. New version not saved.\n",
+              config.name, path);
+    }
+    else {
+      save_template(tpl, path);
+    }
+  }
+
+  free(tmpbuf);
+  fclose(tmp_file);
+}
+
+void save_template(struct template_cache_entry *tpl, char *file)
+{
+  u_int16_t field_idx;
+  u_int8_t idx;
+  char *fmt;
+  char ip_addr[INET6_ADDRSTRLEN];
+  json_t *root = json_object(), *agent_obj, *kv;
+  json_t *list_array, *tpl_array;
+  FILE *tpl_file = open_output_file(config.nfacctd_templates_file, "a", TRUE);
+
+  addr_to_str(ip_addr, &tpl->agent);
+  kv = json_pack("{ss}", "agent", ip_addr);
+  json_object_update_missing(root, kv);
+  json_decref(kv);
+
+  kv = json_pack("{sI}", "source_id", tpl->source_id);
+  json_object_update_missing(root, kv);
+  json_decref(kv);
+
+  kv = json_pack("{sI}", "template_id", tpl->template_id);
+  json_object_update_missing(root, kv);
+  json_decref(kv);
+
+  kv = json_pack("{sI}", "template_type", tpl->template_type);
+  json_object_update_missing(root, kv);
+  json_decref(kv);
+
+  kv = json_pack("{sI}", "num", tpl->num);
+  json_object_update_missing(root, kv);
+  json_decref(kv);
+
+  kv = json_pack("{sI}", "len", tpl->len);
+  json_object_update_missing(root, kv);
+  json_decref(kv);
+
+  /* Data template */
+  if (tpl->template_type == 0) {
+    kv = json_pack("{sI}", "vlen", tpl->vlen);
+    json_object_update_missing(root, kv);
+    json_decref(kv);
+
+    list_array = json_array();
+    for (field_idx = 0; field_idx < tpl->num; field_idx++) {
+      json_t *json_tfl_field = json_object();
+
+      kv = json_pack("{sI}", "type", tpl->list[field_idx].type);
+      json_object_update_missing(json_tfl_field, kv);
+      json_decref(kv);
+
+      /* idea: depending on tpl->list[field_idx].type,
+       * serialize either an otpl_field (if TPL_TYPE_LEGACY) or
+       * an utpl_field (if TPL_TYPE_EXT_DB) */
+      if (tpl->list[field_idx].type == TPL_TYPE_LEGACY){
+        struct otpl_field *otpl_field = (struct otpl_field *) tpl->list[field_idx].ptr;
+        /* Where in tpl->tpl to insert the otpl_field
+         * when deserializing */
+        int tpl_index = (otpl_field - tpl->tpl);
+
+        json_t *json_otpl_field = json_object();
+
+        kv = json_pack("{sI}", "off", otpl_field->off);
+        json_object_update_missing(json_otpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "len", otpl_field->len);
+        json_object_update_missing(json_otpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "tpl_len", otpl_field->tpl_len);
+        json_object_update_missing(json_otpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "tpl_index", tpl_index);
+        json_object_update_missing(json_otpl_field, kv);
+        json_decref(kv);
+
+        json_object_set_new(json_tfl_field, "otpl", json_otpl_field);
+      }
+      else if (tpl->list[field_idx].type == TPL_TYPE_EXT_DB) {
+        struct utpl_field *ext_db_ptr = (struct utpl_field *) tpl->list[field_idx].ptr;
+        u_int16_t ext_db_modulo = (ext_db_ptr->type%TPL_EXT_DB_ENTRIES);
+
+        /* Where in tpl->ext_db[ext_db_modulo].ie
+         * to insert the utpl_field when deserializing */
+        int ie_idx = (ext_db_ptr - tpl->ext_db[ext_db_modulo].ie);
+
+        json_t *json_utpl_field = json_object();
+
+        kv = json_pack("{sI}", "pen", ext_db_ptr->pen);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "type", ext_db_ptr->type);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "off", ext_db_ptr->off);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "len", ext_db_ptr->len);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "tpl_len", ext_db_ptr->tpl_len);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "repeat_id", ext_db_ptr->repeat_id);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        kv = json_pack("{sI}", "ie_idx", ie_idx);
+        json_object_update_missing(json_utpl_field, kv);
+        json_decref(kv);
+
+        json_object_set_new(json_tfl_field, "utpl", json_utpl_field);
+      }
+
+      json_array_append_new(list_array, json_tfl_field);
+    }
+    json_object_set_new(root, "list", list_array);
+  }
+  /* Options template */
+  else {
+    tpl_array = json_array();
+    /* Fields with type >= NF9_MAX_DEFINED_FIELD are not serialized
+     * since they don't appear to be taken into account when receiving
+     * the template. */
+    for (field_idx = 0; field_idx < NF9_MAX_DEFINED_FIELD; field_idx++) {
+      if (tpl->tpl[field_idx].off == 0 && tpl->tpl[field_idx].len == 0) continue;
+
+      json_t *json_tpl_field = json_object();
+
+      kv = json_pack("{sI}", "type", field_idx);
+      json_object_update_missing(json_tpl_field, kv);
+      json_decref(kv);
+
+      kv = json_pack("{sI}", "off", tpl->tpl[field_idx].off);
+      json_object_update_missing(json_tpl_field, kv);
+      json_decref(kv);
+
+      kv = json_pack("{sI}", "len", tpl->tpl[field_idx].len);
+      json_object_update_missing(json_tpl_field, kv);
+      json_decref(kv);
+
+      json_array_append_new(tpl_array, json_tpl_field);
+    }
+
+    json_object_set_new(root, "tpl", tpl_array);
+  }
+
+  /* NB: member `next` is willingly excluded from serialisation, since
+   * it would make more sense for it to be computed when de-serializing,
+   * to prevent the template cache from being corrupted. */
+
+  if (root) {
+      write_and_free_json(tpl_file, root);
+      Log(LOG_DEBUG, "DEBUG ( %s/core ): Saved template %d into file.\n",
+              config.name, tpl->template_id);
+  }
+
+  close_output_file(tpl_file);
+}
+
+struct template_cache_entry *nfacctd_offline_read_json_template(char *buf, char *errbuf, int errlen)
+{
+  struct template_cache_entry *ret = NULL;
+  u_int16_t field_idx;
+
+  json_error_t json_err;
+  json_t *json_obj;
+
+  json_obj = json_loads(buf, 0, &json_err);
+
+  if (!json_obj) {
+    snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): json_loads() error: %s. Line skipped.\n", json_err.text);
+  }
+  else {
+    if (!json_is_object(json_obj)) {
+      snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): json_is_object() failed. Line skipped.\n");
+    }
+    else {
+      ret = malloc(sizeof(struct template_cache_entry));
+      if (!ret) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): Unable to allocate enough memory for a new Template Cache Entry.\n");
+        return NULL;
+      }
+
+      memset(ret, 0, sizeof(struct template_cache_entry));
+
+      json_t *json_tpl_id = json_object_get(json_obj, "template_id");
+      if (json_tpl_id == NULL) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): template ID null. Line skipped.\n");
+        free(ret);
+        return NULL;
+      }
+      else {
+        ret->template_id = json_integer_value(json_tpl_id);
+      }
+
+      free(json_tpl_id);
+
+      json_t *json_src_id = json_object_get(json_obj, "source_id");
+      if (json_src_id == NULL) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): source ID null. Line skipped.\n");
+        free(ret);
+        return NULL;
+      }
+      else {
+        ret->source_id = json_integer_value(json_src_id);
+      }
+
+      free(json_src_id);
+
+      json_t *json_tpl_type = json_object_get(json_obj, "template_type");
+      if (json_tpl_type == NULL) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): template type null. Line skipped.\n");
+        free(ret);
+        return NULL;
+      }
+      else {
+        ret->template_type = json_integer_value(json_tpl_type);
+      }
+
+      free(json_tpl_type);
+
+      json_t *json_num = json_object_get(json_obj, "num");
+      if (json_num == NULL) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): num null. Line skipped.\n");
+        free(ret);
+        return NULL;
+      }
+      else {
+        ret->num = json_integer_value(json_num);
+      }
+
+      free(json_num);
+
+      json_t *json_len = json_object_get(json_obj, "len");
+      if (json_len == NULL) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): len null. Line skipped.\n");
+        free(ret);
+        return NULL;
+      }
+      else {
+        ret->len = json_integer_value(json_len);
+      }
+
+      free(json_len);
+
+      json_t *json_agent = json_object_get(json_obj, "agent");
+      const char *agent_str = json_string_value(json_agent);
+      if(!str_to_addr(agent_str, &ret->agent)) {
+        snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): error creating agent.\n");
+        free(ret);
+        return NULL;
+      }
+
+      /* Data template */
+      if (ret->template_type == 0) {
+        json_t *json_vlen = json_object_get(json_obj, "vlen");
+        if (json_vlen == NULL) {
+          snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): vlen null. Line skipped.\n");
+          free(ret);
+          return NULL;
+        }
+        else {
+          ret->vlen = json_integer_value(json_vlen);
+        }
+
+        free(json_vlen);
+
+        json_t *json_list = json_object_get(json_obj, "list");
+        if (!json_is_array(json_list))
+          snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): error parsing template fields list.\n");
+        else {
+          size_t key;
+          json_t *value;
+          int idx = 0;
+          json_array_foreach(json_list, key, value) {
+            if (json_integer_value(json_object_get(value, "type")) == TPL_TYPE_LEGACY) {
+              ret->list[idx].type = TPL_TYPE_LEGACY;
+              struct otpl_field *otpl = malloc(sizeof(struct otpl_field));
+              if (!otpl) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): Unable to allocate enough memory for a new legacy template field.\n");
+                free(ret);
+                return NULL;
+              }
+              memset(otpl, 0, sizeof (struct otpl_field));
+
+              json_t *json_otpl = json_object_get(value, "otpl");
+              if (json_otpl == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): otpl null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+
+              json_t *json_otpl_member = json_object_get(json_otpl, "off");
+              if (json_otpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): off null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                otpl->off = json_integer_value(json_otpl_member);
+              }
+
+              json_otpl_member = json_object_get(json_otpl, "len");
+              if (json_otpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): len null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                otpl->len = json_integer_value(json_otpl_member);
+              }
+
+              json_otpl_member = json_object_get(json_otpl, "tpl_len");
+              if (json_otpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): tpl_len null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                otpl->tpl_len = json_integer_value(json_otpl_member);
+              }
+
+              int tpl_index;
+              json_otpl_member = json_object_get(json_otpl, "tpl_index");
+              if (json_otpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): tpl_index null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                tpl_index = json_integer_value(json_otpl_member);
+              }
+
+              ret->list[idx].ptr = (char *) otpl;
+              ret->tpl[tpl_index] = *otpl;
+              free(json_otpl_member);
+              free(json_otpl);
+            }
+            else if (json_integer_value(json_object_get(value, "type")) == TPL_TYPE_EXT_DB) {
+              ret->list[idx].type = TPL_TYPE_EXT_DB;
+              struct utpl_field *utpl = malloc(sizeof(struct utpl_field));
+              if (!utpl) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): Unable to allocate enough memory for a new ext_db template field.\n");
+                free(ret);
+                return NULL;
+              }
+              memset(utpl, 0, sizeof(struct utpl_field));
+
+              json_t *json_utpl = json_object_get(value, "utpl");
+              if (json_utpl == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): utpl null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+
+              json_t *json_utpl_member = json_object_get(json_utpl, "pen");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): pen null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                utpl->pen = json_integer_value(json_utpl_member);
+              }
+
+              json_utpl_member = json_object_get(json_utpl, "type");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): type null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                utpl->type = json_integer_value(json_utpl_member);
+              }
+
+              json_utpl_member = json_object_get(json_utpl, "off");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): off null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                utpl->off = json_integer_value(json_utpl_member);
+              }
+
+              json_utpl_member = json_object_get(json_utpl, "len");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): len null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                utpl->len = json_integer_value(json_utpl_member);
+              }
+
+              json_utpl_member = json_object_get(json_utpl, "tpl_len");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): tpl_len null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                utpl->tpl_len = json_integer_value(json_utpl_member);
+              }
+
+              json_utpl_member = json_object_get(json_utpl, "repeat_id");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): repeat_id null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                utpl->repeat_id = json_integer_value(json_utpl_member);
+              }
+
+              int ie_idx, modulo;
+              json_utpl_member = json_object_get(json_utpl, "ie_idx");
+              if (json_utpl_member == NULL) {
+                snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): ie_idx null. Line skipped.\n");
+                free(ret);
+                return NULL;
+              }
+              else {
+                ie_idx = json_integer_value(json_utpl_member);
+              }
+
+              modulo = (utpl->type%TPL_EXT_DB_ENTRIES);
+              ret->list[idx].ptr = (char *) utpl;
+              ret->ext_db[modulo].ie[ie_idx] = *utpl;
+              free(json_utpl_member);
+              free(json_utpl);
+            }
+            else {
+              snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): incorrect field type. Line skipped.\n");
+              free(ret);
+              return NULL;
+            }
+
+            idx++;
+          }
+          free(value);
+        }
+        free(json_list);
+      }
+      /* Options template */
+      else {
+        json_t *json_tpl = json_object_get(json_obj, "tpl");
+        if (!json_is_array(json_tpl))
+          snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): error parsing template fields list.\n");
+        else {
+          size_t key;
+          json_t *value;
+          int tpl_idx = 0;
+          json_array_foreach(json_tpl, key, value) {
+            struct otpl_field *otpl = malloc(sizeof(struct otpl_field));
+            if (!otpl) {
+              snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): Unable to allocate enough memory for a new options template field.\n");
+              free(ret);
+              return NULL;
+            }
+            memset(otpl, 0, sizeof (struct otpl_field));
+
+            json_t *json_otpl_member = json_object_get(value, "type");
+            if (json_otpl_member == NULL) {
+              snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): type null. Line skipped.\n");
+              free(ret);
+              return NULL;
+            }
+            else {
+              tpl_idx = json_integer_value(json_otpl_member);
+            }
+
+            json_otpl_member = json_object_get(value, "off");
+            if (json_otpl_member == NULL) {
+              snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): off null. Line skipped.\n");
+              free(ret);
+              return NULL;
+            }
+            else {
+              otpl->off = json_integer_value(json_otpl_member);
+            }
+
+            json_otpl_member = json_object_get(value, "len");
+            if (json_otpl_member == NULL) {
+              snprintf(errbuf, errlen, "nfacctd_offline_read_json_template(): len null. Line skipped.\n");
+              free(ret);
+              return NULL;
+            }
+            else {
+              otpl->len = json_integer_value(json_otpl_member);
+            }
+
+            ret->tpl[tpl_idx] = *otpl;
+            free(json_otpl_member);
+          }
+        }
+        free (json_tpl);
+      }
+
+      return ret;
+    }
+
+    json_decref(json_obj);
+  }
+  return ret;
+}
+#else
+void load_templates_from_file(char *path)
+{
+  if (config.debug) Log(LOG_DEBUG, "DEBUG ( %s/core ): load_templates_from_file(): JSON object not created due to missing --enable-jansson\n", config.name);
+}
+
+void update_template_in_file(struct template_cache_entry *tpl, char *path)
+{
+  if (config.debug) Log(LOG_DEBUG, "DEBUG ( %s/core ): update_template_in_file(): JSON object not created due to missing --enable-jansson\n", config.name);
+}
+
+void save_template(struct template_cache_entry *tpl, char *file)
+{
+  if (config.debug) Log(LOG_DEBUG, "DEBUG ( %s/core ): save_template(): JSON object not created due to missing --enable-jansson\n", config.name);
+}
+
+struct template_cache_entry *nfacctd_offline_read_json_template(char *buf, char *errbuf, int errlen)
+{
+  if (config.debug) Log(LOG_DEBUG, "DEBUG ( %s/core ): nfacctd_offline_read_json_template(): JSON object not created due to missing --enable-jansson\n", config.name);
+}
+#endif
 
 struct template_cache_entry *refresh_template(struct template_hdr_v9 *hdr, struct template_cache_entry *tpl, struct packet_ptrs *pptrs, u_int16_t tpl_type,
 						u_int32_t sid, u_int16_t *pens, u_int8_t version, u_int16_t len, u_int32_t seq)
@@ -303,6 +1018,11 @@ struct template_cache_entry *refresh_template(struct template_hdr_v9 *hdr, struc
   }
 
   log_template_footer(tpl, tpl->len, version);
+
+#ifdef WITH_JANSSON
+  if (config.nfacctd_templates_file)
+    update_template_in_file(tpl, config.nfacctd_templates_file);
+#endif
 
   return tpl;
 }
@@ -458,6 +1178,11 @@ struct template_cache_entry *insert_opt_template(void *hdr, struct packet_ptrs *
 
   log_template_footer(ptr, ptr->len, version);
 
+#ifdef WITH_JANSSON
+  if (config.nfacctd_templates_file)
+    save_template(ptr, config.nfacctd_templates_file);
+#endif
+
   return ptr;
 }
 
@@ -527,6 +1252,11 @@ struct template_cache_entry *refresh_opt_template(void *hdr, struct template_cac
   }
 
   log_template_footer(tpl, tpl->len, version);
+
+#ifdef WITH_JANSSON
+  if (config.nfacctd_templates_file)
+    update_template_in_file(tpl, config.nfacctd_templates_file);
+#endif
 
   return tpl;
 }


### PR DESCRIPTION
nfacctd templates can be cached to limit the amount of lost
Netflow/IPFIX packets due to unknown templates when nfacctd (re)starts.
This pull request focuses on changes to the nfacctd daemon.
Note: this pull request depends on library code changes and should therefore be reviewed after #106.