### PR TITLE
* examples: fix out-of-tree build of examples/lg

### DIFF
--- a/examples/lg/Makefile.am
+++ b/examples/lg/Makefile.am
@@ -2,6 +2,6 @@ AM_CFLAGS = $(PMACCT_CFLAGS)
 
 noinst_PROGRAMS = pmbgp
 pmbgp_SOURCES = pmbgp.c pmbgp.h
-pmbgp_CFLAGS = -I../../src -I$(srcdir)/.. $(AM_CFLAGS)
+pmbgp_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS)
 pmbgp_LDFLAGS = $(DEFS) @ZMQ_CFLAGS@
 pmbgp_LDADD = $(top_builddir)/src/libcommon.la @ZMQ_LIBS@


### PR DESCRIPTION
Out-of-tree build is when you create a `build/` directory, then use `../configure`. Useful to easily clean a tree.