### PR TITLE
Decode arista iface out of sflow trailer data

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1686,6 +1686,11 @@ DESC:		When IP prefix aggregation (ie. nfacctd_net) is set to 'netflow', 'sflow'
 		from NetFlow/sFlow IP next hop field if BGP next-hop is not available.
 DEFAULT:        false
 
+KEY:            [ decode_arista_trailer ] [GLOBAL]
+VALUES:         [ true | false ]
+DESC:           Decode output interfaces data present on trailer of arista sflow packets.
+DEFAULT:        false
+
 KEY:		[ nfacctd_mcast_groups | sfacctd_mcast_groups ] [GLOBAL, NO_PMACCTD, NO_UACCTD]
 DESC:		Defines one or more IPv4/IPv6 multicast groups to be joined by the daemon. If more groups are
 		supplied, they are expected comma separated. A maximum of 20 multicast groups may be joined by

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -533,6 +533,7 @@ struct configuration {
   int uacctd_threshold;
   char *tunnel0;
   int use_ip_next_hop;
+  int decode_arista_trailer;
   int dump_max_writers;
   int tmp_asa_bi_flow;
   size_t thread_stack;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -175,6 +175,20 @@ int cfg_key_use_ip_next_hop(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_decode_arista_trailer(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  for (; list; list = list->next, changes++) list->cfg.decode_arista_trailer = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'decode_arista_trailer'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_aggregate(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -50,6 +50,7 @@ EXT int cfg_key_pcap_direction(char *, char *, char *);
 EXT int cfg_key_pcap_ifindex(char *, char *, char *);
 EXT int cfg_key_pcap_interfaces_map(char *, char *, char *);
 EXT int cfg_key_use_ip_next_hop(char *, char *, char *);
+EXT int cfg_key_decode_arista_trailer(char *, char *, char *);
 EXT int cfg_key_thread_stack(char *, char *, char *);
 EXT int cfg_key_pcap_interface(char *, char *, char *);
 EXT int cfg_key_pcap_interface_wait(char *, char *, char *);

--- a/src/nl.c
+++ b/src/nl.c
@@ -46,6 +46,8 @@ void pcap_cb(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char *buf)
   struct pcap_callback_data *cb_data = (struct pcap_callback_data *) user;
   struct pcap_device *device = cb_data->device;
   struct plugin_requests req;
+  u_int32_t iface32 = 0;
+  u_int32_t ifacePresent = 0;
 
   /* We process the packet with the appropriate
      data link layer function */
@@ -108,6 +110,14 @@ void pcap_cb(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char *buf)
       pptrs.ifindex_out = cb_data->device->id;
     }
     else pptrs.ifindex_out = 0;
+
+    if (config.decode_arista_trailer) {
+      memcpy(&ifacePresent, buf + pkthdr->len - 8, 4);
+        if (ifacePresent == 1) {
+          memcpy(&iface32, buf + pkthdr->len - 4, 4);
+          pptrs.ifindex_out = iface32;
+        }
+    }
 
     (*device->data->handler)(pkthdr, &pptrs);
     if (pptrs.iph_ptr) {

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -336,6 +336,7 @@ static const struct _dictionary_line dictionary[] = {
   {"pmacctd_net", cfg_key_nfacctd_net},
   {"uacctd_net", cfg_key_nfacctd_net},
   {"use_ip_next_hop", cfg_key_use_ip_next_hop},
+  {"decode_arista_trailer", cfg_key_decode_arista_trailer},
   {"thread_stack", cfg_key_thread_stack},
   {"plugins", NULL},
   {"plugin_pipe_size", cfg_key_plugin_pipe_size},


### PR DESCRIPTION
New option to decode the output interface data that's present in the trailer of the packets on arista switches 