### PR TITLE
ADD-PATH capability exchange fix for MP-BGP OPEN

### DIFF
--- a/src/bgp/bgp_msg.c
+++ b/src/bgp/bgp_msg.c
@@ -289,23 +289,37 @@ int bgp_parse_open_msg(struct bgp_msg_data *bmd, char *bgp_packet_ptr, time_t no
 		char *cap_ptr = optcap_ptr+2;
 		struct capability_add_paths cap_data;
 
-		memcpy(&cap_data, cap_ptr, sizeof(cap_data));
-
-		if (online) {
-                  bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
-		  Log(LOG_INFO, "INFO ( %s/%s ): [%s] Capability: ADD-PATHs [%x] AFI [%x] SAFI [%x] SEND_RECEIVE [%x]\n",
-			config.name, bms->log_str, bgp_peer_str, cap_type, ntohs(cap_data.afi), cap_data.safi,
-			cap_data.sndrcv);
-		}
-
-		if ((cap_data.sndrcv == 2 /* send */) || (cap_data.sndrcv == 3 /* send and receive */)) {
-		  peer->cap_add_paths = TRUE; 
-		  if (online) {
-		    memcpy(bgp_open_cap_reply_ptr, optcap_ptr, cap_len+2);
-		    *(bgp_open_cap_reply_ptr+((cap_len+2)-1)) = 1; /* receive */
-		    bgp_open_cap_reply_ptr += cap_len+2;
-		  }
-		}
+		int cap_set = 0;          /* we only answer to ADD_PATHs sends from peers with receive */
+		u_int8_t *cap_newlen_ptr; /* ptr to field of outbound cap_len */
+		int cap_idx;
+		
+		/* check for each AFI.SAFI included if remote can send - only then reply with receive */
+		for (cap_idx = 0; cap_idx<cap_len; cap_idx += sizeof(struct capability_add_paths)) {
+			memcpy(&cap_data, cap_ptr+cap_idx, sizeof(cap_data));
+			if (online) {
+				bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
+				Log(LOG_INFO, "INFO ( %s/%s ): [%s] Capability: ADD-PATHs [%x] AFI [%x] SAFI [%x] SEND_RECEIVE [%x]\n",
+					config.name, bms->log_str, bgp_peer_str, cap_type, ntohs(cap_data.afi), cap_data.safi,
+					cap_data.sndrcv);
+			}
+			if ((cap_data.sndrcv == 2 /* send */) || (cap_data.sndrcv == 3 /* send and receive */)) {
+				peer->cap_add_paths = TRUE; 
+				if (online) {
+					if (!cap_set) {
+						/* we need to "send" BGP_CAPABILITY_ADD_PATHS first */
+						cap_set = 1;
+						memcpy(bgp_open_cap_reply_ptr, optcap_ptr, 2);
+						cap_newlen_ptr = bgp_open_cap_reply_ptr+1;
+						*cap_newlen_ptr = 0;
+						bgp_open_cap_reply_ptr += 2;
+					}
+					cap_data.sndrcv = 1; /* we can receive */
+					*cap_newlen_ptr = *cap_newlen_ptr + sizeof(cap_data);
+					memcpy(bgp_open_cap_reply_ptr, &cap_data, sizeof(cap_data));
+					bgp_open_cap_reply_ptr += sizeof(cap_data);
+				}
+			}
+	      	 }
 	      }
 
 	      optcap_ptr += cap_len+2;


### PR DESCRIPTION
PMACCTs handled/handles replies to MP-BGP ADD-PATHs incorrectly. It checks only first AFI.SAFI and sets in the reply for last AFI.SAFI RECEIVE(1) if first included SEND(2) or SEND-RECEIVE(3).

Example: Peer with SEND capability for inet unicast (1.1) and inet6 unicast (2.1) sends:
        Optional Parameter: Capability
            Parameter Type: Capability (2)
            Parameter Length: 10
            Capability: Support for Additional Paths
                Type: Support for Additional Paths (69)
                Length: 8
                AFI: IPv4 (1)
                SAFI: Unicast (1)
                Send/Receive: Send (2)
                AFI: IPv6 (2)
                SAFI: Unicast (1)
                Send/Receive: Send (2)
Reply was/is from bgp_msg:
        Optional Parameter: Capability
            Parameter Type: Capability (2)
            Parameter Length: 10
            Capability: Support for Additional Paths
                Type: Support for Additional Paths (69)
                Length: 8
                AFI: IPv4 (1)
                SAFI: Unicast (1)
                Send/Receive: Send (2)
                AFI: IPv6 (2)
                SAFI: Unicast (1)
                Send/Receive: Receive (1)

This patch hopefully fixes it (not too much testing done ...). It checks each AFI.SAFI included in the capability signaled from the peer and only replies with RECEIVE for AFI.SAFI if peer said SEND or SEND-RECEIVE for it.

(Sorry, pasted into http:// from my source ... pull, push ... sigh).