### PR TITLE
Replace ABSTIME with to_timestamp in PG sqls

### DIFF
--- a/src/pgsql_plugin.c
+++ b/src/pgsql_plugin.c
@@ -631,7 +631,7 @@ int PG_evaluate_history(int primitive)
       strncat(where[primitive].string, " AND ", sizeof(where[primitive].string));
     }
     if (!config.timestamps_since_epoch)
-      strncat(where[primitive].string, "ABSTIME(%u)::Timestamp::Timestamp without time zone = ", SPACELEFT(where[primitive].string));
+      strncat(where[primitive].string, "to_timestamp(%u)::Timestamp without time zone = ", SPACELEFT(where[primitive].string));
     else
       strncat(where[primitive].string, "%u = ", SPACELEFT(where[primitive].string));
     strncat(where[primitive].string, "stamp_inserted", SPACELEFT(where[primitive].string));
@@ -661,7 +661,7 @@ int PG_evaluate_history(int primitive)
     }
     else {
       if (!config.timestamps_since_epoch)
-	strncat(values[primitive].string, "ABSTIME(%u)::Timestamp, ABSTIME(%u)::Timestamp", SPACELEFT(values[primitive].string));
+	strncat(values[primitive].string, "to_timestamp(%u), to_timestamp(%u)", SPACELEFT(values[primitive].string));
       else
 	strncat(values[primitive].string, "%u, %u", SPACELEFT(values[primitive].string));
       values[primitive].handler = where[primitive].handler = count_timestamp_handler;

--- a/src/sql_common.c
+++ b/src/sql_common.c
@@ -2633,8 +2633,8 @@ int sql_evaluate_primitives(int primitive)
 	  use_copy = TRUE;
 	}
 	else {
-          strncat(where[primitive].string, "timestamp_start=ABSTIME(%u)::Timestamp", SPACELEFT(where[primitive].string));
-          strncat(values[primitive].string, "ABSTIME(%u)::Timestamp", SPACELEFT(values[primitive].string));
+          strncat(where[primitive].string, "timestamp_start=to_timestamp(%u)", SPACELEFT(where[primitive].string));
+          strncat(values[primitive].string, "to_timestamp(%u)", SPACELEFT(values[primitive].string));
 	}
       }
       else if (!strcmp(config.type, "sqlite3")) {
@@ -2691,8 +2691,8 @@ int sql_evaluate_primitives(int primitive)
           use_copy = TRUE;
         }
         else {
-          strncat(where[primitive].string, "timestamp_end=ABSTIME(%u)::Timestamp", SPACELEFT(where[primitive].string));
-          strncat(values[primitive].string, "ABSTIME(%u)::Timestamp", SPACELEFT(values[primitive].string));
+          strncat(where[primitive].string, "timestamp_end=to_timestamp(%u)", SPACELEFT(where[primitive].string));
+          strncat(values[primitive].string, "to_timestamp(%u)", SPACELEFT(values[primitive].string));
         }
       }
       else if (!strcmp(config.type, "sqlite3")) {
@@ -2749,8 +2749,8 @@ int sql_evaluate_primitives(int primitive)
           use_copy = TRUE;
         }
         else {
-          strncat(where[primitive].string, "timestamp_arrival=ABSTIME(%u)::Timestamp", SPACELEFT(where[primitive].string));
-          strncat(values[primitive].string, "ABSTIME(%u)::Timestamp", SPACELEFT(values[primitive].string));
+          strncat(where[primitive].string, "timestamp_arrival=to_timestamp(%u)", SPACELEFT(where[primitive].string));
+          strncat(values[primitive].string, "to_timestamp(%u)", SPACELEFT(values[primitive].string));
         }
       }
       else if (!strcmp(config.type, "sqlite3")) {
@@ -2808,8 +2808,8 @@ int sql_evaluate_primitives(int primitive)
           use_copy = TRUE;
         }
         else {
-          strncat(where[primitive].string, "timestamp_min=ABSTIME(%u)::Timestamp", SPACELEFT(where[primitive].string));
-          strncat(values[primitive].string, "ABSTIME(%u)::Timestamp", SPACELEFT(values[primitive].string));
+          strncat(where[primitive].string, "timestamp_min=to_timestamp(%u)", SPACELEFT(where[primitive].string));
+          strncat(values[primitive].string, "to_timestamp(%u)", SPACELEFT(values[primitive].string));
         }
       }
       else if (!strcmp(config.type, "sqlite3")) {
@@ -2863,8 +2863,8 @@ int sql_evaluate_primitives(int primitive)
           use_copy = TRUE;
         }
         else {
-          strncat(where[primitive].string, "timestamp_max=ABSTIME(%u)::Timestamp", SPACELEFT(where[primitive].string));
-          strncat(values[primitive].string, "ABSTIME(%u)::Timestamp", SPACELEFT(values[primitive].string));
+          strncat(where[primitive].string, "timestamp_max=to_timestamp(%u)", SPACELEFT(where[primitive].string));
+          strncat(values[primitive].string, "to_timestamp(%u)", SPACELEFT(values[primitive].string));
         }
       }
       else if (!strcmp(config.type, "sqlite3")) {


### PR DESCRIPTION
ABSTIME was dropped in PG commit da6a8d01d391eab45c4b3e0043a1b2b31072f5f
and released in PG12. ABSTIME has been marked deprecated for a *long*
time, to_timestamp is the supported equivalent.

to_timestamp goes back to at least 8.4 which is the PG version shipped
in RHEL/CentOS 6 and the minimum version supported via configure.ac so
all is good.

Closes #329