### PR TITLE
Add internal metrics support: plugins

### DIFF
--- a/src/amqp_plugin.c
+++ b/src/amqp_plugin.c
@@ -268,6 +268,7 @@ void amqp_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
       else {

--- a/src/imt_plugin.c
+++ b/src/imt_plugin.c
@@ -410,6 +410,7 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
         }
 
         memcpy(pipebuf, rgptr, config.buffer_size);
+        status->last_plugin_off = (rgptr - (unsigned char *)((struct channels_list_entry *)ptr)->rg.base);
         if (((struct ch_buf_hdr *)pipebuf)->seq != seq) {
           rg_err_count++;
           if (config.debug || (rg_err_count > MAX_RG_COUNT_ERR)) {

--- a/src/kafka_plugin.h
+++ b/src/kafka_plugin.h
@@ -38,6 +38,7 @@ EXT void kafka_cache_purge(struct chained_cache *[], int);
 #ifdef WITH_AVRO
 EXT void kafka_avro_schema_purge(char *);
 #endif
+EXT void *kafka_generate_stats(void *);
 
 /* global vars */
 EXT void (*insert_func)(struct primitives_ptrs *, struct insert_data *); /* pointer to INSERT function */
@@ -51,6 +52,7 @@ EXT time_t refresh_deadline;
 
 EXT struct timeval sbasetime;
 
+EXT void set_kafka_metric(u_int64_t, void *);
 #ifdef WITH_AVRO
 EXT char *avro_buf;
 EXT avro_schema_t avro_acct_schema;

--- a/src/mongodb_plugin.c
+++ b/src/mongodb_plugin.c
@@ -219,6 +219,7 @@ void mongodb_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/mysql_plugin.c
+++ b/src/mysql_plugin.c
@@ -197,6 +197,7 @@ void mysql_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/nfprobe_plugin/nfprobe_plugin.c
+++ b/src/nfprobe_plugin/nfprobe_plugin.c
@@ -771,23 +771,6 @@ process_packet(struct FLOWTRACK *ft, struct primitives_ptrs *prim_ptrs, const st
   return (PP_OK);
 }
 
-/*
- * Subtract two timevals. Returns (t1 - t2) in milliseconds.
- */
-u_int32_t
-timeval_sub_ms(const struct timeval *t1, const struct timeval *t2)
-{
-	struct timeval res;
-
-	res.tv_sec = t1->tv_sec - t2->tv_sec;
-	res.tv_usec = t1->tv_usec - t2->tv_usec;
-	if (res.tv_usec < 0) {
-		res.tv_usec += 1000000L;
-		res.tv_sec--;
-	}
-	return ((u_int32_t)res.tv_sec * 1000 + (u_int32_t)res.tv_usec / 1000);
-}
-
 static void
 update_statistic(struct STATISTIC *s, double new, double n)
 {
@@ -1648,6 +1631,7 @@ read_data:
   
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/pgsql_plugin.c
+++ b/src/pgsql_plugin.c
@@ -196,6 +196,7 @@ void pgsql_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/plugin_hooks.h
+++ b/src/plugin_hooks.h
@@ -53,6 +53,7 @@ struct ch_status {
   u_int8_t wakeup;		/* plugin is polling */ 
   u_int32_t backlog;
   u_int64_t last_buf_off;	/* offset of last committed buffer */
+  u_int64_t last_plugin_off;	/* offset of last buffer copied by the plugin (for reporting) */
 };
 
 struct sampling {
@@ -72,6 +73,7 @@ struct plugin_type_entry {
   int id;
   char string[10];
   void (*func)(int, struct configuration *, void *);
+  void * (*stats_func)(void *);
 };
 
 struct plugins_list_entry {
@@ -231,5 +233,6 @@ EXT void amqp_plugin(int, struct configuration *, void *);
 
 #ifdef WITH_KAFKA
 EXT void kafka_plugin(int, struct configuration *, void *);
+EXT void *kafka_generate_stats(void *);
 #endif
 #undef EXT

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -35,7 +35,7 @@
 #define PLUGIN_ID_UNKNOWN       -1
 
 /* vars */
-#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMACCT_CLIENT_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C)
+#if (!defined __PMACCTD_C) && (!defined __NFACCTD_C) && (!defined __SFACCTD_C) && (!defined __UACCTD_C) && (!defined __PMTELEMETRYD_C) && (!defined __PMACCT_CLIENT_C) && (!defined __PMBGPD_C) && (!defined __PMBMPD_C) && (!defined __INTSTATSD_C)
 #define EXT extern
 #else
 #define EXT
@@ -836,31 +836,31 @@ static const struct _dictionary_line dictionary[] = {
 };
 
 static struct plugin_type_entry plugin_types_list[] = {
-  {PLUGIN_ID_CORE, 	"core", 	NULL},
-  {PLUGIN_ID_MEMORY, 	"memory", 	imt_plugin},
-  {PLUGIN_ID_PRINT,	"print",	print_plugin},
-  {PLUGIN_ID_NFPROBE,	"nfprobe",	nfprobe_plugin},
-  {PLUGIN_ID_SFPROBE,	"sfprobe",	sfprobe_plugin},
+  {PLUGIN_ID_CORE, 	"core", 	NULL,           NULL},
+  {PLUGIN_ID_MEMORY, 	"memory", 	imt_plugin,     NULL},
+  {PLUGIN_ID_PRINT,	"print",	print_plugin,   NULL},
+  {PLUGIN_ID_NFPROBE,	"nfprobe",	nfprobe_plugin, NULL},
+  {PLUGIN_ID_SFPROBE,	"sfprobe",	sfprobe_plugin, NULL},
 #ifdef WITH_MYSQL
-  {PLUGIN_ID_MYSQL,	"mysql",	mysql_plugin},
+  {PLUGIN_ID_MYSQL,	"mysql",	mysql_plugin,   NULL},
 #endif
 #ifdef WITH_PGSQL
-  {PLUGIN_ID_PGSQL,	"pgsql",	pgsql_plugin},
+  {PLUGIN_ID_PGSQL,	"pgsql",	pgsql_plugin,   NULL},
 #endif
 #ifdef WITH_SQLITE3
-  {PLUGIN_ID_SQLITE3,	"sqlite3",	sqlite3_plugin},
+  {PLUGIN_ID_SQLITE3,	"sqlite3",	sqlite3_plugin, NULL},
 #endif
 #ifdef WITH_MONGODB
-  {PLUGIN_ID_MONGODB,   "mongodb",      mongodb_plugin},
+  {PLUGIN_ID_MONGODB,   "mongodb",      mongodb_plugin, NULL},
 #endif
 #ifdef WITH_RABBITMQ
-  {PLUGIN_ID_AMQP,	"amqp",		amqp_plugin},
+  {PLUGIN_ID_AMQP,	"amqp",		amqp_plugin,    NULL},
 #endif
 #ifdef WITH_KAFKA
-  {PLUGIN_ID_KAFKA,     "kafka",        kafka_plugin},
+  {PLUGIN_ID_KAFKA,     "kafka",        kafka_plugin,   kafka_generate_stats},
 #endif
-  {PLUGIN_ID_TEE,	"tee",		tee_plugin},
-  {PLUGIN_ID_UNKNOWN,	"",		NULL},
+  {PLUGIN_ID_TEE,	"tee",		tee_plugin,     NULL},
+  {PLUGIN_ID_UNKNOWN,	"",		NULL,           NULL},
 };
 #endif
 

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -295,6 +295,7 @@ void print_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/sfprobe_plugin/sfprobe_plugin.c
+++ b/src/sfprobe_plugin/sfprobe_plugin.c
@@ -751,6 +751,7 @@ read_data:
   
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/sqlite3_plugin.c
+++ b/src/sqlite3_plugin.c
@@ -197,6 +197,7 @@ void sqlite3_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ

--- a/src/tee_plugin/tee_plugin.c
+++ b/src/tee_plugin/tee_plugin.c
@@ -267,6 +267,7 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   
         pollagain = FALSE;
         memcpy(pipebuf, rg->ptr, bufsz);
+        status->last_plugin_off = (rg->ptr - rg->base);
         rg->ptr += bufsz;
       }
 #ifdef WITH_RABBITMQ


### PR DESCRIPTION
pmacct now supports periodic sending of internal use metrics to a
[StatsD](https://github.com/etsy/statsd) instance. This pull request focuses on changes to the plugins.