### PR TITLE
Enable -Wall -Werror with --enable-debug and fix all warnings. Add more targets to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,19 @@ install:
   - git clone https://github.com/confluentinc/libserdes
   - cd libserdes && ./configure && make && sudo make install && cd ..
 
+env:
+  #All extensions
+  - CONFIG_FLAGS=--enable-debug --enable-mysql --enable-pgsql --enable-sqlite3 --enable-kafka --enable-geoipv2 --enable-jansson --enable-rabbitmq --enable-nflog --enable-ndpi --enable-zmq --enable-avro --enable-serdes
+  - CONFIG_FLAGS=--enable-mysql --enable-pgsql --enable-sqlite3 --enable-kafka --enable-geoipv2 --enable-jansson --enable-rabbitmq --enable-nflog --enable-ndpi --enable-zmq --enable-avro --enable-serdes
+
+  #No extensions
+  - CONFIG_FLAGS=--enable-debug
+  - CONFIG_FLAGS=
+
+
 script:
   - ./autogen.sh
-  - ./configure --enable-mysql --enable-pgsql --enable-sqlite3 --enable-kafka --enable-geoipv2 --enable-jansson --enable-rabbitmq --enable-nflog --enable-ndpi --enable-zmq --enable-avro --enable-serdes
+  - ./configure $CONFIG_FLAGS
   - make
   - sudo make install
 

--- a/configure.ac
+++ b/configure.ac
@@ -231,8 +231,11 @@ if test x"$ac_cv_unaligned" = x"unknown"; then
     #include <sys/types.h>
     #include <sys/wait.h>
     #include <stdio.h>
+    #include <stdlib.h>
+    #include <unistd.h>
+
     unsigned char a[[5]] = { 1, 2, 3, 4, 5 };
-    main () {
+    int main () {
     	unsigned int i;
         pid_t pid;
         int status;

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_ARG_ENABLE(debug,
 			AC_MSG_RESULT(yes)
 			tmp_CFLAGS=`echo $CFLAGS | sed 's/O2/O0/g'`
 			CFLAGS="$tmp_CFLAGS"
-  			CFLAGS="$CFLAGS -g -W -Wall"
+			CFLAGS="$CFLAGS -g -Wall -Werror"
 		else
 			AC_MSG_RESULT(no)
 		fi

--- a/examples/lg/pmbgp.c
+++ b/examples/lg/pmbgp.c
@@ -345,5 +345,6 @@ int pmbgp_zmq_sendmore_str(struct p_zmq_sock *sock, char *buf)
 int main(int argc,char **argv)
 {
   printf("WARN: pmbgp: tool depends on missing --enable-zmq and --enable-jansson. Exiting.\n");
+  return 1;
 }
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,23 +7,22 @@ AM_LDFLAGS = @GEOIP_LIBS@ @GEOIPV2_LIBS@ @JANSSON_LIBS@ @AVRO_LIBS@
 AM_CFLAGS = $(PMACCT_CFLAGS)
 
 noinst_LTLIBRARIES = libdaemons.la libcommon.la
-libcommon_la_SOURCES = strlcpy.c addr.c addr.h pmacct.h	pmacct-build.h	\
-	pmacct-data.h pmacct-defines.h mpls.h network.h  once.h
-libdaemons_la_SOURCES = signals.c util.c util.h plugin_hooks.c		\
-        plugin_hooks.h server.c acct.c memory.c cfg.c cfg.h		\
-        imt_plugin.c imt_plugin.h log.c log.h pkt_handlers.c		\
-        pkt_handlers.h cfg_handlers.c cfg_handlers.h net_aggr.c		\
-        net_aggr.h bpf_filter.c pmacct-bpf.h print_plugin.c		\
-        print_plugin.h pretag.c pretag-data.h pretag.h ip_frag.c	\
-        ip_frag.h ports_aggr.c ports_aggr.h pretag_handlers.c		\
-        pretag_handlers.h ip_flow.c ip_flow.h setproctitle.c		\
-        setproctitle.h classifier.c classifier.h regexp.c regexp.h	\
-        conntrack.c conntrack.h xflow_status.c xflow_status.h		\
-	plugin_common.c plugin_common.h preprocess.c preprocess-data.h	\
-	preprocess.h ll.c nl.c jhash.h pmacct-dlt.h sflow.h crc32.h	\
-	base64.c base64.h plugin_cmn_json.c plugin_cmn_json.h		\
-	plugin_cmn_avro.c plugin_cmn_avro.h pmsearch.c pmsearch.h	\
-	thread_pool.c thread_pool.h plugin_cmn_custom.h			\
+libcommon_la_SOURCES = strlcpy.c addr.c
+libdaemons_la_SOURCES = signals.c util.c plugin_hooks.c		\
+        server.c acct.c memory.c cfg.c				\
+        imt_plugin.c log.c pkt_handlers.c			\
+        cfg_handlers.c net_aggr.c				\
+        bpf_filter.c print_plugin.c				\
+        pretag.c ip_frag.c					\
+        ports_aggr.c pretag_handlers.c				\
+        ip_flow.c setproctitle.c				\
+        classifier.c regexp.c					\
+        conntrack.c xflow_status.c				\
+	plugin_common.c preprocess.c				\
+	ll.c nl.c 						\
+	base64.c plugin_cmn_json.c 				\
+	plugin_cmn_avro.c pmsearch.c 				\
+	thread_pool.c						\
 	plugin_cmn_custom.c
 
 libcommon_la_LIBADD  = 
@@ -42,22 +41,22 @@ libdaemons_la_LIBADD += telemetry/libpmtelemetry.la
 libdaemons_la_LIBADD += libcommon.la
 libdaemons_la_CFLAGS  = $(AM_CFLAGS)
 if WITH_MYSQL
-libdaemons_la_SOURCES += mysql_plugin.c mysql_plugin.h
+libdaemons_la_SOURCES += mysql_plugin.c
 libdaemons_la_LIBADD  += @MYSQL_LIBS@
 libdaemons_la_CFLAGS  += @MYSQL_CFLAGS@
 endif
 if WITH_PGSQL
-libdaemons_la_SOURCES += pgsql_plugin.c pgsql_plugin.h
+libdaemons_la_SOURCES += pgsql_plugin.c
 libdaemons_la_LIBADD  += @PGSQL_LIBS@
 libdaemons_la_CFLAGS  += @PGSQL_CFLAGS@
 endif
 if WITH_MONGODB
-libdaemons_la_SOURCES += mongodb_plugin.c mongodb_plugin.h
+libdaemons_la_SOURCES += mongodb_plugin.c
 libdaemons_la_LIBADD  += @MONGODB_LIBS@
 libdaemons_la_CFLAGS  += @MONGODB_CFLAGS@
 endif
 if WITH_SQLITE3
-libdaemons_la_SOURCES += sqlite3_plugin.c sqlite3_plugin.h
+libdaemons_la_SOURCES += sqlite3_plugin.c
 libdaemons_la_LIBADD  += @SQLITE3_LIBS@
 libdaemons_la_CFLAGS  += @SQLITE3_CFLAGS@
 endif
@@ -75,22 +74,22 @@ libdaemons_la_LIBADD  += @NDPI_LIBS@
 libdaemons_la_CFLAGS  += @NDPI_CFLAGS@
 endif
 if WITH_RABBITMQ
-libdaemons_la_SOURCES += amqp_common.c amqp_common.h amqp_plugin.c amqp_plugin.h
+libdaemons_la_SOURCES += amqp_common.c amqp_plugin.c
 libdaemons_la_LIBADD  += @RABBITMQ_LIBS@
 libdaemons_la_CFLAGS  += @RABBITMQ_CFLAGS@
 endif
 if WITH_ZMQ
-libdaemons_la_SOURCES += zmq_common.c zmq_common.h
+libdaemons_la_SOURCES += zmq_common.c
 libdaemons_la_LIBADD  += @ZMQ_LIBS@
 libdaemons_la_CFLAGS  += @ZMQ_CFLAGS@
 endif
 if WITH_KAFKA
-libdaemons_la_SOURCES += kafka_common.c kafka_common.h kafka_plugin.c kafka_plugin.h
+libdaemons_la_SOURCES += kafka_common.c kafka_plugin.c
 libdaemons_la_LIBADD  += @KAFKA_LIBS@
 libdaemons_la_CFLAGS  += @KAFKA_CFLAGS@
 endif
 if USING_SQL
-libdaemons_la_SOURCES += sql_common.c sql_handlers.c sql_common.h
+libdaemons_la_SOURCES += sql_common.c sql_handlers.c
 libdaemons_la_LIBADD  += -lm -lz
 endif
 
@@ -99,13 +98,13 @@ sbin_PROGRAMS += pmacctd nfacctd sfacctd
 bin_PROGRAMS += pmacct
 pmacctd_SOURCES = pmacctd.c
 pmacctd_LDADD = libdaemons.la
-nfacctd_SOURCES = nfacctd.c nfacctd.h nfv9_template.c
+nfacctd_SOURCES = nfacctd.c nfv9_template.c
 nfacctd_LDADD = libdaemons.la
-sfacctd_SOURCES = sfacctd.c sflow.c sfacctd.h sfv5_module.c sfv5_module.h
+sfacctd_SOURCES = sfacctd.c sflow.c sfv5_module.c
 sfacctd_LDADD = libdaemons.la
 if WITH_NFLOG
 sbin_PROGRAMS += uacctd
-uacctd_SOURCES = uacctd.c uacctd.h
+uacctd_SOURCES = uacctd.c
 uacctd_CFLAGS  = $(AM_CFLAGS) @NFLOG_CFLAGS@
 uacctd_LDADD   = libdaemons.la @NFLOG_LIBS@
 endif
@@ -114,19 +113,19 @@ pmacct_LDADD = libcommon.la
 endif
 if USING_ST_BINS
 sbin_PROGRAMS += pmtelemetryd
-pmtelemetryd_SOURCES = pmtelemetryd.c pmtelemetryd.h
+pmtelemetryd_SOURCES = pmtelemetryd.c
 pmtelemetryd_LDFLAGS = $(DEFS)
 pmtelemetryd_LDADD = libdaemons.la
 endif
 if USING_BGP_BINS
 sbin_PROGRAMS += pmbgpd
-pmbgpd_SOURCES = pmbgpd.c pmbgpd.h
+pmbgpd_SOURCES = pmbgpd.c
 pmbgpd_LDFLAGS = $(DEFS)
 pmbgpd_LDADD = libdaemons.la
 endif
 if USING_BMP_BINS
 sbin_PROGRAMS += pmbmpd
-pmbmpd_SOURCES = pmbmpd.c pmbmpd.h
+pmbmpd_SOURCES = pmbmpd.c
 pmbmpd_LDFLAGS = $(DEFS)
 pmbmpd_LDADD = libdaemons.la
 endif

--- a/src/acct.c
+++ b/src/acct.c
@@ -38,7 +38,7 @@ struct acc *search_accounting_structure(struct primitives_ptrs *prim_ptrs)
   struct pkt_mpls_primitives *pmpls = prim_ptrs->pmpls;
   struct pkt_tunnel_primitives *ptun = prim_ptrs->ptun;
   u_char *pcust = prim_ptrs->pcust;
-  struct pkt_vlen_hdr_primitives *pvlen = prim_ptrs->pvlen;
+  //struct pkt_vlen_hdr_primitives *pvlen = prim_ptrs->pvlen;
   struct acc *elem_acc;
   unsigned int hash, pos;
   unsigned int pp_size = sizeof(struct pkt_primitives); 
@@ -111,6 +111,7 @@ int compare_accounting_structure(struct acc *elem, struct primitives_ptrs *prim_
 
   if (ptun && elem->ptun) res_tun = memcmp(elem->ptun, ptun, sizeof(struct pkt_tunnel_primitives));
   else res_tun = FALSE;
+  (void)res_tun; //TODO check error
 
   if (pcust && elem->pcust) res_cust = memcmp(elem->pcust, pcust, config.cpptrs.len);
   else res_cust = FALSE;

--- a/src/addr.c
+++ b/src/addr.c
@@ -103,12 +103,10 @@ unsigned int addr_mask_to_str(char *str, int len, const struct host_addr *a, con
  */
 unsigned int str_to_addr_mask(const char *str, struct host_addr *a, struct host_mask *m)
 {
-  char *delim = NULL, *net = NULL, *mask = NULL;
+  char *delim = NULL, *mask = NULL;
   unsigned int family = 0, index = 0, j;
 
   if (!str || !a || !m) return family;
-
-  net = (char *) str;
 
   delim = strchr(str, '/');
   if (delim) {

--- a/src/base64.c
+++ b/src/base64.c
@@ -100,7 +100,7 @@ unsigned char * base64_decode(const unsigned char *src, size_t len,
 			      size_t *out_len)
 {
 	unsigned char dtable[256], *out, *pos, in[4], block[4], tmp;
-	size_t i, count, olen;
+	size_t i, count;
 
 	memset(dtable, 0x80, 256);
 	for (i = 0; i < sizeof(base64_table); i++)
@@ -116,7 +116,6 @@ unsigned char * base64_decode(const unsigned char *src, size_t len,
 	if (count % 4)
 		return NULL;
 
-	olen = count / 4 * 3;
 	pos = out = malloc(count);
 	if (out == NULL)
 		return NULL;

--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -66,7 +66,10 @@ void skinny_bgp_daemon()
 
 void skinny_bgp_daemon_online()
 {
-  int ret, rc, peers_idx, allowed, yes=1, no=0;
+  int ret, rc, peers_idx, allowed, yes=1;
+#if (defined IPV6_BINDV6ONLY)
+  int no=0;
+#endif
   int peers_idx_rr = 0, peers_xconnect_idx_rr = 0, max_peers_idx = 0;
   struct plugin_requests req;
   struct host_addr addr;

--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -22,8 +22,6 @@
 /* defines */
 #define __BGP_LOGDUMP_C
 
-#include <inttypes.h>
-
 /* includes */
 #include "pmacct.h"
 #include "pmacct-data.h"

--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -22,6 +22,8 @@
 /* defines */
 #define __BGP_LOGDUMP_C
 
+#include <inttypes.h>
+
 /* includes */
 #include "pmacct.h"
 #include "pmacct-data.h"
@@ -40,15 +42,13 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, saf
 {
   struct bgp_misc_structs *bms;
   struct bgp_peer *peer;
-  struct bgp_attr *attr;
   int ret = 0, amqp_ret = 0, kafka_ret = 0, etype = BGP_LOGDUMP_ET_NONE;
-  pid_t writer_pid = getpid();
+  (void)etype;
 
   if (!ri || !ri->peer || !event_type) return ERR; /* missing required parameters */
   if (!ri->peer->log && !output_data) return ERR; /* missing any output method */
 
   peer = ri->peer;
-  attr = ri->attr;
 
   bms = bgp_select_misc_db(peer->type);
   if (!bms) return ERR;
@@ -56,6 +56,10 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, saf
   if (!strcmp(event_type, "dump")) etype = BGP_LOGDUMP_ET_DUMP;
   else if (!strcmp(event_type, "log")) etype = BGP_LOGDUMP_ET_LOG;
   else if (!strcmp(event_type, "lglass")) etype = BGP_LOGDUMP_ET_LG;
+
+#if defined(WITH_KAFKA) || defined(WITH_RABBITMQ)
+  pid_t writer_pid = getpid();
+#endif
 
 #ifdef WITH_RABBITMQ
   if ((bms->msglog_amqp_routing_key && etype == BGP_LOGDUMP_ET_LOG) ||
@@ -71,6 +75,8 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, saf
 
   if (output == PRINT_OUTPUT_JSON) {
 #ifdef WITH_JANSSON
+    struct bgp_attr *attr;
+    attr = ri->attr;
     char ip_address[INET6_ADDRSTRLEN];
     json_t *obj = json_object();
 
@@ -221,8 +227,11 @@ int bgp_peer_log_init(struct bgp_peer *peer, int output, int type)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(type);
   int peer_idx, have_it, ret = 0, amqp_ret = 0, kafka_ret = 0;
-  char log_filename[SRVBUFLEN], event_type[] = "log_init";
+  char log_filename[SRVBUFLEN];
+
+#if defined(WITH_KAFKA) || defined(WITH_RABBITMQ)
   pid_t writer_pid = getpid();
+#endif
 
   if (!bms || !peer) return ERR;
 
@@ -290,6 +299,7 @@ int bgp_peer_log_init(struct bgp_peer *peer, int output, int type)
 
     if (output == PRINT_OUTPUT_JSON) {
 #ifdef WITH_JANSSON
+      char event_type[] = "log_init";
       char ip_address[INET6_ADDRSTRLEN];
       json_t *obj = json_object();
 
@@ -338,11 +348,12 @@ int bgp_peer_log_init(struct bgp_peer *peer, int output, int type)
 int bgp_peer_log_close(struct bgp_peer *peer, int output, int type)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(type);
-  char event_type[] = "log_close";
   struct bgp_peer_log *log_ptr;
-  void *amqp_log_ptr, *kafka_log_ptr;
   int ret = 0, amqp_ret = 0, kafka_ret = 0;
+
+#if defined(WITH_KAFKA) || defined(WITH_RABBITMQ)
   pid_t writer_pid = getpid();
+#endif
 
   if (!bms || !peer || !peer->log) return ERR;
 
@@ -357,8 +368,6 @@ int bgp_peer_log_close(struct bgp_peer *peer, int output, int type)
 #endif
 
   log_ptr = peer->log;
-  amqp_log_ptr = peer->log->amqp_host;
-  kafka_log_ptr = peer->log->kafka_host;
 
   assert(peer->log->refcnt);
   peer->log->refcnt--;
@@ -368,6 +377,7 @@ int bgp_peer_log_close(struct bgp_peer *peer, int output, int type)
 #ifdef WITH_JANSSON
     char ip_address[INET6_ADDRSTRLEN];
     json_t *obj = json_object();
+    char event_type[] = "log_close";
 
     json_object_set_new_nocheck(obj, "seq", json_integer((json_int_t) bgp_peer_log_seq_get(&bms->log_seq)));
     bgp_peer_log_seq_increment(&bms->log_seq);
@@ -388,6 +398,7 @@ int bgp_peer_log_close(struct bgp_peer *peer, int output, int type)
       write_and_free_json(log_ptr->fd, obj);
 
 #ifdef WITH_RABBITMQ
+    void *amqp_log_ptr;
     if (bms->msglog_amqp_routing_key) {
       add_writer_name_and_pid_json(obj, config.proc_name, writer_pid);
       amqp_ret = write_and_free_json_amqp(amqp_log_ptr, obj);
@@ -396,6 +407,7 @@ int bgp_peer_log_close(struct bgp_peer *peer, int output, int type)
 #endif
 
 #ifdef WITH_KAFKA
+    void *kafka_log_ptr = peer->log->kafka_host;
     if (bms->msglog_kafka_topic) {
       add_writer_name_and_pid_json(obj, config.proc_name, writer_pid);
       kafka_ret = write_and_free_json_kafka(kafka_log_ptr, obj);
@@ -541,9 +553,11 @@ void bgp_peer_log_dynname(char *new, int newlen, char *old, struct bgp_peer *pee
 int bgp_peer_dump_init(struct bgp_peer *peer, int output, int type)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(type);
-  char event_type[] = "dump_init";
   int ret = 0, amqp_ret = 0, kafka_ret = 0;
+
+#if defined(WITH_KAFKA) || defined(WITH_RABBITMQ)
   pid_t writer_pid = getpid();
+#endif
 
   if (!bms || !peer || !peer->log) return ERR;
 
@@ -571,6 +585,7 @@ int bgp_peer_dump_init(struct bgp_peer *peer, int output, int type)
 #ifdef WITH_JANSSON
     char ip_address[INET6_ADDRSTRLEN];
     json_t *obj = json_object();
+    char event_type[] = "dump_init";
 
     json_object_set_new_nocheck(obj, "timestamp", json_string(bms->dump.tstamp_str));
 
@@ -615,9 +630,11 @@ int bgp_peer_dump_init(struct bgp_peer *peer, int output, int type)
 int bgp_peer_dump_close(struct bgp_peer *peer, struct bgp_dump_stats *bds, int output, int type)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(type);
-  char event_type[] = "dump_close";
   int ret = 0, amqp_ret = 0, kafka_ret = 0;
+
+#if defined(WITH_KAFKA) || defined(WITH_RABBITMQ)
   pid_t writer_pid = getpid();
+#endif
 
   if (!bms || !peer || !peer->log) return ERR;
 
@@ -633,6 +650,7 @@ int bgp_peer_dump_close(struct bgp_peer *peer, struct bgp_dump_stats *bds, int o
 
   if (output == PRINT_OUTPUT_JSON) {
 #ifdef WITH_JANSSON
+    char event_type[] = "dump_close";
     char ip_address[INET6_ADDRSTRLEN];
     json_t *obj = json_object();
 
@@ -857,7 +875,7 @@ void bgp_handle_dump_event()
     }
 
     duration = time(NULL)-start;
-    Log(LOG_INFO, "INFO ( %s/%s ): *** Dumping BGP tables - END (PID: %u TABLES: %u ENTRIES: %llu ET: %u) ***\n",
+    Log(LOG_INFO, "INFO ( %s/%s ): *** Dumping BGP tables - END (PID: %u TABLES: %u ENTRIES: %" PRIu64 " ET: %u) ***\n",
 		config.name, bms->log_str, dumper_pid, tables_num, dump_elems, duration);
 
     exit_gracefully(0);

--- a/src/bgp/bgp_msg.c
+++ b/src/bgp/bgp_msg.c
@@ -190,7 +190,7 @@ int bgp_parse_open_msg(struct bgp_msg_data *bmd, char *bgp_packet_ptr, time_t no
 
       /* OPEN options parsing */
       if (bopen->bgpo_optlen && bopen->bgpo_optlen >= 2) {
-	u_int8_t len, opt_type, opt_len, cap_type;
+	u_int8_t len, opt_type, opt_len;
 	char *ptr;
 
 	ptr = bgp_packet_ptr + BGP_MIN_OPEN_MSG_SIZE;
@@ -711,7 +711,7 @@ int bgp_parse_update_msg(struct bgp_msg_data *bmd, char *pkt)
 int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, char *ptr, int len, struct bgp_nlri *mp_update, struct bgp_nlri *mp_withdraw)
 {
   int to_the_end = len, ret;
-  u_int8_t flag, type, *tmp, mp_nlri = 0;
+  u_int8_t flag, type, *tmp;
   u_int16_t tmp16, attr_len;
   struct aspath *as4_path = NULL;
 
@@ -763,11 +763,9 @@ int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, char *ptr, int 
       break;
     case BGP_ATTR_MP_REACH_NLRI:
       ret = bgp_attr_parse_mp_reach(peer, attr_len, attr, ptr, mp_update);
-      mp_nlri = TRUE;
       break;
     case BGP_ATTR_MP_UNREACH_NLRI:
       ret = bgp_attr_parse_mp_unreach(peer, attr_len, attr, ptr, mp_withdraw);
-      mp_nlri = TRUE;
       break;
     default:
       ret = 0;
@@ -1139,6 +1137,8 @@ int bgp_nlri_parse(struct bgp_msg_data *bmd, void *attr, struct bgp_nlri *info)
     }
     else {
       ret = bgp_process_withdraw(bmd, &p, attr, info->afi, safi, &rd, &path_id, label);
+      (void)ret; //Treat error?
+
     }
 
 #if defined WITH_ZMQ

--- a/src/bgp/bgp_table.c
+++ b/src/bgp/bgp_table.c
@@ -94,6 +94,7 @@ static struct bgp_node *
 bgp_node_set (struct bgp_peer *peer, struct bgp_table *table, struct prefix *prefix)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(peer->type);
+  (void)bms;
   struct bgp_node *node;
   
   node = bgp_node_create (peer);
@@ -334,6 +335,7 @@ struct bgp_node *
 bgp_node_get (struct bgp_peer *peer, struct bgp_table *const table, struct prefix *p)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(peer->type);
+  (void)bms;
   struct bgp_node *new;
   struct bgp_node *node;
   struct bgp_node *match;

--- a/src/bgp/bgp_util.c
+++ b/src/bgp/bgp_util.c
@@ -87,7 +87,6 @@ int bgp_str2rd(rd_t *output, char *value)
   struct host_addr a;
   char *endptr, *token;
   u_int32_t tmp32;
-  u_int16_t tmp16;
   struct rd_ip  *rdi;
   struct rd_as  *rda;
   struct rd_as4 *rda4;
@@ -734,6 +733,7 @@ void bgp_peer_info_delete(struct bgp_peer *peer)
 {
   struct bgp_rt_structs *inter_domain_routing_db = bgp_select_routing_db(peer->type);
   struct bgp_misc_structs *bms = bgp_select_misc_db(peer->type);
+  (void)bms; //TODO treat errors?
   struct bgp_table *table;
   afi_t afi;
   safi_t safi;
@@ -862,11 +862,10 @@ void evaluate_comm_patterns(char *dst, char *src, char **patterns, int dstlen)
 {
   char *ptr, *haystack, *delim_src, *delim_ptn;
   char local_ptr[MAX_BGP_STD_COMMS], *auxptr;
-  int idx, i, j, srclen;
+  int idx, i, j;
 
   if (!src || !dst || !dstlen) return;
 
-  srclen = strlen(src);
   memset(dst, 0, dstlen);
 
   for (idx = 0, j = 0; patterns[idx]; idx++) {

--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -57,7 +57,7 @@ void nfacctd_bmp_wrapper()
 
 void skinny_bmp_daemon()
 {
-  int ret, rc, peers_idx, allowed, yes=1, no=0;
+  int ret, rc, peers_idx, allowed, yes=1;
   int peers_idx_rr = 0, max_peers_idx = 0;
   u_int32_t pkt_remaining_len=0;
   time_t now;

--- a/src/bmp/bmp.h
+++ b/src/bmp/bmp.h
@@ -41,7 +41,7 @@
 #define BMP_MSG_TLV_RM_LOC_RIB		9 /* draft-hsmit-bmp-extensible-routemon-msgs-00 */
 #define BMP_MSG_TYPE_MAX		9 /* set to the highest BMP_MSG_* value */
 
-static const char *bmp_msg_types[] = {
+static const char __attribute__((unused)) *bmp_msg_types[] = {
   "Route Monitoring",
   "Statistics Report",
   "Peer Down Notification",
@@ -66,7 +66,7 @@ struct bmp_common_hdr {
 #define BMP_PEER_TYPE_LOC_RIB	3 /* draft-evens-grow-bmp-local-rib-01 */ 
 #define BMP_PEER_TYPE_MAX	3 /* set to the highest BMP_PEER_TYPE_* value */
 
-static const char *bmp_peer_types[] = {
+static const char __attribute__((unused)) *bmp_peer_types[] = {
   "Global Instance Peer",
   "RD Instance Peer",
   "Local Instance Peer",
@@ -104,7 +104,7 @@ struct bmp_tlv_hdr {
 
 #define BMP_INIT_INFO_ENTRIES	8
 
-static const char *bmp_init_info_types[] = {
+static const char __attribute__((unused)) *bmp_init_info_types[] = {
   "string",
   "sysdescr",
   "sysname"  
@@ -123,12 +123,12 @@ static const char *bmp_init_info_types[] = {
 #define BMP_TERM_REASON_PERM	4
 #define BMP_TERM_REASON_MAX	4 /* set to the highest BMP_TERM_* value */
 
-static const char *bmp_term_info_types[] = {
+static const char __attribute__((unused)) *bmp_term_info_types[] = {
   "string",
   "reason"
 };
 
-static const char *bmp_term_reason_types[] = {
+static const char __attribute__((unused)) *bmp_term_reason_types[] = {
   "Session administratively closed",
   "Unspecified reason",
   "Out of resources",
@@ -201,7 +201,7 @@ struct bmp_peer {
 #define BMP_STATS_TYPE17	17 /* (64-bit Gauge) Number of routes in per-AFI/SAFI Abj-RIB-Out */
 #define BMP_STATS_MAX		17 /* set to the highest BMP_STATS_* value */
 
-static const char *bmp_stats_cnt_types[] = {
+static const char __attribute__((unused)) *bmp_stats_cnt_types[] = {
   "Number of prefixes rejected by inbound policy",
   "Number of (known) duplicate prefix advertisements",
   "Number of (known) duplicate withdraws",
@@ -237,7 +237,7 @@ struct bmp_stats_cnt_hdr {
 #define BMP_PEER_DOWN_DECFG		5
 #define BMP_PEER_DOWN_MAX		5 /* set to the highest BMP_PEER_DOWN_* value */
 
-static const char *bmp_peer_down_reason_types[] = {
+static const char __attribute__((unused)) *bmp_peer_down_reason_types[] = {
   "Reserved",
   "The local system closed the session",
   "The local system closed the session without a notification message",

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -24,8 +24,6 @@
 
 /* includes */
 /* includes */
-#include <inttypes.h>
-
 #include "pmacct.h"
 #include "addr.h"
 #include "bgp/bgp.h"

--- a/src/bmp/bmp_msg.c
+++ b/src/bmp/bmp_msg.c
@@ -813,6 +813,8 @@ void bmp_process_msg_tlv_route_monitor(char **bmp_packet, u_int32_t *len, struct
 
       /* XXX: checks, ie. marker, message length, etc., bypassed */
       bgp_update_len = bgp_parse_update_msg(&bmd, tlv_update.value);
+      (void)bgp_update_len; //TODO check error
+
       bms->peer_str = saved_peer_str;
     }
     /* missing BMP peer up message, ie. case of replay/replication of BMP messages */

--- a/src/bmp/bmp_util.c
+++ b/src/bmp/bmp_util.c
@@ -114,7 +114,6 @@ u_int32_t bmp_packet_adj_offset(char *bmp_packet, u_int32_t buf_len, u_int32_t r
 
 void bgp_peer_log_msg_extras_bmp(struct bgp_peer *peer, int output, void *void_obj)
 {
-  char bmp_msg_type[] = "route_monitor";
   struct bgp_misc_structs *bms;
   struct bmp_peer *bmpp;
 
@@ -126,6 +125,7 @@ void bgp_peer_log_msg_extras_bmp(struct bgp_peer *peer, int output, void *void_o
 
   if (output == PRINT_OUTPUT_JSON) {
 #ifdef WITH_JANSSON
+    char bmp_msg_type[] = "route_monitor";
     char ip_address[INET6_ADDRSTRLEN];
     json_t *obj = void_obj;
 
@@ -310,14 +310,13 @@ void bgp_extra_data_free_bmp(struct bgp_msg_extra_data *bmed)
 
 void bgp_extra_data_print_bmp(struct bgp_msg_extra_data *bmed, int output, void *void_obj)
 {
-  struct bmp_chars *bmed_bmp;
 
   if (!bmed || !void_obj || bmed->id != BGP_MSG_EXTRA_DATA_BMP) return;
 
-  bmed_bmp = bmed->data;
-
   if (output == PRINT_OUTPUT_JSON) {
 #ifdef WITH_JANSSON
+    struct bmp_chars *bmed_bmp;
+    bmed_bmp = bmed->data;
     json_t *obj = void_obj;
 
     if (bmed_bmp->is_loc) {
@@ -368,7 +367,7 @@ char *bmp_tlv_type_print(u_int16_t in, const char *prefix, const char **registry
 char *bmp_term_reason_print(u_int16_t in)
 {
   char *out = NULL;
-  int prefix_len, value_len;
+  int value_len;
 
 
   if (in <= BMP_TERM_REASON_MAX) {

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -583,5 +583,5 @@ EXT struct custom_primitives custom_primitives_registry;
 EXT pm_cfgreg_t custom_primitives_type;
 EXT int rows;
 
-static char default_proc_name[] = "default";
+static char __attribute__((unused)) default_proc_name[] = "default";
 #undef EXT

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -635,7 +635,6 @@ int cfg_key_files_gid(char *filename, char *name, char *value_ptr)
   struct plugins_list_entry *list = plugins_list;
   struct group *group = NULL;
   u_int32_t value, changes = 0;
-  char *endptr;
 
   group = getgrnam(value_ptr);
   if (!group) {
@@ -2344,12 +2343,13 @@ int cfg_key_plugin_pipe_zmq_retry(char *filename, char *name, char *value_ptr)
 
 int cfg_key_plugin_pipe_zmq_profile(char *filename, char *name, char *value_ptr)
 {
-  struct plugins_list_entry *list = plugins_list;
-  int value, changes = 0;
 
+  int changes = 0;
   lower_string(value_ptr);
 
 #ifdef WITH_ZMQ
+  struct plugins_list_entry *list = plugins_list;
+  int value;
   if (!name) for (; list; list = list->next, changes++) {
     value = p_zmq_plugin_pipe_set_profile(&list->cfg, value_ptr);
     if (value < 0) return ERR;

--- a/src/conntrack.h
+++ b/src/conntrack.h
@@ -80,7 +80,7 @@ EXT struct conntrack_ipv6 *conntrack_ipv6_table;
 #undef EXT
 
 #if defined __CONNTRACK_C || defined __CLASSIFIER_C
-static struct conntrack_helper_entry conntrack_helper_list[] = {
+static struct conntrack_helper_entry __attribute__((unused)) conntrack_helper_list[] = {
   { "ftp", conntrack_ftp_helper },
   { "sip", conntrack_sip_helper },
 //  { "irc", conntrack_irc_helper },

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -83,7 +83,7 @@ static unsigned int crc_32_tab[] = { //
 };
 */
 
-Inline unsigned int cache_crc32(const unsigned char *buf, unsigned int len)
+static inline unsigned int cache_crc32(const unsigned char *buf, unsigned int len)
 {
   unsigned int hash = 5381;
   unsigned int i = 0;

--- a/src/imt_plugin.c
+++ b/src/imt_plugin.c
@@ -22,7 +22,6 @@
 #define __IMT_PLUGIN_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "plugin_hooks.h"
 #include "plugin_common.h"

--- a/src/imt_plugin.c
+++ b/src/imt_plugin.c
@@ -22,6 +22,7 @@
 #define __IMT_PLUGIN_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "plugin_hooks.h"
 #include "plugin_common.h"
@@ -60,7 +61,6 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   struct pkt_vlen_hdr_primitives *pvlen, empty_pvlen;
   struct networks_file_data nfd;
   struct primitives_ptrs prim_ptrs;
-  struct plugins_list_entry *plugin_data = ((struct channels_list_entry *)ptr)->plugin;
   socklen_t cLen;
 
   /* poll() stuff */
@@ -79,8 +79,6 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   pm_setproctitle("%s [%s]", "IMT Plugin", config.name);
 
   if (config.proc_priority) {
-    int ret;
-
     ret = setpriority(PRIO_PROCESS, 0, config.proc_priority);
     if (ret) Log(LOG_WARNING, "WARN ( %s/%s ): proc_priority failed (errno: %d)\n", config.name, config.type, errno);
     else Log(LOG_INFO, "INFO ( %s/%s ): proc_priority set to %d\n", config.name, config.type, getpriority(PRIO_PROCESS, 0));
@@ -218,7 +216,6 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     /* doing server tasks */
     if (poll_fd[1].revents & POLLIN) {
       struct pollfd pfd;
-      int ret;
 
       sd2 = accept(sd, &cAddr, &cLen);
       setblocking(sd2);
@@ -356,7 +353,9 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     }
 
     if (poll_fd[0].revents & POLLIN) {
+#ifdef WITH_ZMQ
       read_data:
+#endif
       if (config.pipe_homegrown) {
         if (!pollagain) {
           seq++;
@@ -376,7 +375,7 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
         if (((struct ch_buf_hdr *)pipebuf)->seq != seq) {
           rg_err_count++;
           if (config.debug || (rg_err_count > MAX_RG_COUNT_ERR)) {
-	    Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%llu plugin_pipe_size=%llu).\n",
+	    Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%" PRIu64 " plugin_pipe_size=%" PRIu64 ").\n",
 		config.name, config.type, config.buffer_size, config.pipe_size);
 	    Log(LOG_WARNING, "WARN ( %s/%s ): Increase values or look for plugin_buffer_size, plugin_pipe_size in CONFIG-KEYS document.\n\n",
 		config.name, config.type);
@@ -404,7 +403,7 @@ void imt_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 	data = (struct pkt_data *) (pipebuf+sizeof(struct ch_buf_hdr));
 
 	if (config.debug_internal_msg) 
-	  Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%llu seq=%u num_entries=%u\n",
+	  Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%" PRIu64 " seq=%u num_entries=%u\n",
 		config.name, config.type, ((struct ch_buf_hdr *)pipebuf)->len, seq,
 		((struct ch_buf_hdr *)pipebuf)->num);
 

--- a/src/isis/Makefile.am
+++ b/src/isis/Makefile.am
@@ -12,4 +12,4 @@ libpmisis_la_SOURCES = isis.c checksum.c dict.c table.c prefix.c	\
 	isis_lsp.h isis_misc.h isis_network.h isis_pdu.h isis_route.h	\
 	isis_spf.h isis_tlv.h iso_checksum.h iso.h linklist.h		\
 	prefix.h sockunion.h stream.h table.h thread.h
-libpmisis_la_CFLAGS = -I$(srcdir)/.. $(AM_CFLAGS)
+libpmisis_la_CFLAGS = -I$(srcdir)/.. $(AM_CFLAGS) -Wno-error=pointer-sign

--- a/src/isis/isis.c
+++ b/src/isis/isis.c
@@ -236,7 +236,6 @@ void isis_pdu_runner(u_char *user, const struct pcap_pkthdr *pkthdr, const u_cha
   struct pcap_device *device = cb_data->device;
   struct isis_circuit *circuit = cb_data->circuit;
   struct packet_ptrs pptrs;
-  struct thread thread;
   int ret;
 
   struct stream stm;
@@ -290,6 +289,7 @@ void isis_pdu_runner(u_char *user, const struct pcap_pkthdr *pkthdr, const u_cha
     if (circuit->area->is_type & IS_LEVEL_2) {
       if (circuit->area->ip_circuits) {
 	ret = isis_run_spf(circuit->area, 2, AF_INET);
+        (void)ret; //TODO treat error
 	isis_route_validate_table (circuit->area, circuit->area->route_table[1]);
       }
       /* XXX: IPv6 handled here */
@@ -325,6 +325,7 @@ void isis_sll_handler(const struct pcap_pkthdr *h, register struct packet_ptrs *
   }
 
   p = pptrs->packet_ptr;
+  (void)p; //TODO treat error
 
   sllp = (const struct sll_header *) pptrs->packet_ptr;
   etype = ntohs(sllp->sll_protocol);
@@ -469,7 +470,7 @@ int igp_daemon_map_adj_metric_handler(char *filename, struct id_entry *e, char *
 {
   struct igp_map_entry *entry = (struct igp_map_entry *) req->key_value_table;
   char *str_ptr, *token, *sep, *ip_str, *metric_str, *endptr;
-  int idx = 0, debug_idx;
+  int idx = 0;
   
   str_ptr = strdup(value);
   if (!str_ptr) {
@@ -520,7 +521,7 @@ int igp_daemon_map_reach_metric_handler(char *filename, struct id_entry *e, char
 {
   struct igp_map_entry *entry = (struct igp_map_entry *) req->key_value_table;
   char *str_ptr, *token, *sep, *ip_str, *metric_str, *endptr;
-  int idx = 0, debug_idx;
+  int idx = 0;
 
   str_ptr = strdup(value);
   if (!str_ptr) {
@@ -571,7 +572,7 @@ int igp_daemon_map_reach6_metric_handler(char *filename, struct id_entry *e, cha
 {
   struct igp_map_entry *entry = (struct igp_map_entry *) req->key_value_table;
   char *str_ptr, *token, *sep, *ip_str, *metric_str, *endptr;
-  int idx = 0, debug_idx;
+  int idx = 0;
 
   str_ptr = strdup(value);
   if (!str_ptr) {

--- a/src/isis/isis.h
+++ b/src/isis/isis.h
@@ -40,7 +40,7 @@
 #define ERRNO_IO_RETRY(EN) (((EN) == EAGAIN) || ((EN) == EWOULDBLOCK) || ((EN) == EINTR))
 
 /* structures */
-static struct _devices_struct _isis_devices[] = {
+static struct _devices_struct __attribute__((unused))  _isis_devices[] = {
 #if defined DLT_LINUX_SLL
   {isis_sll_handler, DLT_LINUX_SLL},
 #endif

--- a/src/isis/isis_adjacency.c
+++ b/src/isis/isis_adjacency.c
@@ -58,7 +58,6 @@ isis_new_adj (u_char * id, u_char * snpa, int level,
 	      struct isis_circuit *circuit)
 {
   struct isis_adjacency *adj;
-  int i;
 
   adj = adj_alloc (id);		/* P2P kludge */
 
@@ -133,7 +132,6 @@ isis_adj_state_change (struct isis_adjacency *adj, enum isis_adj_state state,
 		       const char *reason)
 {
   int old_state;
-  int level = adj->level;
   struct isis_circuit *circuit;
 
   old_state = adj->adj_state;
@@ -165,13 +163,11 @@ isis_adj_state_change (struct isis_adjacency *adj, enum isis_adj_state state,
 int
 isis_adj_expire (struct isis_adjacency *adj)
 {
-  int level;
 
   /*
    * Get the adjacency
    */
   assert (adj);
-  level = adj->level;
   memset(&adj->expire, 0, sizeof(struct timeval));
 
   /* trigger the adj expire event */

--- a/src/isis/isis_events.c
+++ b/src/isis/isis_events.c
@@ -146,8 +146,6 @@ circuit_commence_level (struct isis_circuit *circuit, int level)
 static void
 circuit_resign_level (struct isis_circuit *circuit, int level)
 {
-  int idx = level - 1;
-
 //  THREAD_TIMER_OFF (circuit->t_send_csnp[idx]);
 //  THREAD_TIMER_OFF (circuit->t_send_psnp[idx]);
 

--- a/src/isis/isis_lsp.c
+++ b/src/isis/isis_lsp.c
@@ -376,6 +376,7 @@ lsp_update_data (struct isis_lsp *lsp, struct stream *stream,
 		       ISIS_FIXED_HDR_LEN + ISIS_LSP_HDR_LEN,
 		       ntohs (lsp->lsp_header->pdu_len) - ISIS_FIXED_HDR_LEN
 		       - ISIS_LSP_HDR_LEN, &expected, &found, &lsp->tlv_data);
+  (void)retval; //TODO treat error
 
   if (found & TLVFLAG_DYN_HOSTNAME)
     {

--- a/src/isis/isis_pdu.c
+++ b/src/isis/isis_pdu.c
@@ -893,9 +893,7 @@ process_snp (int snp_type, int level, struct isis_circuit *circuit,
 {
   int retval = ISIS_OK;
   int cmp, own_lsp;
-  char typechar = ' ';
   int len;
-  struct isis_adjacency *adj;
   struct isis_complete_seqnum_hdr *chdr = NULL;
   struct isis_partial_seqnum_hdr *phdr = NULL;
   uint32_t found = 0, expected = 0;
@@ -910,7 +908,6 @@ process_snp (int snp_type, int level, struct isis_circuit *circuit,
   if (snp_type == ISIS_SNP_CSNP_FLAG)
     {
       /* getting the header info */
-      typechar = 'C';
       chdr =
 	(struct isis_complete_seqnum_hdr *) STREAM_PNT (circuit->rcv_stream);
       circuit->rcv_stream->getp += ISIS_CSNP_HDRLEN;
@@ -923,7 +920,6 @@ process_snp (int snp_type, int level, struct isis_circuit *circuit,
     }
   else
     {
-      typechar = 'P';
       phdr =
 	(struct isis_partial_seqnum_hdr *) STREAM_PNT (circuit->rcv_stream);
       circuit->rcv_stream->getp += ISIS_PSNP_HDRLEN;
@@ -1568,6 +1564,7 @@ int isis_send_pdu_p2p (struct isis_circuit *circuit, int level)
                     stream_get_endp (circuit->snd_stream), 0,
                     (struct sockaddr *) &sa,
                     sizeof (struct sockaddr_ll));
+  (void)written; //TODO treat error?
 
   return ISIS_OK;
 }

--- a/src/isis/isis_spf.c
+++ b/src/isis/isis_spf.c
@@ -731,17 +731,12 @@ static int
 isis_spf_preload_tent (struct isis_spftree *spftree,
 		       struct isis_area *area, int level, int family)
 {
-  struct isis_vertex *vertex;
   struct isis_circuit *circuit;
-  struct listnode *cnode, *anode, *ipnode;
+  struct listnode *cnode, *ipnode;
   struct isis_adjacency *adj;
-  struct isis_lsp *lsp;
-  struct list *adj_list;
-  struct list *adjdb;
   struct prefix_ipv4 *ipv4;
   struct isis_prefix prefix;
   int retval = ISIS_OK;
-  u_char lsp_id[ISIS_SYS_ID_LEN + 2];
   struct prefix_ipv6 *ipv6;
 
   for (ALL_LIST_ELEMENTS_RO (area->circuit_list, cnode, circuit))

--- a/src/isis/isis_tlv.c
+++ b/src/isis/isis_tlv.c
@@ -115,7 +115,6 @@ parse_tlvs (char *areatag, u_char * stream, int size, u_int32_t * expected,
   struct in6_addr *ipv6_addr;
   struct ipv6_reachability *ipv6_reach;
   int prefix_octets;
-  u_char virtual;
   int value_len, retval = ISIS_OK;
   u_char *pnt = stream;
 
@@ -172,7 +171,6 @@ parse_tlvs (char *areatag, u_char * stream, int size, u_int32_t * expected,
 	       * |                        Virtual Flag                           | 
 	       * +-------+-------+-------+-------+-------+-------+-------+-------+
 	       */
-	      virtual = *pnt;	/* FIXME: what is the use for this? */
 	      pnt++;
 	      value_len++;
 	      /* +-------+-------+-------+-------+-------+-------+-------+-------+

--- a/src/jhash.h
+++ b/src/jhash.h
@@ -41,7 +41,7 @@
  * of bytes.  No alignment or length assumptions are made about
  * the input key.
  */
-Inline u_int32_t jhash(void *key, u_int32_t length, u_int32_t initval)
+static inline u_int32_t jhash(void *key, u_int32_t length, u_int32_t initval)
 {
 	u_int32_t a, b, c, len;
 	u_int8_t *k = key;
@@ -84,7 +84,7 @@ Inline u_int32_t jhash(void *key, u_int32_t length, u_int32_t initval)
 /* A special optimized version that handles 1 or more of u_int32_ts.
  * The length parameter here is the number of u_int32_ts in the key.
  */
-Inline u_int32_t jhash2(u_int32_t *k, u_int32_t length, u_int32_t initval)
+static inline u_int32_t jhash2(u_int32_t *k, u_int32_t length, u_int32_t initval)
 {
 	u_int32_t a, b, c, len;
 
@@ -119,7 +119,7 @@ Inline u_int32_t jhash2(u_int32_t *k, u_int32_t length, u_int32_t initval)
  * NOTE: In partilar the "c += length; __jhash_mix(a,b,c);" normally
  *       done at the end is not done here.
  */
-Inline u_int32_t jhash_3words(u_int32_t a, u_int32_t b, u_int32_t c, u_int32_t initval)
+static inline u_int32_t jhash_3words(u_int32_t a, u_int32_t b, u_int32_t c, u_int32_t initval)
 {
 	a += JHASH_GOLDEN_RATIO;
 	b += JHASH_GOLDEN_RATIO;
@@ -130,12 +130,12 @@ Inline u_int32_t jhash_3words(u_int32_t a, u_int32_t b, u_int32_t c, u_int32_t i
 	return c;
 }
 
-Inline u_int32_t jhash_2words(u_int32_t a, u_int32_t b, u_int32_t initval)
+static inline u_int32_t jhash_2words(u_int32_t a, u_int32_t b, u_int32_t initval)
 {
 	return jhash_3words(a, b, 0, initval);
 }
 
-Inline u_int32_t jhash_1word(u_int32_t a, u_int32_t initval)
+static inline u_int32_t jhash_1word(u_int32_t a, u_int32_t initval)
 {
 	return jhash_3words(a, 0, 0, initval);
 }

--- a/src/ll.c
+++ b/src/ll.c
@@ -344,7 +344,6 @@ void null_handler(const struct pcap_pkthdr *h, register struct packet_ptrs *pptr
 {
   register u_int32_t *family;
   u_int caplen = h->caplen;
-  u_char *p;
 
   if (caplen < 4) {
     pptrs->iph_ptr = NULL;
@@ -352,7 +351,6 @@ void null_handler(const struct pcap_pkthdr *h, register struct packet_ptrs *pptr
   }
 
   family = (u_int32_t *) pptrs->packet_ptr;
-  p = pptrs->packet_ptr;
 
   if (*family == AF_INET || ntohl(*family) == AF_INET ) {
     pptrs->l3_proto = ETHERTYPE_IP;

--- a/src/mysql_plugin.c
+++ b/src/mysql_plugin.c
@@ -22,6 +22,7 @@
 #define __MYSQL_PLUGIN_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "pmacct-data.h"
 #include "plugin_hooks.h"
@@ -196,7 +197,7 @@ void mysql_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 	  else {
 	    rg_err_count++;
 	    if (config.debug || (rg_err_count > MAX_RG_COUNT_ERR)) {
-              Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%llu plugin_pipe_size=%llu).\n",
+              Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%" PRIu64 " plugin_pipe_size=%" PRIu64 ").\n",
                         config.name, config.type, config.buffer_size, config.pipe_size);
               Log(LOG_WARNING, "WARN ( %s/%s ): Increase values or look for plugin_buffer_size, plugin_pipe_size in CONFIG-KEYS document.\n\n",
                         config.name, config.type);
@@ -229,7 +230,7 @@ void mysql_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
       data = (struct pkt_data *) (pipebuf+sizeof(struct ch_buf_hdr));
 
       if (config.debug_internal_msg) 
-        Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%llu seq=%u num_entries=%u\n",
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%" PRIu64 " seq=%u num_entries=%u\n",
                 config.name, config.type, ((struct ch_buf_hdr *)pipebuf)->len, seq,
                 ((struct ch_buf_hdr *)pipebuf)->num);
 
@@ -326,8 +327,8 @@ int MY_cache_dbop(struct DBdesc *db, struct db_cache *cache_elem, struct insert_
       strncpy(insert_full_clause, insert_clause, SPACELEFT(insert_full_clause));
       strncat(insert_full_clause, insert_counters_clause, SPACELEFT(insert_full_clause));
 #if defined HAVE_64BIT_COUNTERS
-      if (have_flows) snprintf(ptr_values, SPACELEFT(values_clause), ", %llu, %llu, %llu)", cache_elem->packet_counter, cache_elem->bytes_counter, cache_elem->flows_counter);
-      else snprintf(ptr_values, SPACELEFT(values_clause), ", %llu, %llu)", cache_elem->packet_counter, cache_elem->bytes_counter);
+      if (have_flows) snprintf(ptr_values, SPACELEFT(values_clause), ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ")", cache_elem->packet_counter, cache_elem->bytes_counter, cache_elem->flows_counter);
+      else snprintf(ptr_values, SPACELEFT(values_clause), ", %" PRIu64 ", %" PRIu64 ")", cache_elem->packet_counter, cache_elem->bytes_counter);
 #else
       if (have_flows) snprintf(ptr_values, SPACELEFT(values_clause), ", %lu, %lu, %lu)", cache_elem->packet_counter, cache_elem->bytes_counter, cache_elem->flows_counter);
       else snprintf(ptr_values, SPACELEFT(values_clause), ", %lu, %lu)", cache_elem->packet_counter, cache_elem->bytes_counter);

--- a/src/mysql_plugin.c
+++ b/src/mysql_plugin.c
@@ -22,7 +22,6 @@
 #define __MYSQL_PLUGIN_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "pmacct-data.h"
 #include "plugin_hooks.h"

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -105,7 +105,7 @@ int main(int argc,char **argv, char **envp)
   struct packet_ptrs_vector pptrs;
   char config_file[SRVBUFLEN];
   unsigned char *netflow_packet;
-  int logf, rc, yes=1, no=0, allowed;
+  int logf, rc, yes=1, allowed;
   struct host_addr addr;
   struct hosts_table allow;
   struct id_table bpas_table;
@@ -116,7 +116,7 @@ int main(int argc,char **argv, char **envp)
   struct id_table bitr_table;
   struct id_table sampling_table;
   u_int32_t idx;
-  int pipe_fd = 0, ret;
+  int ret;
   int capture_methods = 0;
 
   struct sockaddr_storage server, client;
@@ -633,6 +633,7 @@ int main(int argc,char **argv, char **envp)
 
 #ifdef WITH_ZMQ
   else if (config.nfacctd_zmq_address) {
+    int pipe_fd = 0;
     NF_init_zmq_host(&nfacctd_zmq_host, &pipe_fd);
     recv_pptrs.pkthdr = &recv_pkthdr;
 

--- a/src/nfacctd.h
+++ b/src/nfacctd.h
@@ -311,7 +311,7 @@ struct data_hdr_v9 {
 /* CUSTOM TYPES END HERE */
 
 #define MAX_TPL_DESC_LIST 89
-static char *tpl_desc_list[] = {
+static char __attribute__((unused)) *tpl_desc_list[] = {
   "",
   "in bytes",
   "in packets",
@@ -383,7 +383,7 @@ static char *tpl_desc_list[] = {
 };
 
 #define MAX_OPT_TPL_DESC_LIST 100
-static char *opt_tpl_desc_list[] = {
+static char __attribute__((unused)) *opt_tpl_desc_list[] = {
   "",
   "scope", "", "",
   "", "", "",

--- a/src/nfprobe_plugin/common.h
+++ b/src/nfprobe_plugin/common.h
@@ -62,9 +62,6 @@
 #elif defined(HAVE_PCAP_BPF_H)
 #include <pcap-bpf.h>
 #endif
-#if defined(HAVE_INTTYPES_H)
-#include <inttypes.h>
-#endif
 
 /* The name of the program */
 // #define PROGNAME		"softflowd"

--- a/src/nl.c
+++ b/src/nl.c
@@ -623,8 +623,6 @@ int gtp_tunnel_func(register struct packet_ptrs *pptrs)
 {
   register u_int16_t caplen = ((struct pcap_pkthdr *)pptrs->pkthdr)->caplen;
   struct pm_gtphdr_v0 *gtp_hdr_v0 = (struct pm_gtphdr_v0 *) pptrs->payload_ptr;
-  struct pm_gtphdr_v1 *gtp_hdr_v1 = (struct pm_gtphdr_v1 *) pptrs->payload_ptr;
-  struct pm_udphdr *udp_hdr = (struct pm_udphdr *) pptrs->tlh_ptr;
   u_int16_t off = pptrs->payload_ptr-pptrs->packet_ptr;
   u_int16_t gtp_hdr_len, gtp_version;
   u_char *ptr = pptrs->payload_ptr;

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -1010,7 +1010,6 @@ void etype_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs,
 
 void mpls_label_top_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
   u_int32_t *label = (u_int32_t *) pptrs->mpls_ptr;
 
@@ -1019,7 +1018,6 @@ void mpls_label_top_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void mpls_label_bottom_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
   u_int32_t lvalue = 0, *label = (u_int32_t *) pptrs->mpls_ptr;
 
@@ -1035,7 +1033,6 @@ void mpls_label_bottom_handler(struct channels_list_entry *chptr, struct packet_
 
 void mpls_stack_depth_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
   u_int32_t lvalue = 0, *label = (u_int32_t *) pptrs->mpls_ptr;
 
@@ -1072,8 +1069,6 @@ void bgp_dst_nmask_handler(struct channels_list_entry *chptr, struct packet_ptrs
 
 void bgp_peer_dst_ip_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
-  struct bgp_node *ret = (struct bgp_node *) pptrs->bgp_dst;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
   struct bgp_info *nh_info = NULL;
 
@@ -1125,7 +1120,6 @@ void igp_dst_nmask_handler(struct channels_list_entry *chptr, struct packet_ptrs
 
 void igp_peer_dst_ip_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct route_node *ret = (struct route_node *) pptrs->igp_dst;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
@@ -1215,7 +1209,6 @@ void tcp_flags_handler(struct channels_list_entry *chptr, struct packet_ptrs *pp
 
 void tunnel_src_mac_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1226,7 +1219,6 @@ void tunnel_src_mac_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void tunnel_dst_mac_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1237,7 +1229,6 @@ void tunnel_dst_mac_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void tunnel_src_host_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1255,7 +1246,6 @@ void tunnel_src_host_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void tunnel_dst_host_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1273,7 +1263,6 @@ void tunnel_dst_host_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void tunnel_ip_proto_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1282,7 +1271,6 @@ void tunnel_ip_proto_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void tunnel_ip_tos_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
   u_int32_t tos = 0;
@@ -1301,7 +1289,6 @@ void tunnel_ip_tos_handler(struct channels_list_entry *chptr, struct packet_ptrs
 
 void tunnel_src_port_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1316,7 +1303,6 @@ void tunnel_src_port_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void tunnel_dst_port_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   struct packet_ptrs *tpptrs = (struct packet_ptrs *) pptrs->tun_pptrs;
 
@@ -1329,7 +1315,6 @@ void tunnel_dst_port_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void vxlan_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   u_char *vni_ptr;
 
@@ -1654,7 +1639,6 @@ void sampling_direction_handler(struct channels_list_entry *chptr, struct packet
 
 void mpls_vpn_rd_frommap_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
   if (pbgp && pptrs->bitr) memcpy(&pbgp->mpls_vpn_rd, &pptrs->bitr, sizeof(rd_t));
@@ -1662,7 +1646,6 @@ void mpls_vpn_rd_frommap_handler(struct channels_list_entry *chptr, struct packe
 
 void timestamp_start_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
 
   pnat->timestamp_start.tv_sec = ((struct pcap_pkthdr *)pptrs->pkthdr)->ts.tv_sec;
@@ -1673,7 +1656,6 @@ void timestamp_start_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void timestamp_arrival_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
 
   pnat->timestamp_arrival.tv_sec = ((struct pcap_pkthdr *)pptrs->pkthdr)->ts.tv_sec;
@@ -1684,7 +1666,6 @@ void timestamp_arrival_handler(struct channels_list_entry *chptr, struct packet_
 
 void custom_primitives_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   u_char *pcust = (u_char *)((*data) + chptr->extras.off_custom_primitives);
   struct pkt_vlen_hdr_primitives *pvlen = (struct pkt_vlen_hdr_primitives *) ((*data) + chptr->extras.off_pkt_vlen_hdr_primitives);
   struct custom_primitive_entry *cpe;
@@ -2106,7 +2087,6 @@ void NF_dst_as_handler(struct channels_list_entry *chptr, struct packet_ptrs *pp
 
 void NF_peer_src_as_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
@@ -2135,7 +2115,6 @@ void NF_peer_src_as_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void NF_peer_dst_as_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
@@ -2165,7 +2144,6 @@ void NF_peer_dst_as_handler(struct channels_list_entry *chptr, struct packet_ptr
 void NF_peer_src_ip_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
   struct xflow_status_entry *entry = (struct xflow_status_entry *) pptrs->f_status;
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
@@ -2206,7 +2184,6 @@ void NF_peer_src_ip_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void NF_peer_dst_ip_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp;
@@ -2695,8 +2672,6 @@ void NF_time_secs_handler(struct channels_list_entry *chptr, struct packet_ptrs 
 void NF_time_new_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
   struct pkt_data *pdata = (struct pkt_data *) *data;
-  struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
-  struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
 
   pdata->time_start.tv_sec = 0;
   pdata->time_start.tv_usec = 0;
@@ -2923,6 +2898,7 @@ void NF_sampling_rate_handler(struct channels_list_entry *chptr, struct packet_p
       break;
     case 5:
       is_sampled = ( ntohs(hdr->sampling) & 0xC000 );
+      (void)is_sampled; //TODO do something?
       srate = ( ntohs(hdr->sampling) & 0x3FFF );
       if (srate) pdata->primitives.sampling_rate = srate;
       break;
@@ -2972,7 +2948,6 @@ void NF_sampling_direction_handler(struct channels_list_entry *chptr, struct pac
 
 void NF_timestamp_start_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3064,7 +3039,6 @@ void NF_timestamp_start_handler(struct channels_list_entry *chptr, struct packet
 
 void NF_timestamp_end_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3136,9 +3110,6 @@ void NF_timestamp_end_handler(struct channels_list_entry *chptr, struct packet_p
 
 void NF_timestamp_arrival_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
-  struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
-  struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
 
   gettimeofday(&pnat->timestamp_arrival, NULL);
@@ -3196,7 +3167,6 @@ void NF_sysid_handler(struct channels_list_entry *chptr, struct packet_ptrs *ppt
 
 void NF_custom_primitives_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct utpl_field *utpl = NULL;
@@ -3275,7 +3245,6 @@ void NF_custom_primitives_handler(struct channels_list_entry *chptr, struct pack
 
 void NF_post_nat_src_host_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3302,7 +3271,6 @@ void NF_post_nat_src_host_handler(struct channels_list_entry *chptr, struct pack
 
 void NF_post_nat_dst_host_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3329,7 +3297,6 @@ void NF_post_nat_dst_host_handler(struct channels_list_entry *chptr, struct pack
 
 void NF_post_nat_src_port_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3356,7 +3323,6 @@ void NF_post_nat_src_port_handler(struct channels_list_entry *chptr, struct pack
 
 void NF_post_nat_dst_port_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3383,7 +3349,6 @@ void NF_post_nat_dst_port_handler(struct channels_list_entry *chptr, struct pack
 
 void NF_nat_event_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
@@ -3404,7 +3369,6 @@ void NF_nat_event_handler(struct channels_list_entry *chptr, struct packet_ptrs 
 
 void NF_mpls_label_top_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
@@ -3425,7 +3389,6 @@ void NF_mpls_label_top_handler(struct channels_list_entry *chptr, struct packet_
 
 void NF_mpls_label_bottom_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
@@ -3454,7 +3417,6 @@ void NF_mpls_label_bottom_handler(struct channels_list_entry *chptr, struct pack
 
 void NF_mpls_stack_depth_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
@@ -3489,7 +3451,6 @@ void NF_mpls_stack_depth_handler(struct channels_list_entry *chptr, struct packe
 
 void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives); 
@@ -3520,7 +3481,6 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void NF_mpls_pw_id_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives); 
@@ -3541,7 +3501,6 @@ void NF_mpls_pw_id_handler(struct channels_list_entry *chptr, struct packet_ptrs
 
 void NF_vxlan_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
@@ -3770,6 +3729,7 @@ void NF_counters_renormalize_handler(struct channels_list_entry *chptr, struct p
     break;
   case 5:
     is_sampled = ( ntohs(hdr->sampling) & 0xC000 );
+    (void)is_sampled;
     srate = ( ntohs(hdr->sampling) & 0x3FFF );
     /* XXX: checking srate value instead of is_sampled as Sampling
        Mode seems not to be a mandatory field. */
@@ -4464,7 +4424,6 @@ void nfprobe_bgp_ext_handler(struct channels_list_entry *chptr, struct packet_pt
 
 void bgp_peer_src_as_frommap_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
   struct bgp_node *src_ret = (struct bgp_node *) pptrs->bgp_src;
   struct bgp_info *info = NULL;
@@ -4502,7 +4461,6 @@ void bgp_peer_src_as_frommap_handler(struct channels_list_entry *chptr, struct p
 
 void bgp_src_local_pref_frommap_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
   pbgp->src_local_pref = pptrs->blp;
@@ -4510,7 +4468,6 @@ void bgp_src_local_pref_frommap_handler(struct channels_list_entry *chptr, struc
 
 void bgp_src_med_frommap_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
   pbgp->src_med = pptrs->bmed;
@@ -4665,8 +4622,6 @@ void SF_tcp_flags_handler(struct channels_list_entry *chptr, struct packet_ptrs 
 void SF_flows_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
   struct pkt_data *pdata = (struct pkt_data *) *data;
-  SFSample *sample = (SFSample *) pptrs->f_data;
-
   pdata->flo_num = 1;
 }
 
@@ -4805,7 +4760,6 @@ void SF_dst_as_handler(struct channels_list_entry *chptr, struct packet_ptrs *pp
 
 void SF_as_path_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
   struct pkt_legacy_bgp_primitives *plbgp = (struct pkt_legacy_bgp_primitives *) ((*data) + chptr->extras.off_pkt_lbgp_primitives);
   struct pkt_vlen_hdr_primitives *pvlen = (struct pkt_vlen_hdr_primitives *) ((*data) + chptr->extras.off_pkt_vlen_hdr_primitives);
@@ -4861,7 +4815,6 @@ void SF_as_path_handler(struct channels_list_entry *chptr, struct packet_ptrs *p
 
 void SF_peer_src_as_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
@@ -4873,7 +4826,6 @@ void SF_peer_src_as_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void SF_peer_dst_as_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
@@ -4885,7 +4837,6 @@ void SF_peer_dst_as_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void SF_local_pref_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
@@ -4897,7 +4848,6 @@ void SF_local_pref_handler(struct channels_list_entry *chptr, struct packet_ptrs
 
 void SF_std_comms_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
   struct pkt_legacy_bgp_primitives *plbgp = (struct pkt_legacy_bgp_primitives *) ((*data) + chptr->extras.off_pkt_lbgp_primitives);
   struct pkt_vlen_hdr_primitives *pvlen = (struct pkt_vlen_hdr_primitives *) ((*data) + chptr->extras.off_pkt_vlen_hdr_primitives);
@@ -4955,7 +4905,6 @@ void SF_std_comms_handler(struct channels_list_entry *chptr, struct packet_ptrs 
 
 void SF_peer_src_ip_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data;
 
@@ -4971,7 +4920,6 @@ void SF_peer_src_ip_handler(struct channels_list_entry *chptr, struct packet_ptr
 
 void SF_peer_dst_ip_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
   struct pkt_bgp_primitives *pbgp;
   int use_ip_next_hop = FALSE;
@@ -5066,9 +5014,7 @@ void SF_sampling_direction_handler(struct channels_list_entry *chptr, struct pac
 
 void SF_timestamp_start_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
-  SFSample *sample = (SFSample *) pptrs->f_data;
 
   gettimeofday(&pnat->timestamp_start, NULL);
   if (chptr->plugin->cfg.timestamps_secs) pnat->timestamp_start.tv_usec = 0;
@@ -5076,9 +5022,7 @@ void SF_timestamp_start_handler(struct channels_list_entry *chptr, struct packet
 
 void SF_timestamp_arrival_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_nat_primitives *pnat = (struct pkt_nat_primitives *) ((*data) + chptr->extras.off_pkt_nat_primitives);
-  SFSample *sample = (SFSample *) pptrs->f_data;
 
   gettimeofday(&pnat->timestamp_arrival, NULL);
   if (chptr->plugin->cfg.timestamps_secs) pnat->timestamp_arrival.tv_usec = 0;
@@ -5165,7 +5109,6 @@ void sfprobe_sampling_handler(struct channels_list_entry *chptr, struct packet_p
 
 void SF_bgp_peer_src_as_fromstd_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
   pbgp->peer_src_as = 0;
@@ -5175,7 +5118,6 @@ void SF_bgp_peer_src_as_fromstd_handler(struct channels_list_entry *chptr, struc
 
 void SF_bgp_peer_src_as_fromext_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
   pbgp->peer_src_as = 0;
@@ -5185,7 +5127,6 @@ void SF_bgp_peer_src_as_fromext_handler(struct channels_list_entry *chptr, struc
 
 void SF_tunnel_src_mac_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5194,7 +5135,6 @@ void SF_tunnel_src_mac_handler(struct channels_list_entry *chptr, struct packet_
 
 void SF_tunnel_dst_mac_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5203,7 +5143,6 @@ void SF_tunnel_dst_mac_handler(struct channels_list_entry *chptr, struct packet_
 
 void SF_tunnel_src_host_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5223,7 +5162,6 @@ void SF_tunnel_src_host_handler(struct channels_list_entry *chptr, struct packet
 
 void SF_tunnel_dst_host_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5243,7 +5181,6 @@ void SF_tunnel_dst_host_handler(struct channels_list_entry *chptr, struct packet
 
 void SF_tunnel_ip_proto_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5252,7 +5189,6 @@ void SF_tunnel_ip_proto_handler(struct channels_list_entry *chptr, struct packet
 
 void SF_tunnel_ip_tos_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5261,7 +5197,6 @@ void SF_tunnel_ip_tos_handler(struct channels_list_entry *chptr, struct packet_p
 
 void SF_tunnel_src_port_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5276,7 +5211,6 @@ void SF_tunnel_src_port_handler(struct channels_list_entry *chptr, struct packet
 
 void SF_tunnel_dst_port_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data, *sppi = (SFSample *) sample->sppi;
 
@@ -5291,7 +5225,6 @@ void SF_tunnel_dst_port_handler(struct channels_list_entry *chptr, struct packet
 
 void SF_vxlan_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_tunnel_primitives *ptun = (struct pkt_tunnel_primitives *) ((*data) + chptr->extras.off_pkt_tun_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data;
 
@@ -5300,7 +5233,6 @@ void SF_vxlan_handler(struct channels_list_entry *chptr, struct packet_ptrs *ppt
 
 void SF_mpls_pw_id_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data;
 
@@ -5309,7 +5241,6 @@ void SF_mpls_pw_id_handler(struct channels_list_entry *chptr, struct packet_ptrs
 
 void SF_mpls_label_top_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data;
   u_int32_t *label = (u_int32_t *) sample->lstk.stack;
@@ -5319,7 +5250,6 @@ void SF_mpls_label_top_handler(struct channels_list_entry *chptr, struct packet_
 
 void SF_mpls_label_bottom_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data;
   u_int32_t lvalue = 0, *label = (u_int32_t *) sample->lstk.stack;
@@ -5336,7 +5266,6 @@ void SF_mpls_label_bottom_handler(struct channels_list_entry *chptr, struct pack
 
 void SF_mpls_stack_depth_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
   SFSample *sample = (SFSample *) pptrs->f_data;
   u_int32_t lvalue = 0, *label = (u_int32_t *) sample->lstk.stack;
@@ -5354,7 +5283,6 @@ void SF_mpls_stack_depth_handler(struct channels_list_entry *chptr, struct packe
 
 void SF_custom_primitives_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   SFSample *sample = (SFSample *) pptrs->f_data;
 
   custom_primitives_handler(chptr, &sample->hdr_ptrs, data);
@@ -5492,7 +5420,6 @@ void dst_host_geoipv2_lookup_handler(struct channels_list_entry *chptr, struct p
 
 void src_host_country_geoipv2_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct pkt_data *pdata = (struct pkt_data *) *data;
   MMDB_entry_data_list_s *entry_data_list = NULL;
   char other_country[] = "O1";
   int status;

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -22,7 +22,6 @@
 #define __PLUGIN_COMMON_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #include "pmacct-data.h"

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -22,6 +22,7 @@
 #define __PLUGIN_COMMON_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #include "pmacct-data.h"
@@ -86,7 +87,7 @@ void P_init_default_values()
   sa.num = config.print_cache_entries*AVERAGE_CHAIN_LEN;
   sa.size = sa.num*dbc_size;
 
-  Log(LOG_INFO, "INFO ( %s/%s ): cache entries=%d base cache memory=%llu bytes\n", config.name, config.type,
+  Log(LOG_INFO, "INFO ( %s/%s ): cache entries=%d base cache memory=%" PRIu64 " bytes\n", config.name, config.type,
 	config.print_cache_entries, ((config.print_cache_entries * dbc_size) + (2 * ((sa.num +
 	config.print_cache_entries) * sizeof(struct chained_cache *))) + sa.size));
 

--- a/src/plugin_hooks.c
+++ b/src/plugin_hooks.c
@@ -22,6 +22,7 @@
 #define __PLUGIN_HOOKS_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "pmacct-data.h"
 #include "thread_pool.h"
@@ -47,12 +48,12 @@ void load_plugins(struct plugin_requests *req)
   socklen_t l = sizeof(list->cfg.pipe_size);
   struct channels_list_entry *chptr = NULL;
 
-  char username[SHORTBUFLEN], password[SHORTBUFLEN];
  
   init_random_seed(); 
   init_pipe_channels();
  
 #ifdef WITH_ZMQ
+  char username[SHORTBUFLEN], password[SHORTBUFLEN];
   memset(username, 0, sizeof(username));
   memset(password, 0, sizeof(password));
 
@@ -153,7 +154,7 @@ void load_plugins(struct plugin_requests *req)
         }
 
         if (list->cfg.debug || (list->cfg.pipe_size > WARNING_PIPE_SIZE)) {
-	  Log(LOG_INFO, "INFO ( %s/%s ): plugin_pipe_size=%llu bytes plugin_buffer_size=%llu bytes\n", 
+	  Log(LOG_INFO, "INFO ( %s/%s ): plugin_pipe_size=%" PRIu64 " bytes plugin_buffer_size=%" PRIu64 " bytes\n", 
 		list->name, list->type.string, list->cfg.pipe_size, list->cfg.buffer_size);
 	  if (target_buflen <= snd_buflen) 
             Log(LOG_INFO, "INFO ( %s/%s ): ctrl channel: obtained=%d bytes target=%d bytes\n",
@@ -356,7 +357,7 @@ void exec_plugins(struct packet_ptrs *pptrs, struct plugin_requests *req)
   pm_id_t saved_tag = 0, saved_tag2 = 0;
   pt_label_t saved_label;
 
-  int num, ret, fixed_size;
+  int num, fixed_size;
   u_int32_t savedptr;
   char *bptr;
   int index, got_tags = FALSE;
@@ -487,7 +488,7 @@ reprocess:
 
         if (config.debug_internal_msg) {
 	  struct plugins_list_entry *list = channels_list[index].plugin;
-	  Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer released len=%llu seq=%u num_entries=%u off=%llu\n",
+	  Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer released len=%" PRIu64 " seq=%u num_entries=%u off=%" PRIu64 "\n",
 		list->name, list->type.string, channels_list[index].bufptr, channels_list[index].hdr.seq,
 		channels_list[index].hdr.num, channels_list[index].status->last_buf_off);
 	}
@@ -497,7 +498,8 @@ reprocess:
 #ifdef WITH_ZMQ
           struct channels_list_entry *chptr = &channels_list[index];
 
-	  ret = p_zmq_topic_send(&chptr->zmq_host, chptr->rg.ptr, chptr->bufsize);
+	  int ret = p_zmq_topic_send(&chptr->zmq_host, chptr->rg.ptr, chptr->bufsize);
+          (void)ret; //Check error?
 #endif
 	}
 	else {

--- a/src/plugin_hooks.c
+++ b/src/plugin_hooks.c
@@ -22,7 +22,6 @@
 #define __PLUGIN_HOOKS_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "pmacct-data.h"
 #include "thread_pool.h"

--- a/src/pmacct-data.h
+++ b/src/pmacct-data.h
@@ -274,7 +274,7 @@ static const struct _protocols_struct _protocols[] = {
 };
 
 /* cps = custom primitive semantics */
-static const char *cps_type[] = {
+static const char __attribute__((unused)) *cps_type[] = {
   "",
   "u",
   "x",
@@ -284,7 +284,7 @@ static const char *cps_type[] = {
   "s"
 };
 
-static const int cps_flen[] = {
+static const int __attribute__((unused)) cps_flen[] = {
   0,
   3,
   5,
@@ -296,14 +296,14 @@ static const int cps_flen[] = {
   20
 };
 
-static const char *bgp_origin[] = {
+static const char __attribute__((unused)) *bgp_origin[] = {
   "i",
   "e",
   "u",
   ""
 };
 
-static const char *rpki_roa[] = {
+static const char __attribute__((unused)) *rpki_roa[] = {
   "u",
   "i",
   "v",

--- a/src/pmacct.c
+++ b/src/pmacct.c
@@ -24,7 +24,6 @@
 #include <time.h>
 
 /* include */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "pmacct-data.h"
 #include "addr.h"

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -30,6 +30,7 @@
 #include <pcap.h>
 #endif
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/pmacctd.c
+++ b/src/pmacctd.c
@@ -188,9 +188,7 @@ err:
 void pm_pcap_add_filter(struct pcap_device *dev_ptr)
 {
   /* pcap library stuff */
-  bpf_u_int32 localnet, netmask;
   struct bpf_program filter;
-  char errbuf[PCAP_ERRBUF_SIZE];
 
   memset(&filter, 0, sizeof(filter));
   if (pcap_compile(dev_ptr->dev_desc, &filter, config.clbuf, 0, PCAP_NETMASK_UNKNOWN) < 0) {
@@ -1230,6 +1228,7 @@ int main(int argc,char **argv, char **envp)
       memcpy(&read_descs, &bkp_read_descs, sizeof(bkp_read_descs));
 
       select_num = select(select_fd, &read_descs, NULL, NULL, NULL);
+      (void)select_num; //TODO treat?
 
       if (reload_map_pmacctd) {
 	struct pcap_interface *pcap_if_entry;

--- a/src/pretag_handlers.c
+++ b/src/pretag_handlers.c
@@ -1867,7 +1867,6 @@ int pretag_src_roa_handler(struct packet_ptrs *pptrs, void *unused, void *e)
 int pretag_dst_roa_handler(struct packet_ptrs *pptrs, void *unused, void *e)
 {
   struct id_entry *entry = e;
-  struct bgp_node *dst_ret = (struct bgp_node *) pptrs->bgp_dst;
   u_int8_t roa = ROA_STATUS_UNKNOWN;
 
   if (entry->key.dst_roa.n == roa) return (FALSE | entry->key.dst_roa.neg);

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -22,7 +22,6 @@
 #define __PRINT_PLUGIN_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #include "pmacct-data.h"

--- a/src/rpki/rpki.c
+++ b/src/rpki/rpki.c
@@ -100,6 +100,7 @@ void rpki_daemon()
     ret = rpki_roas_file_load(config.rpki_roas_file,
 			rpki_roa_db->rib[AFI_IP][SAFI_UNICAST],
 			rpki_roa_db->rib[AFI_IP6][SAFI_UNICAST]);
+    (void)ret; //TODO check error
   }
 
   if (config.rpki_rtr_cache) {

--- a/src/rpki/rpki_msg.c
+++ b/src/rpki/rpki_msg.c
@@ -281,6 +281,7 @@ void rpki_rtr_parse_ipv4_prefix(struct rpki_rtr_handle *cache, struct rpki_rtr_i
   struct prefix_ipv4 p;
   as_t asn;
   int ret;
+  (void)ret; //TODO check all ret errors
 
   memset(&p, 0, sizeof(p));
   p.family = AF_INET;
@@ -320,6 +321,7 @@ void rpki_rtr_parse_ipv6_prefix(struct rpki_rtr_handle *cache, struct rpki_rtr_i
   struct prefix_ipv6 p;
   as_t asn;
   int ret;
+  (void)ret; //TODO check all ret errors
 
   memset(&p, 0, sizeof(p));
   p.family = AF_INET6;
@@ -684,8 +686,8 @@ void rpki_rtr_recv_error_report(struct rpki_rtr_handle *cache)
 {
   struct rpki_rtr_err_report erm;
   ssize_t msglen;
-  char *ermbuf = NULL, *encpdu_ptr, *errmsg_ptr;
-  u_int32_t *encpdu_len, *errmsg_len;
+  char *ermbuf = NULL, *errmsg_ptr;
+  u_int32_t *encpdu_len;
 
   if (cache->fd > 0) {
     if (config.debug) Log(LOG_DEBUG, "DEBUG ( %s/core/RPKI ): rpki_rtr_recv_error_report()\n", config.name);
@@ -713,8 +715,6 @@ void rpki_rtr_recv_error_report(struct rpki_rtr_handle *cache)
       ermbuf[rem_len] = '\0';
 
       encpdu_len = (u_int32_t *) ermbuf;
-      encpdu_ptr = (char *) (ermbuf + 4);
-      errmsg_len = (u_int32_t *)(char *)(ermbuf + (*encpdu_len) + 4);
       errmsg_ptr = (char *) (ermbuf + (*encpdu_len) + 4 + 4);
 
       Log(LOG_WARNING, "WARN ( %s/core/RPKI ): rpki_rtr_recv_error_report(): %s\n", config.name, errmsg_ptr);

--- a/src/setproctitle.c
+++ b/src/setproctitle.c
@@ -95,7 +95,6 @@ initsetproctitle(argc, argv, envp)
 	char **envp;
 {
 	register int i;
-	int align;
 	extern char **environ;
 
 	/*

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -110,7 +110,7 @@ int main(int argc,char **argv, char **envp)
   struct packet_ptrs_vector pptrs;
   char config_file[SRVBUFLEN];
   unsigned char *sflow_packet;
-  int logf, rc, yes=1, no=0, allowed;
+  int logf, rc, yes=1, allowed;
   struct host_addr addr;
   struct hosts_table allow;
   struct id_table bpas_table;
@@ -121,7 +121,7 @@ int main(int argc,char **argv, char **envp)
   struct id_table bitr_table;
   struct id_table sampling_table;
   u_int32_t idx;
-  int pipe_fd = 0, capture_methods = 0;
+  int capture_methods = 0;
   int ret, alloc_sppi = FALSE;
   SFSample spp;
 
@@ -642,6 +642,7 @@ int main(int argc,char **argv, char **envp)
 #endif
 #ifdef WITH_ZMQ
   else if (config.nfacctd_zmq_address) {
+    int pipe_fd = 0;
     SF_init_zmq_host(&nfacctd_zmq_host, &pipe_fd);
     recv_pptrs.pkthdr = &recv_pkthdr;
 
@@ -2207,6 +2208,7 @@ int sf_cnt_log_msg(struct bgp_peer *peer, SFSample *sample, int version, u_int32
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(FUNC_TYPE_SFLOW_COUNTER);
   int ret = 0, amqp_ret = 0, kafka_ret = 0, etype = BGP_LOGDUMP_ET_NONE;
+  (void)etype;
 
   if (!bms || !peer || !sample || !event_type) {
     skipBytes(sample, len);
@@ -2323,9 +2325,9 @@ int sf_cnt_log_msg(struct bgp_peer *peer, SFSample *sample, int version, u_int32
 
 int readCounters_generic(struct bgp_peer *peer, SFSample *sample, char *event_type, int output, void *vobj)
 {
-  char msg_type[] = "sflow_cnt_generic";
   int ret = 0;
 #ifdef WITH_JANSSON
+  char msg_type[] = "sflow_cnt_generic";
   json_t *obj = (json_t *) vobj;
 
   /* parse sFlow first and foremost */
@@ -2398,9 +2400,9 @@ int readCounters_generic(struct bgp_peer *peer, SFSample *sample, char *event_ty
 
 int readCounters_ethernet(struct bgp_peer *peer, SFSample *sample, char *event_type, int output, void *vobj)
 {
-  char msg_type[] = "sflow_cnt_ethernet";
   int ret = 0;
 #ifdef WITH_JANSSON
+  char msg_type[] = "sflow_cnt_ethernet";
   json_t *obj = (json_t *) vobj;
 
   u_int32_t m32_1, m32_2, m32_3, m32_4, m32_5;
@@ -2458,9 +2460,9 @@ int readCounters_ethernet(struct bgp_peer *peer, SFSample *sample, char *event_t
 
 int readCounters_vlan(struct bgp_peer *peer, SFSample *sample, char *event_type, int output, void *vobj)
 {
-  char msg_type[] = "sflow_cnt_vlan";
   int ret = 0;
 #ifdef WITH_JANSSON
+  char msg_type[] = "sflow_cnt_vlan";
   json_t *obj = (json_t *) vobj;
 
   u_int64_t m64_1;

--- a/src/sflow.c
+++ b/src/sflow.c
@@ -186,10 +186,8 @@ void decodeIPLayer4(SFSample *sample, u_char *ptr, u_int32_t ipProtocol) {
       sample->dcd_dport = ntohs(tcp.th_dport);
       sample->dcd_tcpFlags = tcp.th_flags;
       if(sample->dcd_dport == 80) {
-	int bytesLeft;
 	int headerBytes = (tcp.th_off_and_unused >> 4) * 4;
 	ptr += headerBytes;
-	bytesLeft = sample->header + sample->headerLen - ptr;
       }
     }
     break;
@@ -310,7 +308,6 @@ void decodeIPV4(SFSample *sample)
 
 void decodeIPV6(SFSample *sample)
 {
-  u_int16_t payloadLen;
   u_int32_t label;
   u_int32_t nextHeader;
   u_char *end = sample->header + sample->headerLen;
@@ -336,7 +333,6 @@ void decodeIPV6(SFSample *sample)
     label <<= 8;
     label += *ptr++;
     // payload
-    payloadLen = (ptr[0] << 8) + ptr[1];
     ptr += 2;
     // if payload is zero, that implies a jumbo payload
 
@@ -544,10 +540,8 @@ void readExtendedGateway(SFSample *sample)
   sample->dst_as_path_len = getData32(sample);
   if (sample->dst_as_path_len > 0) {
     for (idx = 0, len_tot = 0; idx < sample->dst_as_path_len; idx++) {
-      u_int32_t seg_type;
       u_int32_t seg_len, i;
 
-      seg_type = getData32(sample);
       seg_len = getData32(sample);
 
       for (i = 0; i < seg_len; i++) {
@@ -718,11 +712,9 @@ void readExtendedMplsTunnel(SFSample *sample)
 {
 #define SA_MAX_TUNNELNAME_LEN 100
   char tunnel_name[SA_MAX_TUNNELNAME_LEN+1];
-  u_int32_t tunnel_cos;
   
   getString(sample, tunnel_name, SA_MAX_TUNNELNAME_LEN); 
   sample->mpls_tunnel_id = getData32(sample);
-  tunnel_cos = getData32(sample);
 
   sample->extended_data_tag |= SASAMPLE_EXTENDED_DATA_MPLS_TUNNEL;
 }
@@ -736,11 +728,9 @@ void readExtendedMplsVC(SFSample *sample)
 {
 #define SA_MAX_VCNAME_LEN 100
   char vc_name[SA_MAX_VCNAME_LEN+1];
-  u_int32_t vc_cos;
 
   getString(sample, vc_name, SA_MAX_VCNAME_LEN); 
   sample->mpls_vll_vc_id = getData32(sample);
-  vc_cos = getData32(sample);
 
   sample->extended_data_tag |= SASAMPLE_EXTENDED_DATA_MPLS_VC;
 }
@@ -754,10 +744,8 @@ void readExtendedMplsFTN(SFSample *sample)
 {
 #define SA_MAX_FTN_LEN 100
   char ftn_descr[SA_MAX_FTN_LEN+1];
-  u_int32_t ftn_mask;
 
   getString(sample, ftn_descr, SA_MAX_FTN_LEN);
-  ftn_mask = getData32(sample);
 
   sample->extended_data_tag |= SASAMPLE_EXTENDED_DATA_MPLS_FTN;
 }
@@ -769,8 +757,6 @@ void readExtendedMplsFTN(SFSample *sample)
 
 void readExtendedMplsLDP_FEC(SFSample *sample)
 {
-  u_int32_t fec_addr_prefix_len = getData32(sample);
-
   sample->extended_data_tag |= SASAMPLE_EXTENDED_DATA_MPLS_LDP_FEC;
 }
 

--- a/src/sfprobe_plugin/sfprobe_plugin.c
+++ b/src/sfprobe_plugin/sfprobe_plugin.c
@@ -24,7 +24,6 @@
 #include <sys/socket.h>
 #include <net/if.h>
 #include <sys/poll.h>
-#include <inttypes.h>
 
 #include "sflow_api.h"
 #include "addr.h"

--- a/src/sfprobe_plugin/sfprobe_plugin.c
+++ b/src/sfprobe_plugin/sfprobe_plugin.c
@@ -24,6 +24,7 @@
 #include <sys/socket.h>
 #include <net/if.h>
 #include <sys/poll.h>
+#include <inttypes.h>
 
 #include "sflow_api.h"
 #include "addr.h"
@@ -237,6 +238,7 @@ static void init_agent(SflSp *sp)
 
   // add a receiver
   receiver = sfl_agent_addReceiver(sp->agent);
+  (void)receiver; // todo treat result?
 
   // define the data source
   SFL_DS_SET(dsi, 0, 1, 0);  // ds_class = 0, ds_index = 1, ds_instance = 0
@@ -295,7 +297,10 @@ static void init_agent(SflSp *sp)
 
 static void readPacket(SflSp *sp, struct pkt_payload *hdr, const unsigned char *buf)
 {
-  SFLFlow_sample_element hdrElem, classHdrElem, class2HdrElem, tagHdrElem;
+  SFLFlow_sample_element hdrElem, classHdrElem, tagHdrElem;
+#if defined (WITH_NDPI)
+  SFLFlow_sample_element class2HdrElem;
+#endif
   SFLFlow_sample_element gatewayHdrElem, routerHdrElem, switchHdrElem;
   SFLExtended_as_path_segment as_path_segment;
   u_int32_t frame_len, header_len;
@@ -611,9 +616,7 @@ void sfprobe_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   int refresh_timeout, ret, num, recv_budget, poll_bypass;
   struct ring *rg = &((struct channels_list_entry *)ptr)->rg;
   struct ch_status *status = ((struct channels_list_entry *)ptr)->status;
-  struct plugins_list_entry *plugin_data = ((struct channels_list_entry *)ptr)->plugin;
   u_int32_t bufsz = ((struct channels_list_entry *)ptr)->bufsize;
-  pid_t core_pid = ((struct channels_list_entry *)ptr)->core_pid;
   unsigned char *rgptr;
   int pollagain = TRUE;
   u_int32_t seq = 1, rg_err_count = 0;
@@ -748,7 +751,7 @@ void sfprobe_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
           else {
   	    rg_err_count++;
   	    if (config.debug || (rg_err_count > MAX_RG_COUNT_ERR)) {
-              Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%llu plugin_pipe_size=%llu).\n",
+              Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%" PRIu64 " plugin_pipe_size=%" PRIu64 ").\n",
                         config.name, config.type, config.buffer_size, config.pipe_size);
               Log(LOG_WARNING, "WARN ( %s/%s ): Increase values or look for plugin_buffer_size, plugin_pipe_size in CONFIG-KEYS document.\n\n",
                         config.name, config.type);
@@ -782,7 +785,7 @@ void sfprobe_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
       pipebuf_ptr = (unsigned char *) pipebuf+ChBufHdrSz+PpayloadSz;
 
       if (config.debug_internal_msg) 
-	Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%llu seq=%u num_entries=%u\n",
+	Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%" PRIu64 " seq=%u num_entries=%u\n",
 		config.name, config.type, ((struct ch_buf_hdr *)pipebuf)->len, seq,
 		((struct ch_buf_hdr *)pipebuf)->num);
 
@@ -819,9 +822,13 @@ void sfprobe_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
 	((struct ch_buf_hdr *)pipebuf)->num--;
 	if (((struct ch_buf_hdr *)pipebuf)->num) {
+#if ! NEED_ALIGN
 	  pipebuf_ptr += hdr->cap_len;
-#if NEED_ALIGN
-	  while ((u_int32_t)pipebuf_ptr % 4 != 0) (u_int32_t)pipebuf_ptr++;
+#else
+          uint32_t tmp = hdr->cap_len;
+          if ( ( tmp%4 ) != 0 )
+            tmp = ( tmp + 4 ) & 4;
+	  pipebuf_ptr += tmp;
 #endif
 	  hdr = (struct pkt_payload *) pipebuf_ptr;
 	  pipebuf_ptr += PpayloadSz;

--- a/src/tee_plugin/tee_plugin.c
+++ b/src/tee_plugin/tee_plugin.c
@@ -21,7 +21,6 @@
 
 #define __TEE_PLUGIN_C
 
-#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #ifdef WITH_KAFKA

--- a/src/tee_plugin/tee_plugin.c
+++ b/src/tee_plugin/tee_plugin.c
@@ -21,6 +21,7 @@
 
 #define __TEE_PLUGIN_C
 
+#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #ifdef WITH_KAFKA
@@ -39,9 +40,7 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   int refresh_timeout, ret, pool_idx, recv_idx, recv_budget, poll_bypass;
   struct ring *rg = &((struct channels_list_entry *)ptr)->rg;
   struct ch_status *status = ((struct channels_list_entry *)ptr)->status;
-  struct plugins_list_entry *plugin_data = ((struct channels_list_entry *)ptr)->plugin;
   u_int32_t bufsz = ((struct channels_list_entry *)ptr)->bufsize;
-  pid_t core_pid = ((struct channels_list_entry *)ptr)->core_pid;
   unsigned char *dataptr;
   struct tee_receiver *target = NULL;
   struct plugin_requests req;
@@ -49,8 +48,6 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   unsigned char *rgptr;
   int pollagain = TRUE;
   u_int32_t seq = 1, rg_err_count = 0;
-  time_t now;
-
 #ifdef WITH_ZMQ
   struct p_zmq_host *zmq_host = &((struct channels_list_entry *)ptr)->zmq_host;
 #else
@@ -132,8 +129,6 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   if (config.pipe_zmq) P_zmq_pipe_init(zmq_host, &pipe_fd, &seq);
   else setnonblocking(pipe_fd);
 
-  now = time(NULL);
-
   memset(pipebuf, 0, config.buffer_size);
   err_cant_bridge_af = 0;
 
@@ -166,8 +161,6 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
       reload_map = FALSE;
     }
-
-    now = time(NULL);
 
     recv_budget = 0;
     if (poll_bypass) {
@@ -207,7 +200,7 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
           else {
             rg_err_count++;
             if (config.debug || (rg_err_count > MAX_RG_COUNT_ERR)) {
-              Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%llu plugin_pipe_size=%llu).\n",
+              Log(LOG_WARNING, "WARN ( %s/%s ): Missing data detected (plugin_buffer_size=%" PRIu64 " plugin_pipe_size=%" PRIu64 ").\n",
                         config.name, config.type, config.buffer_size, config.pipe_size);
               Log(LOG_WARNING, "WARN ( %s/%s ): Increase values or look for plugin_buffer_size, plugin_pipe_size in CONFIG-KEYS document.\n\n",
                         config.name, config.type);
@@ -241,7 +234,7 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
       msg->payload = (pipebuf+sizeof(struct ch_buf_hdr)+PmsgSz);
 
       if (config.debug_internal_msg) 
-        Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%llu seq=%u num_entries=%u\n",
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): buffer received len=%" PRIu64 " seq=%u num_entries=%u\n",
                 config.name, config.type, ((struct ch_buf_hdr *)pipebuf)->len, seq,
                 ((struct ch_buf_hdr *)pipebuf)->num);
 

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -67,7 +67,7 @@ void telemetry_daemon(void *t_data_void)
   struct telemetry_data *t_data = t_data_void;
   telemetry_peer_cache tpc;
 
-  int ret, rc, peers_idx, allowed, yes=1, no=0;
+  int ret, rc, peers_idx, allowed, yes=1;
   int peers_idx_rr = 0, max_peers_idx = 0, peers_num = 0;
   int data_decoder = 0, recv_flags = 0;
   u_int16_t port = 0;

--- a/src/telemetry/telemetry_logdump.c
+++ b/src/telemetry/telemetry_logdump.c
@@ -23,7 +23,6 @@
 #define __TELEMETRY_LOGDUMP_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "bgp/bgp.h"
 #include "bmp/bmp.h"

--- a/src/telemetry/telemetry_logdump.c
+++ b/src/telemetry/telemetry_logdump.c
@@ -23,6 +23,7 @@
 #define __TELEMETRY_LOGDUMP_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "bgp/bgp.h"
 #include "bmp/bmp.h"
@@ -40,11 +41,12 @@ int telemetry_log_msg(telemetry_peer *peer, struct telemetry_data *t_data, void 
 {
   telemetry_misc_structs *tms;
   int ret = 0, amqp_ret = 0, kafka_ret = 0, etype = TELEMETRY_LOGDUMP_ET_NONE;
-  pid_t writer_pid = getpid();
+  (void)etype;
 
-  u_char *base64_tdata = NULL;
-  size_t base64_tdata_len = 0;
-  
+#if defined(WITH_KAFKA) || defined(WITH_RABBITMQ)
+  pid_t writer_pid = getpid();
+#endif
+
   if (!peer || !peer->log || !log_data || !log_data_len || !t_data || !event_type) return ERR;
 
   tms = bgp_select_misc_db(FUNC_TYPE_TELEMETRY);
@@ -68,6 +70,8 @@ int telemetry_log_msg(telemetry_peer *peer, struct telemetry_data *t_data, void 
 
   if (output == PRINT_OUTPUT_JSON) {
 #ifdef WITH_JANSSON
+    u_char *base64_tdata = NULL;
+    size_t base64_tdata_len = 0;
     json_t *obj = json_object();
 
     json_object_set_new_nocheck(obj, "event_type", json_string(event_type));
@@ -260,6 +264,7 @@ void telemetry_handle_dump_event(struct telemetry_data *t_data)
   telemetry_misc_structs *tms = bgp_select_misc_db(FUNC_TYPE_TELEMETRY);
   char current_filename[SRVBUFLEN], last_filename[SRVBUFLEN], tmpbuf[SRVBUFLEN];
   char latest_filename[SRVBUFLEN], event_type[] = "dump", *fd_buf = NULL;
+  (void)event_type;
   int ret, peers_idx, duration, tables_num;
   pid_t dumper_pid;
   time_t start;
@@ -404,7 +409,7 @@ void telemetry_handle_dump_event(struct telemetry_data *t_data)
 
     duration = time(NULL)-start;
 
-    Log(LOG_INFO, "INFO ( %s/%s ): *** Dumping telemetry data - END (PID: %u, PEERS: %u ENTRIES: %llu ET: %u) ***\n",
+    Log(LOG_INFO, "INFO ( %s/%s ): *** Dumping telemetry data - END (PID: %u, PEERS: %u ENTRIES: %" PRIu64 " ET: %u) ***\n",
                 config.name, t_data->log_str, dumper_pid, tables_num, dump_elems, duration);
 
     exit_gracefully(0);

--- a/src/util.c
+++ b/src/util.c
@@ -22,6 +22,7 @@
 #define __UTIL_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #ifdef WITH_KAFKA
@@ -609,8 +610,8 @@ int handle_dynname_internal_strings(char *new, int newlen, char *old, struct pri
       ptr_end += strlen(tag_string);
       len = strlen(ptr_end);
 
-      if (prim_ptrs && prim_ptrs->data) snprintf(buf, newlen, "%llu", prim_ptrs->data->primitives.tag); 
-      else snprintf(buf, newlen, "%llu", zero_tag);
+      if (prim_ptrs && prim_ptrs->data) snprintf(buf, newlen, "%" PRIu64 "", prim_ptrs->data->primitives.tag); 
+      else snprintf(buf, newlen, "%" PRIu64 "", zero_tag);
 
       sub_len = strlen(buf);
       if ((sub_len + len) >= newlen) return ERR;
@@ -631,8 +632,8 @@ int handle_dynname_internal_strings(char *new, int newlen, char *old, struct pri
       ptr_end += strlen(tag2_string);
       len = strlen(ptr_end);
 
-      if (prim_ptrs && prim_ptrs->data) snprintf(buf, newlen, "%llu", prim_ptrs->data->primitives.tag2);
-      else snprintf(buf, newlen, "%llu", zero_tag);
+      if (prim_ptrs && prim_ptrs->data) snprintf(buf, newlen, "%" PRIu64 "", prim_ptrs->data->primitives.tag2);
+      else snprintf(buf, newlen, "%" PRIu64 "", zero_tag);
 
       sub_len = strlen(buf);
       if ((sub_len + len) >= newlen) return ERR;
@@ -652,7 +653,7 @@ int handle_dynname_internal_strings(char *new, int newlen, char *old, struct pri
       ptr_end += strlen(post_tag_string);
       len = strlen(ptr_end);
 
-      snprintf(buf, newlen, "%llu", config.post_tag);
+      snprintf(buf, newlen, "%" PRIu64 "", config.post_tag);
 
       sub_len = strlen(buf);
       if ((sub_len + len) >= newlen) return ERR;
@@ -672,7 +673,7 @@ int handle_dynname_internal_strings(char *new, int newlen, char *old, struct pri
       ptr_end += strlen(post_tag2_string);
       len = strlen(ptr_end);
 
-      snprintf(buf, newlen, "%llu", config.post_tag2);
+      snprintf(buf, newlen, "%" PRIu64 "", config.post_tag2);
 
       sub_len = strlen(buf);
       if ((sub_len + len) >= newlen) return ERR;
@@ -1556,8 +1557,8 @@ void *pm_malloc(size_t size)
 
   obj = (unsigned char *) malloc(size);
   if (!obj) {
-    Log(LOG_ERR, "ERROR ( %s/%s ): Unable to grab enough memory (requested: %llu bytes). Exiting ...\n",
-    config.name, config.type, (unsigned long long)size);
+    Log(LOG_ERR, "ERROR ( %s/%s ): Unable to grab enough memory (requested: %" PRIu64 " bytes). Exiting ...\n",
+    config.name, config.type, size);
     exit_gracefully(1);
   }
 
@@ -1725,7 +1726,7 @@ int load_tags(char *filename, struct pretag_filter *filter, char *value_ptr)
     else range = value;
 
     if (range_ptr && range <= value) {
-      Log(LOG_ERR, "WARN ( %s/%s ): [%s] Range value is expected in format low-high. '%llu-%llu'.\n",
+      Log(LOG_ERR, "WARN ( %s/%s ): [%s] Range value is expected in format low-high. '%" PRIu64 "-%" PRIu64 "'.\n",
 			config.name, config.type, filename, value, range);
       changes++;
       break;
@@ -2143,11 +2144,11 @@ void custom_primitives_reconcile(struct custom_primitives_ptrs *cpptrs, struct c
       struct custom_primitive_entry *cpe = cpptrs->primitive[cpptrs_idx].ptr;
 
       if (cpptrs->primitive[cpptrs_idx].off != PM_VARIABLE_LENGTH) { 
-        Log(LOG_DEBUG, "DEBUG ( %s/%s ): Custom primitive '%s': type=%llx off=%u len=%u\n", config.name, config.type,
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): Custom primitive '%s': type=%" PRIx64 " off=%u len=%u\n", config.name, config.type,
 	  cpptrs->primitive[cpptrs_idx].name, cpe->type, cpptrs->primitive[cpptrs_idx].off, cpe->len);
       }
       else {
-        Log(LOG_DEBUG, "DEBUG ( %s/%s ): Custom primitive '%s': type=%llx len=vlen\n", config.name, config.type,
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): Custom primitive '%s': type=%" PRIx64 " len=vlen\n", config.name, config.type,
 	  cpptrs->primitive[cpptrs_idx].name, cpe->type);
       } 
     }
@@ -2522,7 +2523,7 @@ void vlen_prims_debug(struct pkt_vlen_hdr_primitives *hdr)
     label_ptr = (pm_label_t *) ptr;
     ptr += PmLabelTSz;
 
-    Log(LOG_DEBUG, "DEBUG ( %s/%s ): vlen_prims_debug(): LABEL #%u: type: %llx len: %u val: %s\n",
+    Log(LOG_DEBUG, "DEBUG ( %s/%s ): vlen_prims_debug(): LABEL #%u: type: %" PRIx64 " len: %u val: %s\n",
 	config.name, config.type, x, label_ptr->type, label_ptr->len, ptr);
   }
 }

--- a/src/util.c
+++ b/src/util.c
@@ -22,7 +22,6 @@
 #define __UTIL_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 #ifdef WITH_KAFKA

--- a/src/xflow_status.c
+++ b/src/xflow_status.c
@@ -22,6 +22,7 @@
 #define __XFLOW_STATUS_C
 
 /* includes */
+#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 
@@ -141,7 +142,7 @@ void print_status_table(time_t now, int buckets)
     if (entry && entry->counters.total && entry->counters.bytes) {
       addr_to_str(agent_ip_address, &entry->agent_addr);
 
-      Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s:%u] agent=%s:%u time=%ld packets=%llu bytes=%llu seq_good=%u seq_jmp_fwd=%u seq_jmp_bck=%u\n",
+      Log(LOG_NOTICE, "NOTICE ( %s/%s ): stats [%s:%u] agent=%s:%u time=%ld packets=%" PRIu64 " bytes=%" PRIu64 " seq_good=%u seq_jmp_fwd=%u seq_jmp_bck=%u\n",
 		config.name, config.type, collector_ip_address, config.nfacctd_port,
 		agent_ip_address, entry->aux1, (long)now, entry->counters.total, entry->counters.bytes,
 		entry->counters.good, entry->counters.jumps_f, entry->counters.jumps_b);
@@ -219,9 +220,11 @@ search_class_id_status_table(struct xflow_status_entry_class *centry, pm_class_t
   pm_class_t needle, haystack;
 
   needle = ntohl(class_id);
+  (void)needle; //TODO: do something?
 
   while (centry) {
     haystack = ntohl(centry->class_id);
+    (void)haystack; //TODO: do something?
 
     if (centry->class_id == class_id) return centry;
     centry = centry->next;

--- a/src/xflow_status.c
+++ b/src/xflow_status.c
@@ -22,7 +22,6 @@
 #define __XFLOW_STATUS_C
 
 /* includes */
-#include <inttypes.h>
 #include "pmacct.h"
 #include "addr.h"
 


### PR DESCRIPTION
### What it does

This patchset:

1) Adds `-Wall -Werror`  in all builds

2) "Fixes" all warnings generated by such a perilous act, including removing all dead code that gcc indicates. I didn't spend much time, as a lot of warnings come from old Quagga code, and that code is not actively being developed. It would be a good idea to fix some of them "properly", but at least now new code will be checked.

3) It modifies `.travis.yml` to add 4 compilation envs (targets):

* ALL plugins + NDEBUG
* ALL plugins + DEBUG
* NO plugins + NDEBUG
* NO plugins + DEBUG

It should be adding more compilation coverage.

### Future work (for someone else with more time :P)

* It would be a good idea to move al static arrays defined in the header as static inline, now marked as `__attribute(unused)__` to be defined with `extern` and populated in a `.c`.

* There is a certain degree of duplicity in the log dumpers etc... which could be refactored and unifed.

### Peer-review

NOTE: this patchset  is a big (and rather stupid) set of changes, so it should be carefully peer-reviewed.