### PR TITLE
pmacctd: add option 'gre_decap' for IPv4/GRE decapsulation of captured packets

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -161,6 +161,13 @@ DESC:		If set, specifies a specific packet socket protocol value to limit packet
 		against a version of libpcap that supports pcap_set_protocol().
 DEFAULT:	none
 
+KEY:		decap_gre [GLOBAL, PMACCTD_ONLY]
+VALUES:		[ true | false ]
+DESC:		If set, makes the daemon decapsulate GRE-tunneled traffic.
+			Packets that are not encapsulated in an IPv4/GRE tunnel are processed as usual.
+			This option only applies to pmacctd.
+DEFAULT:	false
+
 KEY:		snaplen (-L) [GLOBAL, NO_NFACCTD, NO_SFACCTD]
 DESC:		Specifies the maximum number of bytes to capture for each packet. This directive has
 		key importance to both classification and connection tracking engines. In fact, some

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -459,6 +459,7 @@ struct configuration {
   int pcap_sf_wait;
   int pcap_sf_delay;
   int pcap_sf_replay;
+  int gre_decap;
   int num_memory_pools;
   int memory_pool_size;
   int buckets;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -548,6 +548,20 @@ int cfg_key_pcap_interface(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_gre_decap(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  for (; list; list = list->next, changes++) list->cfg.gre_decap = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'gre_decap'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_files_umask(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -57,6 +57,7 @@ EXT int cfg_key_decode_arista_trailer(char *, char *, char *);
 EXT int cfg_key_thread_stack(char *, char *, char *);
 EXT int cfg_key_pcap_interface(char *, char *, char *);
 EXT int cfg_key_pcap_interface_wait(char *, char *, char *);
+EXT int cfg_key_gre_decap(char *, char *, char *);
 EXT int cfg_key_files_umask(char *, char *, char *);
 EXT int cfg_key_files_uid(char *, char *, char *);
 EXT int cfg_key_files_gid(char *, char *, char *);

--- a/src/network.h
+++ b/src/network.h
@@ -54,6 +54,8 @@
 #define AF_PLABEL		255
 #endif
 #define PRIMPTRS_FUNCS_N	16
+#define GRE_HDRLEN          4
+#define IP_HDRLEN           20
 
 /* 10Mb/s ethernet header */
 struct eth_header

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -351,6 +351,7 @@ static const struct _dictionary_line dictionary[] = {
   {"plugin_pipe_zmq_hwm", cfg_key_plugin_pipe_zmq_hwm},
   {"interface", cfg_key_pcap_interface}, 		/* Legacy key */
   {"interface_wait", cfg_key_pcap_interface_wait},	/* Legacy key */
+  {"gre_decap", cfg_key_gre_decap},
   {"files_umask", cfg_key_files_umask},
   {"files_uid", cfg_key_files_uid},
   {"files_gid", cfg_key_files_gid},

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -408,6 +408,7 @@ EXT int gtp_tunnel_func(register struct packet_ptrs *);
 EXT int gtp_tunnel_configurator(struct tunnel_handler *, char *);
 EXT void tunnel_registry_init();
 EXT void pcap_cb(u_char *, const struct pcap_pkthdr *, const u_char *);
+EXT void gre_decap_cb(u_char *, const struct pcap_pkthdr *, const u_char *);
 EXT int PM_find_id(struct id_table *, struct packet_ptrs *, pm_id_t *, pm_id_t *);
 EXT void compute_once();
 EXT void reset_index_pkt_ptrs(struct packet_ptrs *);

--- a/src/pmacctd.c
+++ b/src/pmacctd.c
@@ -1134,6 +1134,13 @@ int main(int argc,char **argv, char **envp)
     else sleep(config.pcap_sf_delay);
   }
 
+  /* GRE decapsulation */
+  pcap_handler pcap_cb0 = pcap_cb;
+  if (config.gre_decap) {
+    Log(LOG_INFO, "INFO ( %s/core ): will decapsulate IPV4/GRE\n", config.name);
+    pcap_cb0 = gre_decap_cb;
+  }
+
   /* Main loop (for the case of a single interface): if pcap_loop() exits
      maybe an error occurred; we will try closing and reopening again our
      listening device */
@@ -1148,8 +1155,8 @@ int main(int argc,char **argv, char **envp)
 	}
       }
 
-      read_packet:
-      pcap_loop(device.list[0].dev_desc, -1, pcap_cb, (u_char *) &cb_data);
+	read_packet:
+      pcap_loop(device.list[0].dev_desc, -1, pcap_cb0, (u_char *) &cb_data);
       pcap_close(device.list[0].dev_desc);
 
       if (config.pcap_savefile) {
@@ -1259,7 +1266,7 @@ int main(int argc,char **argv, char **envp)
 	pkt_body = pcap_next(dev_ptr->dev_desc, &pkt_hdr); 
 	if (pkt_body) {
 	  cb_data.device = dev_ptr;
-	  pcap_cb((u_char *) &cb_data, &pkt_hdr, pkt_body);
+	  pcap_cb0((u_char *) &cb_data, &pkt_hdr, pkt_body);
 	}
       }
     }


### PR DESCRIPTION
Hi there, 
I propose this option that enables accounting of packets inside a GRE tunnel
---
If set, makes the daemon decapsulate GRE-tunneled traffic.
Packets that are not encapsulated in an IPv4/GRE tunnel are processed as usual.
---