### PR TITLE
Fix trigger script execution

### DIFF
--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -797,10 +797,8 @@ void P_exit_now(int signum)
 
 int P_trigger_exec(char *filename)
 {
-  char *args[1];
+  char *args[2] = { filename, NULL };
   int pid;
-
-  memset(args, 0, sizeof(args));
 
   switch (pid = vfork()) {
   case -1:

--- a/src/sql_common.c
+++ b/src/sql_common.c
@@ -997,10 +997,8 @@ void sql_sum_mac_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *i
 
 int sql_trigger_exec(char *filename)
 {
-  char *args[1];
+  char *args[2] = { filename, NULL };
   int pid;
-
-  memset(args, 0, sizeof(args));
 
   switch (pid = vfork()) {
   case -1:


### PR DESCRIPTION
First argument to execv should be path to executable.  Otherwise this
causes execv(3) to fail and return EFAULT on OpenBSD.