### PR TITLE
Fix type mismatches in format strings

### DIFF
--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -656,9 +656,9 @@ void skinny_bgp_daemon_online()
 		bgp_peer_close(&peers[peers_check_idx], FUNC_TYPE_BGP, FALSE, FALSE, FALSE, FALSE, NULL);
 	      }
 	      else {
-		Log(LOG_WARNING, "WARN ( %s/%s ): [%s] Refusing new connection from existing peer (residual holdtime: %u).\n",
+		Log(LOG_WARNING, "WARN ( %s/%s ): [%s] Refusing new connection from existing peer (residual holdtime: %ld).\n",
 			config.name, bgp_misc_db->log_str, bgp_peer_str,
-			(peers[peers_check_idx].ht - (now - peers[peers_check_idx].last_keepalive)));
+			(peers[peers_check_idx].ht - ((long)now - peers[peers_check_idx].last_keepalive)));
 		FD_CLR(peer->fd, &bkp_read_descs);
 		bgp_peer_close(peer, FUNC_TYPE_BGP, FALSE, FALSE, FALSE, FALSE, NULL);
 		goto read_data;

--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -767,7 +767,8 @@ void bgp_handle_dump_event()
 	    peer->log->fd = open_output_file(current_filename, "w", TRUE);
 	    if (fd_buf) {
 	      if (setvbuf(peer->log->fd, fd_buf, _IOFBF, OUTPUT_FILE_BUFSZ))
-		Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, bms->log_str, current_filename, errno);
+		Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n",
+		    config.name, bms->log_str, current_filename, strerror(errno));
 	      else memset(fd_buf, 0, OUTPUT_FILE_BUFSZ); 
 	    }
 	  }

--- a/src/bgp/bgp_msg.c
+++ b/src/bgp/bgp_msg.c
@@ -133,7 +133,7 @@ int bgp_parse_msg(struct bgp_peer *peer, time_t now, int online)
       ret = bgp_parse_update_msg(&bmd, bgp_packet_ptr);
       if (ret < 0) {
         bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
-	Log(LOG_WARNING, "WARN ( %s/%s ): [%s] BGP UPDATE: malformed (%d).\n", config.name, bms->log_str, bgp_peer_str);
+	Log(LOG_WARNING, "WARN ( %s/%s ): [%s] BGP UPDATE: malformed.\n", config.name, bms->log_str, bgp_peer_str);
 	return BGP_NOTIFY_UPDATE_ERR;
       }
 

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -522,7 +522,7 @@ void bmp_handle_dump_event()
             peer->log->fd = open_output_file(current_filename, "w", TRUE);
             if (fd_buf) {
               if (setvbuf(peer->log->fd, fd_buf, _IOFBF, OUTPUT_FILE_BUFSZ))
-		Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, bms->log_str, current_filename, errno);
+		Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, bms->log_str, current_filename, strerror(errno));
               else memset(fd_buf, 0, OUTPUT_FILE_BUFSZ);
             }
           }

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -1025,7 +1025,7 @@ int cfg_key_print_latest_file(char *filename, char *name, char *value_ptr)
   int changes = 0;
 
   if (strchr(value_ptr, '%')) {
-    Log(LOG_ERR, "ERROR: [%s] invalid 'print_latest_file' value: time-based '%' variables not allowed.\n", filename);
+    Log(LOG_ERR, "ERROR: [%s] invalid 'print_latest_file' value: time-based '%%' variables not allowed.\n", filename);
     return TRUE;
   }
 
@@ -6011,7 +6011,7 @@ void cfg_set_aggregate(char *filename, u_int64_t registry[], u_int64_t input, ch
   u_int64_t value = (input & COUNT_REGISTRY_MASK);
 
   if (registry[index] & value) {
-    Log(LOG_ERR, "ERROR: [%s] '%s' repeated in 'aggregate' or invalid 0x%x bit code.\n", filename, token, input);
+    Log(LOG_ERR, "ERROR: [%s] '%s' repeated in 'aggregate' or invalid 0x%llx bit code.\n", filename, token, (unsigned long long)input);
     exit(1);
   }
   else registry[index] |= value;

--- a/src/imt_plugin.c
+++ b/src/imt_plugin.c
@@ -134,7 +134,7 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   if (!config.memory_pool_size) config.memory_pool_size = MEMORY_POOL_SIZE;  
   else {
     if (config.memory_pool_size < sizeof(struct acc)) {
-      Log(LOG_WARNING, "WARN ( %s/%s ): enforcing memory pool's minimum size, %d bytes.\n", config.name, config.type, sizeof(struct acc));
+      Log(LOG_WARNING, "WARN ( %s/%s ): enforcing memory pool's minimum size, %d bytes.\n", config.name, config.type, (int)sizeof(struct acc));
       config.memory_pool_size = MEMORY_POOL_SIZE;
     }
   }

--- a/src/log.h
+++ b/src/log.h
@@ -72,7 +72,11 @@ struct _log_notifications {
 #else
 #define EXT
 #endif
-EXT void Log(short int, char *, ...);
+EXT void Log(short int, char *, ...)
+#ifdef __GNUC__
+  __attribute__((format(printf, 2, 3)))
+#endif
+  ;
 EXT int parse_log_facility(const char *);
 EXT void log_notification_init(struct log_notification *);
 EXT void log_notifications_init(struct _log_notifications *);

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -2549,7 +2549,7 @@ void notify_malf_packet(short int severity, char *severity_str, char *ostr, stru
 		severity_str, config.name, ostr, ((config.nfacctd_ip) ? config.nfacctd_ip : any),
 		config.nfacctd_port, agent_addr, agent_port);
 
-  Log(severity, errstr);
+  Log(severity, "%s", errstr);
 }
 
 int NF_find_id(struct id_table *t, struct packet_ptrs *pptrs, pm_id_t *tag, pm_id_t *tag2)

--- a/src/nl.c
+++ b/src/nl.c
@@ -462,14 +462,14 @@ void PM_print_stats(time_t now)
   if (config.pcap_if || config.pcap_interfaces_map) {
     for (device_idx = 0; device_idx < devices.num; device_idx++) {
       if (pcap_stats(devices.list[device_idx].dev_desc, &ps) < 0) {
-	Log(LOG_INFO, "INFO ( %s/%s ): stats [%s,%u] time=%u error='pcap_stats(): %s'\n",
+	Log(LOG_INFO, "INFO ( %s/%s ): stats [%s,%u] time=%ld error='pcap_stats(): %s'\n",
 	    config.name, config.type, devices.list[device_idx].str, devices.list[device_idx].id,
-	    now, pcap_geterr(devices.list[device_idx].dev_desc));
+	    (long)now, pcap_geterr(devices.list[device_idx].dev_desc));
       }
 
-      Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s,%u] time=%u received_packets=%u dropped_packets=%u\n",
+      Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s,%u] time=%ld received_packets=%u dropped_packets=%u\n",
 	  config.name, config.type, devices.list[device_idx].str, devices.list[device_idx].id,
-	  now, ps.ps_recv, ps.ps_drop);
+	  (long)now, ps.ps_recv, ps.ps_drop);
     }
   }
 

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -86,7 +86,7 @@ void P_init_default_values()
   sa.num = config.print_cache_entries*AVERAGE_CHAIN_LEN;
   sa.size = sa.num*dbc_size;
 
-  Log(LOG_INFO, "INFO ( %s/%s ): cache entries=%llu base cache memory=%llu bytes\n", config.name, config.type,
+  Log(LOG_INFO, "INFO ( %s/%s ): cache entries=%d base cache memory=%llu bytes\n", config.name, config.type,
 	config.print_cache_entries, ((config.print_cache_entries * dbc_size) + (2 * ((sa.num +
 	config.print_cache_entries) * sizeof(struct chained_cache *))) + sa.size));
 

--- a/src/plugin_hooks.c
+++ b/src/plugin_hooks.c
@@ -127,8 +127,9 @@ void load_plugins(struct plugin_requests *req)
 
         buf_pipe_ratio_sz = (list->cfg.pipe_size/list->cfg.buffer_size)*sizeof(char *);
         if (buf_pipe_ratio_sz > INT_MAX) {
-	  Log(LOG_ERR, "ERROR ( %s/%s ): Current plugin_buffer_size elems per plugin_pipe_size: %d. Max: %d.\nExiting.\n",
-		list->name, list->type.string, (list->cfg.pipe_size/list->cfg.buffer_size), (INT_MAX/sizeof(char *)));
+	  Log(LOG_ERR, "ERROR ( %s/%s ): Current plugin_buffer_size elems per plugin_pipe_size: %llu. Max: %d.\nExiting.\n",
+		list->name, list->type.string, (unsigned long long)(list->cfg.pipe_size/list->cfg.buffer_size),
+		(INT_MAX/(int)sizeof(char *)));
           exit_gracefully(1);
         }
         else target_buflen = buf_pipe_ratio_sz;

--- a/src/pmacct.c
+++ b/src/pmacct.c
@@ -1507,7 +1507,7 @@ int main(int argc,char **argv)
           request.data.cos = atoi(match_string_token);
         }
         else if (!strcmp(count_token[match_string_index], "etype")) {
-	  sscanf(match_string_token, "%x", &request.data.etype);
+	  sscanf(match_string_token, "%hx", &request.data.etype);
         }
 #endif
 
@@ -2805,7 +2805,7 @@ int main(int argc,char **argv)
 
     if (unpacked == (sizeof(struct query_header) + sizeof(struct timeval))) {
       memcpy(&table_reset_stamp, (largebuf + sizeof(struct query_header)), sizeof(struct timeval));
-      if (table_reset_stamp.tv_sec) printf("%u\n", cycle_stamp.tv_sec - table_reset_stamp.tv_sec);
+      if (table_reset_stamp.tv_sec) printf("%ld\n", (long)(cycle_stamp.tv_sec - table_reset_stamp.tv_sec));
       else printf("never\n");
     }
   }
@@ -2871,10 +2871,10 @@ int main(int argc,char **argv)
 	/* print flows */
 	else if (which_counter == 3) printf("%llu\n", acc_elem->flo_num);
 #else
-        if (which_counter == 0) printf("%lu\n", acc_elem->pkt_len); 
-        else if (which_counter == 1) printf("%lu\n", acc_elem->pkt_num); 
-        else if (which_counter == 2) printf("%lu %lu %lu %lu\n", acc_elem->pkt_num, acc_elem->pkt_len, acc_elem->flo_num, acc_elem->time_start.tv_sec); 
-        else if (which_counter == 3) printf("%lu\n", acc_elem->flo_num); 
+        if (which_counter == 0) printf("%u\n", acc_elem->pkt_len); 
+        else if (which_counter == 1) printf("%u\n", acc_elem->pkt_num); 
+        else if (which_counter == 2) printf("%u %u %u %lu\n", acc_elem->pkt_num, acc_elem->pkt_len, acc_elem->flo_num, acc_elem->time_start.tv_sec); 
+        else if (which_counter == 3) printf("%u\n", acc_elem->flo_num); 
 #endif
       }
     }
@@ -2886,10 +2886,10 @@ int main(int argc,char **argv)
       else if (which_counter == 2) printf("%llu %llu %llu %u\n", pcnt, bcnt, fcnt, num_counters); /* print packets+bytes+flows+num */
       else if (which_counter == 3) printf("%llu\n", fcnt); /* print flows */
 #else
-      if (which_counter == 0) printf("%lu\n", bcnt); 
-      else if (which_counter == 1) printf("%lu\n", pcnt); 
-      else if (which_counter == 2) printf("%lu %lu %lu %u\n", pcnt, bcnt, fcnt, num_counters); 
-      else if (which_counter == 3) printf("%lu\n", fcnt); 
+      if (which_counter == 0) printf("%u\n", bcnt); 
+      else if (which_counter == 1) printf("%u\n", pcnt); 
+      else if (which_counter == 2) printf("%u %u %u %u\n", pcnt, bcnt, fcnt, num_counters); 
+      else if (which_counter == 3) printf("%u\n", fcnt); 
 #endif
     }
   }
@@ -2993,14 +2993,14 @@ int Recv(int sd, unsigned char **buf)
 int check_data_sizes(struct query_header *qh, struct pkt_data *acc_elem)
 {
   if (qh->cnt_sz != sizeof(acc_elem->pkt_len)) {
-    printf("ERROR: Counter sizes mismatch: daemon: %d  client: %d\n", qh->cnt_sz*8, sizeof(acc_elem->pkt_len)*8);
+    printf("ERROR: Counter sizes mismatch: daemon: %d  client: %d\n", qh->cnt_sz*8, (int)sizeof(acc_elem->pkt_len)*8);
     printf("ERROR: It's very likely that a 64bit package has been mixed with a 32bit one.\n\n");
     printf("ERROR: Please fix the issue before trying again.\n");
     return (qh->cnt_sz-sizeof(acc_elem->pkt_len));
   }
 
   if (qh->ip_sz != sizeof(acc_elem->primitives.src_ip)) {
-    printf("ERROR: IP address sizes mismatch. daemon: %d  client: %d\n", qh->ip_sz, sizeof(acc_elem->primitives.src_ip));
+    printf("ERROR: IP address sizes mismatch. daemon: %d  client: %d\n", qh->ip_sz, (int)sizeof(acc_elem->primitives.src_ip));
     printf("ERROR: It's very likely that an IPv6-enabled package has been mixed with a IPv4-only one.\n\n");
     printf("ERROR: Please fix the issue before trying again.\n");
     return (qh->ip_sz-sizeof(acc_elem->primitives.src_ip));
@@ -3682,7 +3682,7 @@ void pmc_compose_timestamp(char *buf, int buflen, struct timeval *tv, int usec, 
   struct tm *time2;
 
   if (tstamp_since_epoch) {
-    if (usec) snprintf(buf, buflen, "%ld.%.6ld", tv->tv_sec, tv->tv_usec);
+    if (usec) snprintf(buf, buflen, "%ld.%.6ld", tv->tv_sec, (long)tv->tv_usec);
     else snprintf(buf, buflen, "%ld", tv->tv_sec);
   }
   else {
@@ -3692,7 +3692,7 @@ void pmc_compose_timestamp(char *buf, int buflen, struct timeval *tv, int usec, 
 
     slen = strftime(buf, buflen, "%Y-%m-%dT%H:%M:%S", time2);
 
-    if (usec) snprintf((buf + slen), (buflen - slen), ".%.6ld", tv->tv_usec);
+    if (usec) snprintf((buf + slen), (buflen - slen), ".%.6ld", (long)tv->tv_usec);
     pmc_append_rfc3339_timezone(buf, buflen, time2);
   }
 }
@@ -3707,7 +3707,7 @@ void pmc_custom_primitive_header_print(char *out, int outlen, struct imt_custom_
     if (cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_UINT ||
         cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_HEX) {
       if (formatted) {
-	snprintf(format, SRVBUFLEN, "%%-%u", cps_flen[cp_entry->len] > strlen(cp_entry->name) ? cps_flen[cp_entry->len] : strlen(cp_entry->name));
+	snprintf(format, SRVBUFLEN, "%%-%d", cps_flen[cp_entry->len] > strlen(cp_entry->name) ? cps_flen[cp_entry->len] : (int)strlen(cp_entry->name));
 	strncat(format, "s", SRVBUFLEN);
       }
       else snprintf(format, SRVBUFLEN, "%s", "%s");
@@ -3715,7 +3715,7 @@ void pmc_custom_primitive_header_print(char *out, int outlen, struct imt_custom_
     else if (cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_STRING ||
 	     cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_RAW) {
       if (formatted) {
-	snprintf(format, SRVBUFLEN, "%%-%u", cp_entry->len > strlen(cp_entry->name) ? cp_entry->len : strlen(cp_entry->name));
+	snprintf(format, SRVBUFLEN, "%%-%d", cp_entry->len > strlen(cp_entry->name) ? cp_entry->len : (int)strlen(cp_entry->name));
 	strncat(format, "s", SRVBUFLEN);
       }
       else snprintf(format, SRVBUFLEN, "%s", "%s");
@@ -3726,7 +3726,7 @@ void pmc_custom_primitive_header_print(char *out, int outlen, struct imt_custom_
       len = INET6_ADDRSTRLEN;
       	
       if (formatted) {
-        snprintf(format, SRVBUFLEN, "%%-%u", len > strlen(cp_entry->name) ? len : strlen(cp_entry->name));
+        snprintf(format, SRVBUFLEN, "%%-%d", len > strlen(cp_entry->name) ? len : (int)strlen(cp_entry->name));
         strncat(format, "s", SRVBUFLEN);
       }
       else snprintf(format, SRVBUFLEN, "%s", "%s");
@@ -3735,7 +3735,7 @@ void pmc_custom_primitive_header_print(char *out, int outlen, struct imt_custom_
       int len = ETHER_ADDRSTRLEN;
 
       if (formatted) {
-        snprintf(format, SRVBUFLEN, "%%-%u", len > strlen(cp_entry->name) ? len : strlen(cp_entry->name));
+        snprintf(format, SRVBUFLEN, "%%-%d", len > strlen(cp_entry->name) ? len : (int)strlen(cp_entry->name));
         strncat(format, "s", SRVBUFLEN);
       }
       else snprintf(format, SRVBUFLEN, "%s", "%s");
@@ -3755,7 +3755,7 @@ void pmc_custom_primitive_value_print(char *out, int outlen, char *in, struct im
     if (cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_UINT ||
 	cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_HEX) {
       if (formatted)
-        snprintf(format, SRVBUFLEN, "%%-%u%s", cps_flen[cp_entry->len] > strlen(cp_entry->name) ? cps_flen[cp_entry->len] : strlen(cp_entry->name), 
+        snprintf(format, SRVBUFLEN, "%%-%d%s", cps_flen[cp_entry->len] > strlen(cp_entry->name) ? cps_flen[cp_entry->len] : (int)strlen(cp_entry->name), 
 			cps_type[cp_entry->semantics]); 
       else
         snprintf(format, SRVBUFLEN, "%%%s", cps_type[cp_entry->semantics]); 
@@ -3791,7 +3791,7 @@ void pmc_custom_primitive_value_print(char *out, int outlen, char *in, struct im
     else if (cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_STRING ||
 	     cp_entry->semantics == CUSTOM_PRIMITIVE_TYPE_RAW) {
       if (formatted)
-	snprintf(format, SRVBUFLEN, "%%-%u%s", cp_entry->len > strlen(cp_entry->name) ? cp_entry->len : strlen(cp_entry->name),
+	snprintf(format, SRVBUFLEN, "%%-%d%s", cp_entry->len > strlen(cp_entry->name) ? cp_entry->len : (int)strlen(cp_entry->name),
 			cps_type[cp_entry->semantics]); 
       else
 	snprintf(format, SRVBUFLEN, "%%%s", cps_type[cp_entry->semantics]); 
@@ -3819,7 +3819,7 @@ void pmc_custom_primitive_value_print(char *out, int outlen, char *in, struct im
 
       addr_to_str(ip_str, &ip_addr);
       if (formatted)
-        snprintf(format, SRVBUFLEN, "%%-%u%s", len > strlen(cp_entry->name) ? len : strlen(cp_entry->name),
+        snprintf(format, SRVBUFLEN, "%%-%d%s", len > strlen(cp_entry->name) ? len : (int)strlen(cp_entry->name),
                         cps_type[cp_entry->semantics]);
       else
         snprintf(format, SRVBUFLEN, "%%%s", cps_type[cp_entry->semantics]);
@@ -3834,7 +3834,7 @@ void pmc_custom_primitive_value_print(char *out, int outlen, char *in, struct im
       etheraddr_string(in+cp_entry->off, eth_str);
 
       if (formatted)
-        snprintf(format, SRVBUFLEN, "%%-%u%s", len > strlen(cp_entry->name) ? len : strlen(cp_entry->name),
+        snprintf(format, SRVBUFLEN, "%%-%d%s", len > strlen(cp_entry->name) ? len : (int)strlen(cp_entry->name),
                         cps_type[cp_entry->semantics]);
       else
         snprintf(format, SRVBUFLEN, "%%%s", cps_type[cp_entry->semantics]);

--- a/src/pretag.c
+++ b/src/pretag.c
@@ -243,7 +243,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                   }
                   if (err) {
                     if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
-						config.name, config.type, filename, tot_lines, filename, key);
+						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
                   }

--- a/src/pretag.c
+++ b/src/pretag.c
@@ -1089,7 +1089,7 @@ void pretag_index_report(struct id_table *t)
 	  config.name, config.type, t->filename, (unsigned long long)t->index[iterator].bitmap,
 	  bucket_depths[0], bucket_depths[1], bucket_depths[2], bucket_depths[3],
 	  bucket_depths[4], bucket_depths[5], bucket_depths[6], bucket_depths[7],
-	  (buckets * sizeof(struct id_index_entry)));
+	  (unsigned long)(buckets * sizeof(struct id_index_entry)));
     } 
   }
 }

--- a/src/pretag.c
+++ b/src/pretag.c
@@ -936,8 +936,8 @@ int pretag_index_set_handlers(struct id_table *t)
     }
 
     if (residual_idx_bmap) {
-      Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: not supported for field(s) %x. Indexing disabled.\n",
-		config.name, config.type, t->filename, residual_idx_bmap);
+      Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: not supported for field(s) %llx. Indexing disabled.\n",
+		config.name, config.type, t->filename, (unsigned long long)residual_idx_bmap);
       pretag_index_destroy(t);
     }
   }
@@ -955,16 +955,16 @@ int pretag_index_allocate(struct id_table *t)
 
   for (iterator = 0; iterator < t->index_num; iterator++) {
     if (t->index[iterator].entries) {
-      Log(LOG_INFO, "INFO ( %s/%s ): [%s] maps_index: created index %x (%u entries).\n", config.name,
-    		config.type, t->filename, t->index[iterator].bitmap, t->index[iterator].entries);
+      Log(LOG_INFO, "INFO ( %s/%s ): [%s] maps_index: created index %llx (%u entries).\n", config.name,
+    		config.type, t->filename, (unsigned long long)t->index[iterator].bitmap, t->index[iterator].entries);
 
       assert(!t->index[iterator].idx_t);
       idx_t_size = IDT_INDEX_HASH_BASE(t->index[iterator].entries) * sizeof(struct id_index_entry);
       t->index[iterator].idx_t = malloc(idx_t_size);
 
       if (!t->index[iterator].idx_t) {
-        Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: unable to allocate index %x.\n", config.name,
-		config.type, t->filename, t->index[iterator].bitmap);
+        Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: unable to allocate index %llx.\n", config.name,
+		config.type, t->filename, (unsigned long long)t->index[iterator].bitmap);
 	t->index[iterator].bitmap = 0;
 	t->index[iterator].entries = 0;
 	destroy = TRUE;
@@ -979,8 +979,8 @@ int pretag_index_allocate(struct id_table *t)
 
 	ret = hash_init_serial(&t->index[iterator].hash_serializer, 16 /* dummy len for init sake */);
 	if (ret == ERR) {
-	  Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: unable to allocate hash serializer for index %x.\n", config.name,
-		config.type, t->filename, t->index[iterator].bitmap);
+	  Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: unable to allocate hash serializer for index %llx.\n", config.name,
+		config.type, t->filename, (unsigned long long)t->index[iterator].bitmap);
 	  destroy = TRUE;
 	  break;
 	}
@@ -1052,8 +1052,8 @@ int pretag_index_fill(struct id_table *t, pt_bitmap_t idx_bmap, struct id_entry 
       }
 
       if (index == idie->depth) {
-        Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: out of index space %x. Indexing disabled.\n",
-		config.name, config.type, t->filename, idx_bmap);
+        Log(LOG_WARNING, "WARN ( %s/%s ): [%s] maps_index: out of index space %llx. Indexing disabled.\n",
+		config.name, config.type, t->filename, (unsigned long long)idx_bmap);
 	pretag_index_destroy(t);
 	break;
       }
@@ -1085,8 +1085,8 @@ void pretag_index_report(struct id_table *t)
 	bucket_depths[depth]++;
       }
 
-      Log(LOG_DEBUG, "DEBUG ( %s/%s ): [%s] maps_index: index %x depths: 0:%u 1:%u 2:%u 3:%u 4:%u 5:%u 6:%u 7:%u size: %u\n",
-	  config.name, config.type, t->filename, t->index[iterator].bitmap,
+      Log(LOG_DEBUG, "DEBUG ( %s/%s ): [%s] maps_index: index %llx depths: 0:%u 1:%u 2:%u 3:%u 4:%u 5:%u 6:%u 7:%u size: %lu\n",
+	  config.name, config.type, t->filename, (unsigned long long)t->index[iterator].bitmap,
 	  bucket_depths[0], bucket_depths[1], bucket_depths[2], bucket_depths[3],
 	  bucket_depths[4], bucket_depths[5], bucket_depths[6], bucket_depths[7],
 	  (buckets * sizeof(struct id_index_entry)));
@@ -1113,8 +1113,8 @@ void pretag_index_destroy(struct id_table *t)
       }
 
       free(t->index[iterator].idx_t);
-      Log(LOG_INFO, "INFO ( %s/%s ): [%s] maps_index: destroyed index %x.\n",
-                config.name, config.type, t->filename, t->index[iterator].bitmap);
+      Log(LOG_INFO, "INFO ( %s/%s ): [%s] maps_index: destroyed index %llx.\n",
+                config.name, config.type, t->filename, (unsigned long long)t->index[iterator].bitmap);
     }
 
     hash_serializer = &t->index[iterator].hash_serializer;

--- a/src/pretag_handlers.c
+++ b/src/pretag_handlers.c
@@ -1335,7 +1335,7 @@ int PT_map_stack_handler(char *filename, struct id_entry *e, char *value, struct
 
   if (*value == '+' || !strncmp(value, "sum", 3)) e->stack.func = PT_stack_sum;
   else if (!strncmp(value, "or", 2)) e->stack.func = PT_stack_logical_or;
-  else Log(LOG_WARNING, "WARN ( %s/%s ): [%s] Unknown STACK operator: '%c'. Ignoring.\n", config.name, config.type, filename, value);
+  else Log(LOG_WARNING, "WARN ( %s/%s ): [%s] Unknown STACK operator: '%s'. Ignoring.\n", config.name, config.type, filename, value);
 
   return FALSE;
 }

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -1257,8 +1257,8 @@ void P_cache_purge(struct chained_cache *queue[], int index, int safe_action)
   /* If we have pending queries then start again */
   if (pqq_ptr) goto start;
 
-  Log(LOG_INFO, "INFO ( %s/%s ): *** Purging cache - END (PID: %u, QN: %u/%u, ET: %u) ***\n",
-		config.name, config.type, writer_pid, qn, saved_index, duration);
+  Log(LOG_INFO, "INFO ( %s/%s ): *** Purging cache - END (PID: %u, QN: %u/%u, ET: %lu) ***\n",
+		config.name, config.type, writer_pid, qn, saved_index, (long)duration);
 
   if (config.sql_trigger_exec && !safe_action) P_trigger_exec(config.sql_trigger_exec); 
 

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -438,7 +438,7 @@ void P_cache_purge(struct chained_cache *queue[], int index, int safe_action)
     if (f) {
       if (!(config.print_output & PRINT_OUTPUT_AVRO) && fd_buf) {
         if (setvbuf(f, fd_buf, _IOFBF, OUTPUT_FILE_BUFSZ))
-          Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, config.type, current_table, errno);
+          Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, config.type, current_table, strerror(errno));
         else memset(fd_buf, 0, OUTPUT_FILE_BUFSZ);
       }
 

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -1598,7 +1598,7 @@ void SF_notify_malf_packet(short int severity, char *severity_str, char *ostr, s
   snprintf(errstr, SRVBUFLEN, "%s ( %s/core ): %s: sfacctd=%s:%u agent=%s:%u \n", severity_str,
 	config.name, ostr, ((config.nfacctd_ip) ? config.nfacctd_ip : any), config.nfacctd_port,
 	agent_addr, agent_port);
-  Log(severity, errstr);
+  Log(severity, "%s", errstr);
 }
 
 void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct plugin_requests *req)

--- a/src/sflow.c
+++ b/src/sflow.c
@@ -432,7 +432,7 @@ u_int32_t getAddress(SFSample *sample, SFLAddress *address)
 
 char *printTag(u_int32_t tag, char *buf, int bufLen) {
   // should really be: snprintf(buf, buflen,...) but snprintf() is not always available
-  sprintf(buf, "%lu:%lu", (tag >> 12), (tag & 0x00000FFF));
+  sprintf(buf, "%lu:%lu", (unsigned long)(tag >> 12), (unsigned long)(tag & 0x00000FFF));
   return buf;
 }
 

--- a/src/telemetry/telemetry_logdump.c
+++ b/src/telemetry/telemetry_logdump.c
@@ -342,7 +342,7 @@ void telemetry_handle_dump_event(struct telemetry_data *t_data)
             peer->log->fd = open_output_file(current_filename, "w", TRUE);
             if (fd_buf) {
               if (setvbuf(peer->log->fd, fd_buf, _IOFBF, OUTPUT_FILE_BUFSZ))
-                Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, t_data->log_str, current_filename, errno);
+                Log(LOG_WARNING, "WARN ( %s/%s ): [%s] setvbuf() failed: %s\n", config.name, t_data->log_str, current_filename, strerror(errno));
               else memset(fd_buf, 0, OUTPUT_FILE_BUFSZ);
             }
           }

--- a/src/telemetry/telemetry_util.c
+++ b/src/telemetry/telemetry_util.c
@@ -168,9 +168,10 @@ int telemetry_validate_input_output_decoders(int input, int output)
 
 void telemetry_log_peer_stats(telemetry_peer *peer, struct telemetry_data *t_data)
 {
-  Log(LOG_INFO, "INFO ( %s/%s ): [%s:%u] pkts=%u pktBytes=%u msgBytes=%u msgErrors=%u\n",
-	config.name, t_data->log_str, peer->addr_str, peer->tcp_port, peer->stats.packets,
-	peer->stats.packet_bytes, peer->stats.msg_bytes, peer->stats.msg_errors);
+  Log(LOG_INFO, "INFO ( %s/%s ): [%s:%u] pkts=%llu pktBytes=%llu msgBytes=%llu msgErrors=%llu\n",
+	config.name, t_data->log_str, peer->addr_str, peer->tcp_port,
+	(unsigned long long)peer->stats.packets, (unsigned long long)peer->stats.packet_bytes,
+	(unsigned long long)peer->stats.msg_bytes, (unsigned long long)peer->stats.msg_errors);
 
   t_data->global_stats.packets += peer->stats.packets;
   t_data->global_stats.packet_bytes += peer->stats.packet_bytes;
@@ -185,9 +186,10 @@ void telemetry_log_peer_stats(telemetry_peer *peer, struct telemetry_data *t_dat
 
 void telemetry_log_global_stats(struct telemetry_data *t_data)
 {
-  Log(LOG_INFO, "INFO ( %s/%s ): [Total] pkts=%u pktBytes=%u msgBytes=%u msgErrors=%u\n",
-        config.name, t_data->log_str, t_data->global_stats.packets, t_data->global_stats.packet_bytes,
-	t_data->global_stats.msg_bytes, t_data->global_stats.msg_errors);
+  Log(LOG_INFO, "INFO ( %s/%s ): [Total] pkts=%llu pktBytes=%llu msgBytes=%llu msgErrors=%llu\n",
+        config.name, t_data->log_str, (unsigned long long)t_data->global_stats.packets,
+	(unsigned long long)t_data->global_stats.packet_bytes, (unsigned long long)t_data->global_stats.msg_bytes,
+	(unsigned long long)t_data->global_stats.msg_errors);
 
   t_data->global_stats.packets = 0;
   t_data->global_stats.packet_bytes = 0;

--- a/src/thread_pool.c
+++ b/src/thread_pool.c
@@ -122,7 +122,7 @@ thread_pool_t *allocate_thread_pool(int count)
       attr_ptr = &attr;
       pthread_attr_getstacksize(&attr, &confd_stack_size);
       if (confd_stack_size != config.thread_stack && confd_stack_size != default_stack_size) 
-        Log(LOG_INFO, "INFO ( %s/%s ): pthread_attr_setstacksize(): %u\n", config.name, config.type, confd_stack_size);
+        Log(LOG_INFO, "INFO ( %s/%s ): pthread_attr_setstacksize(): %lu\n", config.name, config.type, (unsigned long)confd_stack_size);
     }
     else {
       Log(LOG_ERR, "ERROR ( %s/%s ): pthread_attr_setstacksize(): %s\n", config.name, config.type, strerror(rc));

--- a/src/util.c
+++ b/src/util.c
@@ -1550,7 +1550,7 @@ void *pm_malloc(size_t size)
   obj = (unsigned char *) malloc(size);
   if (!obj) {
     Log(LOG_ERR, "ERROR ( %s/%s ): Unable to grab enough memory (requested: %llu bytes). Exiting ...\n",
-    config.name, config.type, size);
+    config.name, config.type, (unsigned long long)size);
     exit_gracefully(1);
   }
 
@@ -1955,7 +1955,7 @@ void compose_timestamp(char *buf, int buflen, struct timeval *tv, int usec, int 
   if (buflen < VERYSHORTBUFLEN) return; 
 
   if (since_epoch) {
-    if (usec) snprintf(buf, buflen, "%ld.%.6ld", tv->tv_sec, tv->tv_usec);
+    if (usec) snprintf(buf, buflen, "%ld.%.6ld", tv->tv_sec, (long)tv->tv_usec);
     else snprintf(buf, buflen, "%ld", tv->tv_sec);
   }
   else {
@@ -1966,7 +1966,7 @@ void compose_timestamp(char *buf, int buflen, struct timeval *tv, int usec, int 
     if (!rfc3339) slen = strftime(buf, buflen, "%Y-%m-%d %H:%M:%S", time2);
     else slen = strftime(buf, buflen, "%Y-%m-%dT%H:%M:%S", time2);
 
-    if (usec) snprintf((buf + slen), (buflen - slen), ".%.6ld", tv->tv_usec);
+    if (usec) snprintf((buf + slen), (buflen - slen), ".%.6ld", (long)tv->tv_usec);
     if (rfc3339) append_rfc3339_timezone(buf, buflen, time2);
   }
 }
@@ -2160,7 +2160,7 @@ void custom_primitive_header_print(char *out, int outlen, struct custom_primitiv
     if (cp_entry->ptr->semantics == CUSTOM_PRIMITIVE_TYPE_UINT ||
         cp_entry->ptr->semantics == CUSTOM_PRIMITIVE_TYPE_HEX) {
       if (formatted) {
-	snprintf(format, VERYSHORTBUFLEN, "%%-%u", cps_flen[cp_entry->ptr->len] > strlen(cp_entry->ptr->name) ? cps_flen[cp_entry->ptr->len] : strlen(cp_entry->ptr->name));
+	snprintf(format, VERYSHORTBUFLEN, "%%-%d", cps_flen[cp_entry->ptr->len] > strlen(cp_entry->ptr->name) ? cps_flen[cp_entry->ptr->len] : (int)strlen(cp_entry->ptr->name));
 	strncat(format, "s", VERYSHORTBUFLEN);
       }
       else snprintf(format, VERYSHORTBUFLEN, "%s", "%s");
@@ -2168,7 +2168,7 @@ void custom_primitive_header_print(char *out, int outlen, struct custom_primitiv
     else if (cp_entry->ptr->semantics == CUSTOM_PRIMITIVE_TYPE_STRING ||
 	     cp_entry->ptr->semantics == CUSTOM_PRIMITIVE_TYPE_RAW) {
       if (formatted) {
-	snprintf(format, VERYSHORTBUFLEN, "%%-%u", cp_entry->ptr->len > strlen(cp_entry->ptr->name) ? cp_entry->ptr->len : strlen(cp_entry->ptr->name));
+	snprintf(format, VERYSHORTBUFLEN, "%%-%d", cp_entry->ptr->len > strlen(cp_entry->ptr->name) ? cp_entry->ptr->len : (int)strlen(cp_entry->ptr->name));
 	strncat(format, "s", VERYSHORTBUFLEN);
       }
       else snprintf(format, VERYSHORTBUFLEN, "%s", "%s");
@@ -2179,7 +2179,7 @@ void custom_primitive_header_print(char *out, int outlen, struct custom_primitiv
       len = INET6_ADDRSTRLEN;
       	
       if (formatted) {
-        snprintf(format, VERYSHORTBUFLEN, "%%-%u", len > strlen(cp_entry->ptr->name) ? len : strlen(cp_entry->ptr->name));
+        snprintf(format, VERYSHORTBUFLEN, "%%-%d", len > strlen(cp_entry->ptr->name) ? len : (int)strlen(cp_entry->ptr->name));
         strncat(format, "s", VERYSHORTBUFLEN);
       }
       else snprintf(format, VERYSHORTBUFLEN, "%s", "%s");
@@ -2188,7 +2188,7 @@ void custom_primitive_header_print(char *out, int outlen, struct custom_primitiv
       int len = ETHER_ADDRSTRLEN;
 
       if (formatted) {
-        snprintf(format, VERYSHORTBUFLEN, "%%-%u", len > strlen(cp_entry->ptr->name) ? len : strlen(cp_entry->ptr->name));
+        snprintf(format, VERYSHORTBUFLEN, "%%-%d", len > strlen(cp_entry->ptr->name) ? len : (int)strlen(cp_entry->ptr->name));
         strncat(format, "s", VERYSHORTBUFLEN);
       }
       else snprintf(format, VERYSHORTBUFLEN, "%s", "%s");
@@ -2215,8 +2215,8 @@ void custom_primitive_value_print(char *out, int outlen, char *in, struct custom
 	snprintf(semantics, VERYSHORTBUFLEN, "%s", cps_type[cp_entry->ptr->semantics]); 
 
       if (formatted)
-        snprintf(format, VERYSHORTBUFLEN, "%%-%u%s",
-		cps_flen[cp_entry->ptr->len] > strlen(cp_entry->ptr->name) ? cps_flen[cp_entry->ptr->len] : strlen(cp_entry->ptr->name), 
+        snprintf(format, VERYSHORTBUFLEN, "%%-%d%s",
+		cps_flen[cp_entry->ptr->len] > strlen(cp_entry->ptr->name) ? cps_flen[cp_entry->ptr->len] : (int)strlen(cp_entry->ptr->name), 
 		semantics);
       else
         snprintf(format, VERYSHORTBUFLEN, "%%%s", semantics);
@@ -2252,7 +2252,7 @@ void custom_primitive_value_print(char *out, int outlen, char *in, struct custom
     else if (cp_entry->ptr->semantics == CUSTOM_PRIMITIVE_TYPE_STRING ||
 	     cp_entry->ptr->semantics == CUSTOM_PRIMITIVE_TYPE_RAW) {
       if (formatted)
-	snprintf(format, VERYSHORTBUFLEN, "%%-%u%s", cp_entry->ptr->len > strlen(cp_entry->ptr->name) ? cp_entry->ptr->len : strlen(cp_entry->ptr->name),
+	snprintf(format, VERYSHORTBUFLEN, "%%-%d%s", cp_entry->ptr->len > strlen(cp_entry->ptr->name) ? cp_entry->ptr->len : (int)strlen(cp_entry->ptr->name),
 			cps_type[cp_entry->ptr->semantics]); 
       else
 	snprintf(format, VERYSHORTBUFLEN, "%%%s", cps_type[cp_entry->ptr->semantics]); 
@@ -2280,7 +2280,7 @@ void custom_primitive_value_print(char *out, int outlen, char *in, struct custom
 
       addr_to_str(ip_str, &ip_addr);
       if (formatted)
-        snprintf(format, VERYSHORTBUFLEN, "%%-%u%s", len > strlen(cp_entry->ptr->name) ? len : strlen(cp_entry->ptr->name),
+        snprintf(format, VERYSHORTBUFLEN, "%%-%d%s", len > strlen(cp_entry->ptr->name) ? len : (int)strlen(cp_entry->ptr->name),
                         cps_type[cp_entry->ptr->semantics]);
       else
         snprintf(format, VERYSHORTBUFLEN, "%%%s", cps_type[cp_entry->ptr->semantics]);
@@ -2295,7 +2295,7 @@ void custom_primitive_value_print(char *out, int outlen, char *in, struct custom
       etheraddr_string(in+cp_entry->off, eth_str);
 
       if (formatted)
-        snprintf(format, VERYSHORTBUFLEN, "%%-%u%s", len > strlen(cp_entry->ptr->name) ? len : strlen(cp_entry->ptr->name),
+        snprintf(format, VERYSHORTBUFLEN, "%%-%d%s", len > strlen(cp_entry->ptr->name) ? len : (int)strlen(cp_entry->ptr->name),
                         cps_type[cp_entry->ptr->semantics]);
       else
         snprintf(format, VERYSHORTBUFLEN, "%%%s", cps_type[cp_entry->ptr->semantics]);

--- a/src/xflow_status.c
+++ b/src/xflow_status.c
@@ -141,9 +141,9 @@ void print_status_table(time_t now, int buckets)
     if (entry && entry->counters.total && entry->counters.bytes) {
       addr_to_str(agent_ip_address, &entry->agent_addr);
 
-      Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s:%u] agent=%s:%u time=%u packets=%llu bytes=%llu seq_good=%u seq_jmp_fwd=%u seq_jmp_bck=%u\n",
+      Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s:%u] agent=%s:%u time=%ld packets=%llu bytes=%llu seq_good=%u seq_jmp_fwd=%u seq_jmp_bck=%u\n",
 		config.name, config.type, collector_ip_address, config.nfacctd_port,
-		agent_ip_address, entry->aux1, now, entry->counters.total, entry->counters.bytes,
+		agent_ip_address, entry->aux1, (long)now, entry->counters.total, entry->counters.bytes,
 		entry->counters.good, entry->counters.jumps_f, entry->counters.jumps_b);
 
       if (entry->next) {
@@ -153,9 +153,9 @@ void print_status_table(time_t now, int buckets)
     } 
   }
 
-  Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s:%u] time=%u discarded_packets=%u\n",
+  Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s:%u] time=%ld discarded_packets=%u\n",
 		config.name, config.type, collector_ip_address, config.nfacctd_port,
-		now, xflow_tot_bad_datagrams);
+		(long)now, xflow_tot_bad_datagrams);
 
   Log(LOG_NOTICE, "NOTICE ( %s/%s ): ---\n", config.name, config.type);
 }


### PR DESCRIPTION
The first commit in this PR adds an annotation to the `Log` function to tell the compiler it's a printf-style function, allowing it to give warnings for argument mismatches. Subsequent commits address all the `-Wformat` errors I get on Apple Clang 10.0.0.

The problems fixed range from the benign, like printing signed as unsigned, to code that will certainly segfault when executed. I think they all deserve to be fixed so future serious problems don't drown in the noise of existing warnings. See details on individual commits.

These problems came to my attention when looking at the alerts for this project on https://lgtm.com/projects/g/pmacct/pmacct/alerts/?mode=tree (full disclosure: I work for the company behind lgtm.com).