### PR TITLE
Add internal metrics support: nfacctd

### DIFF
--- a/src/nfacctd.h
+++ b/src/nfacctd.h
@@ -398,6 +398,12 @@ struct data_hdr_v9 {
   u_int16_t flow_len;
 };
 
+struct nfacctd_metrics {
+  int rcv_pkt;
+  int udp_drop_cnt;
+  int udp_rcv_buf;
+};
+
 /* defines */
 #define DEFAULT_NFACCTD_PORT 2100
 #define NETFLOW_MSG_SIZE PKT_MSG_SIZE
@@ -781,8 +787,12 @@ EXT int NF_find_id(struct id_table *, struct packet_ptrs *, pm_id_t *, pm_id_t *
 EXT char *nfv578_check_status(struct packet_ptrs *);
 EXT char *nfv9_check_status(struct packet_ptrs *, u_int32_t, u_int32_t, u_int32_t, u_int8_t);
 
+EXT void increment_metric(int *);
+
 EXT struct template_cache tpl_cache;
 EXT struct v8_handler_entry v8_handlers[15];
+
+EXT struct nfacctd_metrics nf_metrics;
 
 EXT struct host_addr debug_a;
 EXT u_char debug_agent_addr[50];

--- a/src/nfv9_template.c
+++ b/src/nfv9_template.c
@@ -115,6 +115,7 @@ struct template_cache_entry *insert_template(struct template_hdr_v9 *hdr, struct
     if (off >= len) {
       notify_malf_packet(LOG_INFO, "INFO: unable to read next Template Flowset (malformed template)",
                         (struct sockaddr *) pptrs->f_agent, seq);
+      increment_metric(&nf_metrics.udp_drop_cnt);
       xflow_tot_bad_datagrams++;
       free(ptr);
       return NULL;
@@ -231,6 +232,7 @@ struct template_cache_entry *refresh_template(struct template_hdr_v9 *hdr, struc
     if (off >= len) {
       notify_malf_packet(LOG_INFO, "INFO: unable to read next Template Flowset (malformed template)",
                         (struct sockaddr *) pptrs->f_agent, seq);
+      increment_metric(&nf_metrics.udp_drop_cnt);
       xflow_tot_bad_datagrams++;
       memcpy(tpl, &backup, sizeof(struct template_cache_entry));
       return NULL;
@@ -434,6 +436,7 @@ struct template_cache_entry *insert_opt_template(void *hdr, struct packet_ptrs *
     if (off >= len) {
       notify_malf_packet(LOG_INFO, "INFO: unable to read next Options Template Flowset (malformed template)",
                         (struct sockaddr *) pptrs->f_agent, seq);
+      increment_metric(&nf_metrics.udp_drop_cnt);
       xflow_tot_bad_datagrams++;
       free(ptr);
       return NULL;
@@ -507,6 +510,7 @@ struct template_cache_entry *refresh_opt_template(void *hdr, struct template_cac
     if (off >= len) {
       notify_malf_packet(LOG_INFO, "INFO: unable to read next Options Template Flowset (malformed template)",
                         (struct sockaddr *) pptrs->f_agent, seq);
+      increment_metric(&nf_metrics.udp_drop_cnt);
       xflow_tot_bad_datagrams++;
       memcpy(tpl, &backup, sizeof(struct template_cache_entry));
       return NULL;


### PR DESCRIPTION
pmacct now supports periodic sending of internal use metrics to a
[StatsD](https://github.com/etsy/statsd) instance. This pull request focuses on changes to nfacctd.