### PR TITLE
Change parent alive check to work with Docker

### DIFF
--- a/src/amqp_plugin.c
+++ b/src/amqp_plugin.c
@@ -201,7 +201,7 @@ void amqp_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }

--- a/src/imt_plugin.c
+++ b/src/imt_plugin.c
@@ -221,7 +221,7 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     gettimeofday(&cycle_stamp, NULL);
 
     if (num <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
 	Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
 	exit_plugin(1);
       } 

--- a/src/kafka_plugin.c
+++ b/src/kafka_plugin.c
@@ -194,7 +194,7 @@ void kafka_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }

--- a/src/mongodb_plugin.c
+++ b/src/mongodb_plugin.c
@@ -169,7 +169,7 @@ void mongodb_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), refresh_timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }

--- a/src/mysql_plugin.c
+++ b/src/mysql_plugin.c
@@ -124,7 +124,7 @@ void mysql_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), refresh_timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }

--- a/src/pgsql_plugin.c
+++ b/src/pgsql_plugin.c
@@ -121,7 +121,7 @@ void pgsql_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), refresh_timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -200,7 +200,7 @@ void print_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), refresh_timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }

--- a/src/sqlite3_plugin.c
+++ b/src/sqlite3_plugin.c
@@ -124,7 +124,7 @@ void sqlite3_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), refresh_timeout);
 
     if (ret <= 0) {
-      if (getppid() == 1) {
+      if (getppid() != core_pid) {
         Log(LOG_ERR, "ERROR ( %s/%s ): Core process *seems* gone. Exiting.\n", config.name, config.type);
         exit_plugin(1);
       }


### PR DESCRIPTION
The origional code checked if the parent PID was equal to 1 (init) to
detect if the parent process died. Docker containers only launch the
required processes which would make the pmacctd core process PID 1,
failing the check.

During initialization of the plugin the core PID is already saved. We
can use this to compare it with the current PID which should have the
same intended effect and still works with Docker.

If this solution is accepted it should be duplicated to the other
plugins.