### PR TITLE
Tweaking signal handling during critical sections of polling/netflow processing for nfacctd

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -147,6 +147,8 @@ int main(int argc,char **argv, char **envp)
   struct packet_ptrs recv_pptrs;
   struct pcap_pkthdr recv_pkthdr;
 
+  extern struct sigaction sighandler_action;
+
   /* getopt() stuff */
   extern char *optarg;
   extern int optind, opterr, optopt;
@@ -587,11 +589,23 @@ int main(int argc,char **argv, char **envp)
 #endif
 
   /* signal handling we want to inherit to plugins (when not re-defined elsewhere) */
-  signal(SIGCHLD, startup_handle_falling_child); /* takes note of plugins failed during startup phase */
-  signal(SIGHUP, reload); /* handles reopening of syslog channel */
-  signal(SIGUSR1, push_stats); /* logs various statistics via Log() calls */ 
-  signal(SIGUSR2, reload_maps); /* sets to true the reload_maps flag */
-  signal(SIGPIPE, SIG_IGN); /* we want to exit gracefully when a pipe is broken */
+  memset(&sighandler_action, 0, sizeof(sighandler_action)); //To ensure the struct holds no garbage values
+  sigemptyset(&sighandler_action.sa_mask);  //Within a signal handler all the signals are enabled
+  sighandler_action.sa_flags = SA_RESTART;  //To enable re-entering a system call afer done with signal handling
+  sighandler_action.sa_handler = startup_handle_falling_child;
+  sigaction(SIGCHLD, &sighandler_action, NULL);
+  /* handles reopening of syslog channel */
+  sighandler_action.sa_handler = reload;
+  sigaction(SIGHUP, &sighandler_action, NULL); 
+  /* logs various statistics via Log() calls */
+  sighandler_action.sa_handler = push_stats;
+  sigaction(SIGUSR1, &sighandler_action, NULL); 
+  /* sets to true the reload_maps flag */
+  sighandler_action.sa_handler = reload_maps;
+  sigaction(SIGUSR2, &sighandler_action, NULL);
+  /* we want to exit gracefully when a pipe is broken */
+  sighandler_action.sa_handler = SIG_IGN;
+  sigaction(SIGPIPE, &sighandler_action, NULL);
 
   if (config.pcap_savefile) {
     open_pcap_savefile(&device, config.pcap_savefile);
@@ -884,9 +898,14 @@ int main(int argc,char **argv, char **envp)
 
   /* signals to be handled only by the core process;
      we set proper handlers after plugin creation */
-  signal(SIGINT, PM_sigint_handler);
-  signal(SIGTERM, PM_sigint_handler);
-  signal(SIGCHLD, handle_falling_child);
+  sighandler_action.sa_handler = PM_sigint_handler;
+  sigaction(SIGINT, &sighandler_action, NULL);
+
+  sighandler_action.sa_handler = PM_sigint_handler;
+  sigaction(SIGTERM, &sighandler_action, NULL);
+
+  sighandler_action.sa_handler = handle_falling_child;
+  sigaction(SIGCHLD, &sighandler_action, NULL);
   kill(getpid(), SIGCHLD);
 
   /* initializing template cache */ 
@@ -1050,9 +1069,14 @@ int main(int argc,char **argv, char **envp)
 
   /* fixing NetFlow v9/IPFIX template func pointers */
   get_ext_db_ie_by_type = &ext_db_get_ie;
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGUSR1);
+
 
   /* Main loop */
   for (;;) {
+    sigprocmask(SIG_BLOCK, &set, NULL);
     if (config.pcap_savefile) {
       ret = recvfrom_savefile(&device, (void **) &netflow_packet, (struct sockaddr *) &client, NULL, &pcap_savefile_round, &recv_pptrs);
     }
@@ -1196,6 +1220,7 @@ int main(int argc,char **argv, char **envp)
 
       process_raw_packet(netflow_packet, ret, &pptrs, &req);
     }
+    sigprocmask(SIG_UNBLOCK, &set, NULL);
   }
 }
 

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -1071,7 +1071,12 @@ int main(int argc,char **argv, char **envp)
   get_ext_db_ie_by_type = &ext_db_get_ie;
   sigset_t set;
   sigemptyset(&set);
+  sigaddset(&set, SIGCHLD);
+  sigaddset(&set, SIGHUP);
   sigaddset(&set, SIGUSR1);
+  sigaddset(&set, SIGUSR2);
+  sigaddset(&set, SIGINT);
+  sigaddset(&set, SIGTERM);
 
 
   /* Main loop */


### PR DESCRIPTION
There have been certain issues in the network regarding how signals are processed causing a block in zmq from sending a message to the print plugins. The added code tweaks the signal handling behavior to block certain signals(Currently blocking only USR1) during critical sections of polling/Netflow processing. 