### PR TITLE
Fixed pgsql plugin Purging cache Crash

### DIFF
--- a/src/pgsql_plugin.c
+++ b/src/pgsql_plugin.c
@@ -472,7 +472,7 @@ void PG_cache_purge(struct db_cache *queue[], int index, struct insert_data *ida
   start = time(NULL);
 
   /* re-using pending queries queue stuff from parent and saving clauses */
-  memcpy(pending_queries_queue, queue, index*sizeof(struct db_cache *));
+  memcpy(sql_pending_queries_queue, queue, index*sizeof(struct db_cache *));
   pqq_ptr = index;
 
   strlcpy(orig_copy_clause, copy_clause, LONGSRVBUFLEN);
@@ -481,8 +481,8 @@ void PG_cache_purge(struct db_cache *queue[], int index, struct insert_data *ida
   strlcpy(orig_lock_clause, lock_clause, LONGSRVBUFLEN);
 
   start:
-  memcpy(queue, pending_queries_queue, pqq_ptr*sizeof(struct db_cache *));
-  memset(pending_queries_queue, 0, pqq_ptr*sizeof(struct db_cache *));
+  memcpy(queue, sql_pending_queries_queue, pqq_ptr*sizeof(struct db_cache *));
+  memset(sql_pending_queries_queue, 0, pqq_ptr*sizeof(struct db_cache *));
   index = pqq_ptr; pqq_ptr = 0;
 
   /* We check for variable substitution in SQL table */


### PR DESCRIPTION
`#0  0x00007ffff6d1ac4b in __memcpy_sse2 () from /lib64/libc.so.6`
`#1  0x0000000000495419 in PG_cache_purge (queue=0x7ffff7f97010, index=976, idata=0x7ffffffe23e0)
    at pgsql_plugin.c:475`
`#2  0x000000000049933a in sql_cache_handle_flush_event (idata=0x7ffffffe23e0,
    refresh_deadline=0x7ffffffe23d8, pt=0x7ffffffe25c0) at sql_common.c:466`
`#3  0x00000000004942fd in pgsql_plugin (pipe_fd=7, cfgptr=0x91bbf8, ptr=0x836f60 <channels_list>)
    at pgsql_plugin.c:169`
`#4  0x000000000043570b in load_plugins (req=0x7fffffffe380) at plugin_hooks.c:287`
`#5  0x000000000042a795 in main (argc=3, argv=0x7fffffffe578, envp=0x7fffffffe598) at pmacctd.c:918`

