### PR TITLE
Fix building against >=nDPI-3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -923,6 +923,7 @@ AC_ARG_ENABLE(ndpi,
       CFLAGS="$_save_CFLAGS"
     ])
     PKG_CHECK_MODULES([NDPI26], [libndpi >= 2.6], [AC_DEFINE(WITH_NDPI26, 1)], [AC_DEFINE(WITH_NDPI, 1)])
+    PKG_CHECK_MODULES([NDPI30], [libndpi >= 3.0], [AC_DEFINE(WITH_NDPI30, 1)], [AC_DEFINE(WITH_NDPI, 1)])
     ;;
   no)
     AC_MSG_RESULT(no)

--- a/src/ndpi/ndpi.c
+++ b/src/ndpi/ndpi.c
@@ -374,10 +374,14 @@ struct ndpi_proto pm_ndpi_packet_processing(struct pm_ndpi_workflow *workflow,
   if (flow->detection_completed || flow->tcp_finished) {
     if (flow->detected_protocol.app_protocol == NDPI_PROTOCOL_UNKNOWN)
 #ifdef WITH_NDPI26
+#ifdef WITH_NDPI30
+	  flow->detected_protocol = ndpi_detection_giveup(workflow->ndpi_struct, flow->ndpi_flow, 1, workflow->prefs.protocol_guess);
+#else
       flow->detected_protocol = ndpi_detection_giveup(workflow->ndpi_struct, flow->ndpi_flow, workflow->prefs.protocol_guess);
+#endif /* WITH_NDPI30 */
 #else
       flow->detected_protocol = ndpi_detection_giveup(workflow->ndpi_struct, flow->ndpi_flow);
-#endif
+#endif /* WITH_NDPI26 */
 
     if (workflow->prefs.protocol_guess) {
       if (flow->detected_protocol.app_protocol == NDPI_PROTOCOL_UNKNOWN && !flow->guess_completed) {


### PR DESCRIPTION
```
ndpi.c: In function 'pm_ndpi_packet_processing':
ndpi.c:377:33: error: too few arguments to function 'ndpi_detection_giveup'
  377 |       flow->detected_protocol = ndpi_detection_giveup(workflow->ndpi_struct, flow->ndpi_flow, workflow->prefs.protocol_guess);
      |                                 ^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/ndpi/ndpi_main.h:31,
                 from ../pmacct.h:97,
                 from ndpi.c:30:
/usr/include/ndpi/ndpi_api.h:232:17: note: declared here
```

Signed-off-by: Jeroen Roovers <jer@gentoo.org>