### PR TITLE
* fix, nDPI >= 3.2 requires to call ndpi_finalize_initalization

### DIFF
--- a/src/ndpi/ndpi_util.c
+++ b/src/ndpi/ndpi_util.c
@@ -78,6 +78,10 @@ struct pm_ndpi_workflow *pm_ndpi_workflow_init()
   NDPI_BITMASK_SET_ALL(all);
   ndpi_set_protocol_detection_bitmask2(workflow->ndpi_struct, &all);
 
+#if NDPI_MAJOR >= 3 && NDPI_MINOR >= 2
+  ndpi_finalize_initalization(workflow->ndpi_struct);
+#endif
+
   return workflow;
 }
 


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

### Short description
Newer nDPI libraries require calling ndpi_finalize_initialization somewhere after the detection module init finished.
It was first introduced in nDPI-0558d641f and released with 3.2

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
