### PR TITLE
setsockopt SO_KEEPALIVE fix

### DIFF
--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -83,6 +83,10 @@ void skinny_bmp_daemon()
   time_t dump_refresh_deadline = {0};
   struct timeval dump_refresh_timeout, *drt_ptr;
 
+  /* flags */
+  int flags = 1;
+
+
 
   /* initial cleanups */
   reload_map_bmp_thread = FALSE;
@@ -653,7 +657,6 @@ void skinny_bmp_daemon()
     /* New connection is coming in */
     if (FD_ISSET(config.bmp_sock, &read_descs)) {
       int peers_check_idx, peers_num;
-      int flags = 1;
 
       fd = accept(config.bmp_sock, (struct sockaddr *) &client, &clen);
       if (fd == ERR) goto read_data;

--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -217,6 +217,8 @@ void skinny_bmp_daemon()
     }
   }
   setnonblocking(config.bmp_sock);
+  setsockopt(config.bmp_sock, SOL_SOCKET, SO_KEEPALIVE, (void *)&flags, sizeof(flags));
+
 
   if (config.nfacctd_bmp_ipprec) {
     int opt = config.nfacctd_bmp_ipprec << 5;
@@ -655,8 +657,6 @@ void skinny_bmp_daemon()
 
       fd = accept(config.bmp_sock, (struct sockaddr *) &client, &clen);
       if (fd == ERR) goto read_data;
-
-      setsockopt(config.bmp_sock, SOL_SOCKET, SO_KEEPALIVE, (void *)&flags, sizeof(flags));
 
       ipv4_mapped_to_ipv4(&client);
 


### PR DESCRIPTION
This solves a problem where it should have been on the fd variable but wasn't, and the first connected socket would not receive the SO_KEEPALIVE option.  Move this out of the loop to make it work better and all connections will inherit the SO_KEEPALIVE option