### PR TITLE
misc: fix warnings introduced 0e25ee3

### DIFF
--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -57,7 +57,7 @@ void nfacctd_bmp_wrapper()
 
 void skinny_bmp_daemon()
 {
-  int ret, rc, peers_idx, allowed, yes=1, no=0;
+  int ret, rc, peers_idx, allowed, yes=1;
   int peers_idx_rr = 0, max_peers_idx = 0;
   u_int32_t pkt_remaining_len=0;
   time_t now;
@@ -232,6 +232,7 @@ void skinny_bmp_daemon()
 #endif
 
 #if (defined IPV6_BINDV6ONLY)
+  int no=0;
   rc = setsockopt(config.bmp_sock, IPPROTO_IPV6, IPV6_BINDV6ONLY, (char *) &no, (socklen_t) sizeof(no));
   if (rc < 0) Log(LOG_ERR, "WARN ( %s/%s ): setsockopt() failed for IPV6_BINDV6ONLY (errno: %d).\n", config.name, bmp_misc_db->log_str, errno);
 #endif

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -105,7 +105,7 @@ int main(int argc,char **argv, char **envp)
   struct packet_ptrs_vector pptrs;
   char config_file[SRVBUFLEN];
   unsigned char *netflow_packet;
-  int logf, rc, yes=1, no=0, allowed;
+  int logf, rc, yes=1, allowed;
   struct host_addr addr;
   struct hosts_table allow;
   struct id_table bpas_table;
@@ -693,6 +693,7 @@ int main(int argc,char **argv, char **envp)
 #endif
 
 #if (defined IPV6_BINDV6ONLY)
+    int no=0;
     rc = setsockopt(config.sock, IPPROTO_IPV6, IPV6_BINDV6ONLY, (char *) &no, (socklen_t) sizeof(no));
     if (rc < 0) Log(LOG_ERR, "WARN ( %s/core ): setsockopt() failed for IPV6_BINDV6ONLY.\n", config.name);
 #endif

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -110,7 +110,7 @@ int main(int argc,char **argv, char **envp)
   struct packet_ptrs_vector pptrs;
   char config_file[SRVBUFLEN];
   unsigned char *sflow_packet;
-  int logf, rc, yes=1, no=0, allowed;
+  int logf, rc, yes=1, allowed;
   struct host_addr addr;
   struct hosts_table allow;
   struct id_table bpas_table;
@@ -702,6 +702,7 @@ int main(int argc,char **argv, char **envp)
 #endif
 
 #if (defined IPV6_BINDV6ONLY)
+    int no=0;
     rc = setsockopt(config.sock, IPPROTO_IPV6, IPV6_BINDV6ONLY, (char *) &no, (socklen_t) sizeof(no));
     if (rc < 0) Log(LOG_ERR, "WARN ( %s/core ): setsockopt() failed for IPV6_BINDV6ONLY.\n", config.name);
 #endif

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -67,7 +67,7 @@ void telemetry_daemon(void *t_data_void)
   struct telemetry_data *t_data = t_data_void;
   telemetry_peer_cache tpc;
 
-  int ret, rc, peers_idx, allowed, yes=1, no=0;
+  int ret, rc, peers_idx, allowed, yes=1;
   int peers_idx_rr = 0, max_peers_idx = 0, peers_num = 0;
   int data_decoder = 0, recv_flags = 0;
   u_int16_t port = 0;
@@ -312,6 +312,7 @@ void telemetry_daemon(void *t_data_void)
 #endif
 
 #if (defined IPV6_BINDV6ONLY)
+    int no=0;
     rc = setsockopt(config.telemetry_sock, IPPROTO_IPV6, IPV6_BINDV6ONLY, (char *) &no, (socklen_t) sizeof(no));
     if (rc < 0) Log(LOG_ERR, "WARN ( %s/%s ): setsockopt() failed for IPV6_BINDV6ONLY (errno: %d).\n", config.name, t_data->log_str, errno);
 #endif


### PR DESCRIPTION
Move `int no=0` to #ifdef section, so that both Linux and non-Linux
compilations work without warnings.