### PR TITLE
Fix compile on debian buster

### DIFF
--- a/src/mysql_plugin.h
+++ b/src/mysql_plugin.h
@@ -22,10 +22,8 @@
 /* includes */
 #if defined HAVE_MYSQL_H 
 #include <mysql.h>
-#include <mysql_version.h>
 #else
 #include <mysql/mysql.h>
-#include <mysql/mysql_version.h>
 #endif
 
 #include "sql_common.h"


### PR DESCRIPTION
### Short description
I had to make this modification on a Debian 10.3 machine.

I received this error while running make before this patch:

make[2]: Entering directory '/root/pmacct/src'
  CC       libdaemons_la-util.lo
In file included from mysql_plugin.h:25,
                 from util.c:29:
/usr/include/mariadb/mysql_version.h:3:2: error: #warning This file should not be included by clients, include only <mysql.h> [-Werror=cpp]
 #warning This file should not be included by clients, include only <mysql.h>
  ^~~~~~~
cc1: all warnings being treated as errors

The patched fixed that.

### Checklist
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)

