### PR TITLE
internal metrics support: libraries

### DIFF
--- a/src/network.h
+++ b/src/network.h
@@ -637,7 +637,7 @@ struct tunnel_entry {
 };
 
 /* global variables */
-#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C)
+#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C) && (!defined __INTSTATSD_C)
 #define EXT extern
 #else
 #define EXT

--- a/src/nfprobe_plugin/nfprobe_plugin.c
+++ b/src/nfprobe_plugin/nfprobe_plugin.c
@@ -771,23 +771,6 @@ process_packet(struct FLOWTRACK *ft, struct primitives_ptrs *prim_ptrs, const st
   return (PP_OK);
 }
 
-/*
- * Subtract two timevals. Returns (t1 - t2) in milliseconds.
- */
-u_int32_t
-timeval_sub_ms(const struct timeval *t1, const struct timeval *t2)
-{
-	struct timeval res;
-
-	res.tv_sec = t1->tv_sec - t2->tv_sec;
-	res.tv_usec = t1->tv_usec - t2->tv_usec;
-	if (res.tv_usec < 0) {
-		res.tv_usec += 1000000L;
-		res.tv_sec--;
-	}
-	return ((u_int32_t)res.tv_sec * 1000 + (u_int32_t)res.tv_usec / 1000);
-}
-
 static void
 update_statistic(struct STATISTIC *s, double new, double n)
 {

--- a/src/once.h
+++ b/src/once.h
@@ -22,7 +22,7 @@
 #ifndef _ONCE_H_
 #define _ONCE_H_
 
-#if defined __PMACCTD_C || defined __NFACCTD_C || defined __SFACCTD_C || defined __UACCTD_C || defined __PMACCT_CLIENT_C || defined __PMTELEMETRYD_C || defined __PMBGPD_C || defined __PMBMPD_C
+#if defined __PMACCTD_C || defined __NFACCTD_C || defined __SFACCTD_C || defined __UACCTD_C || defined __PMACCT_CLIENT_C || defined __PMTELEMETRYD_C || defined __PMBGPD_C || defined __PMBMPD_C || defined __INTSTATSD_C
 #define EXT 
 #else
 #define EXT extern

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -35,7 +35,7 @@
 #define PLUGIN_ID_UNKNOWN       -1
 
 /* vars */
-#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMACCT_CLIENT_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C)
+#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMACCT_CLIENT_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C) && (!defined __INTSTATSD_C)
 #define EXT extern
 #else
 #define EXT

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -379,7 +379,7 @@ void
 initsetproctitle(int, char**, char**);
 
 /* global variables */
-#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C)
+#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C) && (!defined __INTSTATSD_C)
 #define EXT extern
 #else
 #define EXT

--- a/src/util.c
+++ b/src/util.c
@@ -1011,6 +1011,23 @@ int timeval_cmp(struct timeval *a, struct timeval *b)
 }
 
 /*
+ * Subtract two timevals. Returns (t1 - t2) in milliseconds.
+ */
+u_int32_t
+timeval_sub_ms(const struct timeval *t1, const struct timeval *t2)
+{
+	struct timeval res;
+
+	res.tv_sec = t1->tv_sec - t2->tv_sec;
+	res.tv_usec = t1->tv_usec - t2->tv_usec;
+	if (res.tv_usec < 0) {
+		res.tv_usec += 1000000L;
+		res.tv_sec--;
+	}
+	return ((u_int32_t)res.tv_sec * 1000 + (u_int32_t)res.tv_usec / 1000);
+}
+
+/*
  * exit_all(): Core Process exit lane. Not meant to be a nice shutdown method: it is
  * an exit() replacement that sends kill signals to the plugins.
  */


### PR DESCRIPTION
pmacct now supports periodic sending of internal use metrics to a
[StatsD](https://github.com/etsy/statsd)  instance. This pull request focuses on libraries changes.