### PR TITLE
Fix pcap iterface-map lookup

### DIFF
--- a/src/pmacctd.c
+++ b/src/pmacctd.c
@@ -112,9 +112,8 @@ void pm_pcap_device_copy_entry(struct pcap_devices *dst, struct pcap_devices *sr
 int pm_pcap_device_getindex_byifname(struct pcap_devices *map, char *ifname)
 {
   int loc_idx;
-
-  for (loc_idx = 0; loc_idx < map->num; loc_idx++) {
-    if (!strncmp(map->list[loc_idx].str, ifname, strlen(ifname))) {
+   for (loc_idx = 0; loc_idx < map->num; loc_idx++) {
+    if (strlen(map->list[loc_idx].str) == strlen(ifname) && !strncmp(map->list[loc_idx].str, ifname, strlen(ifname))) {
       return loc_idx;
     }
   }

--- a/src/pretag_handlers.c
+++ b/src/pretag_handlers.c
@@ -3747,7 +3747,7 @@ u_int32_t pcap_interfaces_map_lookup_ifname(struct pcap_interfaces *map, char *i
   int idx;
 
   for (idx = 0; idx < map->num; idx++) {
-    if (!strncmp(map->list[idx].ifname, ifname, strlen(ifname))) {
+    if (strlen(map->list[idx].ifname) == strlen(ifname) && !strncmp(map->list[idx].ifname, ifname, strlen(ifname))) {
       ifindex = map->list[idx].ifindex;
       break;
     }
@@ -3761,7 +3761,7 @@ struct pcap_interface *pcap_interfaces_map_getentry_by_ifname(struct pcap_interf
   int idx;
 
   for (idx = 0; idx < map->num; idx++) {
-    if (!strncmp(map->list[idx].ifname, ifname, strlen(ifname))) {
+    if (strlen(map->list[idx].ifname) == strlen(ifname) && !strncmp(map->list[idx].ifname, ifname, strlen(ifname))) {
       return &map->list[idx];
     }
   }


### PR DESCRIPTION
So `eth1` and `eth10` are not mixed up anymore :+1: 
It was mostly an issue when the map was reloaded, as it made libpcap re-registering the same interface.