### PR TITLE
fix a bracket correspondence in addr.c.

### DIFF
--- a/src/addr.c
+++ b/src/addr.c
@@ -371,8 +371,8 @@ unsigned int sa_to_str(char *str, int len, const struct sockaddr *sa)
 
       return sa->sa_family;
     }
-  }
 #endif
+  }
 
   memset(str, 0, len);
 


### PR DESCRIPTION
I tried to build with --disable-ipv6, but I saw an error.

```
addr.c: In function 'sa_to_str':
addr.c:745:1: error: expected declaration or statement at end of input
 }
 ^
addr.c:745:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
``` 

addr.c has a problem with bracket correspondence in sa_to_str().