### PR TITLE
add config option: print_allow_empty_file = true|false

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -130,6 +130,7 @@ static const struct _dictionary_line dictionary[] = {
   {"print_output_separator", cfg_key_print_output_separator},
   {"print_output_custom_lib", cfg_key_print_output_custom_lib},
   {"print_output_custom_cfg_file", cfg_key_print_output_custom_cfg_file},
+  {"print_allow_empty_file", cfg_key_print_allow_empty_file},
   {"print_latest_file", cfg_key_print_latest_file},
   {"print_num_protos", cfg_key_num_protos},
   {"print_trigger_exec", cfg_key_sql_trigger_exec},

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -130,7 +130,7 @@ static const struct _dictionary_line dictionary[] = {
   {"print_output_separator", cfg_key_print_output_separator},
   {"print_output_custom_lib", cfg_key_print_output_custom_lib},
   {"print_output_custom_cfg_file", cfg_key_print_output_custom_cfg_file},
-  {"print_allow_empty_file", cfg_key_print_allow_empty_file},
+  {"print_write_empty_file", cfg_key_print_write_empty_file},
   {"print_latest_file", cfg_key_print_latest_file},
   {"print_num_protos", cfg_key_num_protos},
   {"print_trigger_exec", cfg_key_sql_trigger_exec},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -176,6 +176,7 @@ struct configuration {
   int print_markers;
   int print_output;
   int print_output_file_append;
+  int print_allow_empty_file;
   char *print_output_lock_file;
   char *print_output_separator;
   char *print_output_file;

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -176,7 +176,7 @@ struct configuration {
   int print_markers;
   int print_output;
   int print_output_file_append;
-  int print_allow_empty_file;
+  int print_write_empty_file;
   char *print_output_lock_file;
   char *print_output_separator;
   char *print_output_file;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -1067,7 +1067,7 @@ int cfg_key_print_output_file_append(char *filename, char *name, char *value_ptr
   return changes;
 }
 
-int cfg_key_print_allow_empty_file(char *filename, char *name, char *value_ptr)
+int cfg_key_print_write_empty_file(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;
   int value, changes = 0;
@@ -1075,11 +1075,11 @@ int cfg_key_print_allow_empty_file(char *filename, char *name, char *value_ptr)
   value = parse_truefalse(value_ptr);
   if (value < 0) return ERR;
 
-  if (!name) for (; list; list = list->next, changes++) list->cfg.print_allow_empty_file = value;
+  if (!name) for (; list; list = list->next, changes++) list->cfg.print_write_empty_file = value;
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-        list->cfg.print_allow_empty_file = value;
+        list->cfg.print_write_empty_file = value;
         changes++;
         break;
       }

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -1067,6 +1067,28 @@ int cfg_key_print_output_file_append(char *filename, char *name, char *value_ptr
   return changes;
 }
 
+int cfg_key_print_allow_empty_file(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.print_allow_empty_file = value;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.print_allow_empty_file = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_print_output_lock_file(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -136,6 +136,7 @@ extern int cfg_key_print_markers(char *, char *, char *);
 extern int cfg_key_print_output(char *, char *, char *);
 extern int cfg_key_print_output_file(char *, char *, char *);
 extern int cfg_key_print_output_file_append(char *, char *, char *);
+extern int cfg_key_print_allow_empty_file(char *, char *, char *);
 extern int cfg_key_print_output_lock_file(char *, char *, char *);
 extern int cfg_key_print_output_separator(char *, char *, char *);
 extern int cfg_key_print_output_custom_lib(char *, char *, char *);

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -136,7 +136,7 @@ extern int cfg_key_print_markers(char *, char *, char *);
 extern int cfg_key_print_output(char *, char *, char *);
 extern int cfg_key_print_output_file(char *, char *, char *);
 extern int cfg_key_print_output_file_append(char *, char *, char *);
-extern int cfg_key_print_allow_empty_file(char *, char *, char *);
+extern int cfg_key_print_write_empty_file(char *, char *, char *);
 extern int cfg_key_print_output_lock_file(char *, char *, char *);
 extern int cfg_key_print_output_separator(char *, char *, char *);
 extern int cfg_key_print_output_custom_lib(char *, char *, char *);

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -362,7 +362,7 @@ void P_cache_purge(struct chained_cache *queue[], int index, int safe_action)
   avro_file_writer_t avro_writer;
 #endif
 
-  if (!index && !config.print_allow_empty_file) {
+  if (!index && !config.print_write_empty_file) {
     Log(LOG_INFO, "INFO ( %s/%s ): *** Purging cache - START (PID: %u) ***\n", config.name, config.type, writer_pid);
     Log(LOG_INFO, "INFO ( %s/%s ): *** Purging cache - END (PID: %u, QN: 0/0, ET: X) ***\n", config.name, config.type, writer_pid);
     return;
@@ -389,18 +389,15 @@ void P_cache_purge(struct chained_cache *queue[], int index, int safe_action)
   for (j = 0, stop = 0; (!stop) && P_preprocess_funcs[j]; j++)
     stop = P_preprocess_funcs[j](queue, &index, j);
 
-  if (index > 0)
-    memcpy(pending_queries_queue, queue, index*sizeof(struct db_cache *));
+  memcpy(pending_queries_queue, queue, index*sizeof(struct db_cache *));
   pqq_ptr = index;
 
   Log(LOG_INFO, "INFO ( %s/%s ): *** Purging cache - START (PID: %u) ***\n", config.name, config.type, writer_pid);
   start = time(NULL);
 
   start:
-  if (pqq_ptr > 0) {
-    memcpy(queue, pending_queries_queue, pqq_ptr*sizeof(struct db_cache *));
-    memset(pending_queries_queue, 0, pqq_ptr*sizeof(struct db_cache *));
-  }
+  memcpy(queue, pending_queries_queue, pqq_ptr*sizeof(struct db_cache *));
+  memset(pending_queries_queue, 0, pqq_ptr*sizeof(struct db_cache *));
   index = pqq_ptr; pqq_ptr = 0; file_to_be_created = FALSE;
 
   if (config.print_output & PRINT_OUTPUT_EVENT) is_event = TRUE;


### PR DESCRIPTION
to create empty file when no cache entry to purge out

My system uses old pmacct's behavior -- to generate empty file even not data to purge exists -- 
to chech the proof-of-healthyness of sfacctd by the existence of data file (configured per-minute).
But,  new sfacctd omits data file without data. So option is added to behave as old... 