### PR TITLE
Fixing BMP v flag test to allow IPv6 prefixes/peer

### DIFF
--- a/src/bmp/bmp_msg.c
+++ b/src/bmp/bmp_msg.c
@@ -853,7 +853,7 @@ void bmp_peer_hdr_get_v_flag(struct bmp_peer_hdr *bph, u_int8_t *family)
     (*family) = FALSE;
 
     if (version == 0) (*family) = AF_INET;
-    else if (version == 1) (*family) = AF_INET6;
+    else (*family) = AF_INET6;
   }
 }
 


### PR DESCRIPTION
The test on line 856 was originally checking `else if (version == 1) (*family) = AF_INET6;` which it seems will never be true.

In the case of IPv6:
`bph->flags & BMP_PEER_FLAGS_ARI_V` == `11010000 & 0x80` == 10000000 (binary) ==  128 integer

Debug output:
```
INFO bmp_peer_hdr_get_v_flag flags == 11010000
INFO bmp_peer_hdr_get_v_flag version (bin) == 10000000
INFO bmp_peer_hdr_get_v_flag version (int) == 128
```
With that check never passing for v6, `family` was never being set to a non-zero value, and the `if (bdata.family) {` test on line 434 never passes, and so v6 peers were always skipped.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
