### PR TITLE
uacctd: handle non-ethernet packets correctly

### DIFF
--- a/src/uacctd.c
+++ b/src/uacctd.c
@@ -53,8 +53,11 @@ static int nflog_incoming(struct nflog_g_handle *gh, struct nfgenmsg *nfmsg,
   struct pcap_pkthdr hdr;
   char *pkt = NULL;
   ssize_t pkt_len = nflog_get_payload(nfa, &pkt);
-  ssize_t mac_len = nflog_get_msg_packet_hwhdrlen(nfa);
+  ssize_t mac_len = 0;
   struct pm_pcap_callback_data *cb_data = p;
+
+  if (nflog_get_hwtype(nfa) == DLT_EN10MB)
+    mac_len = nflog_get_msg_packet_hwhdrlen(nfa);
 
   /* Check we can handle this packet */
   switch (nfmsg->nfgen_family) {


### PR DESCRIPTION
Use mac_len = 0 for non-ethernet packets. In this case zeroed ethernet header
is used.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [ ] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
