### PR TITLE
Add `base` docker image and upload it automatically to docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,3 +197,18 @@ jobs:
   - <<: *build_test_centos_8_1
     name: "docker: Centos 8.1, CONFIG_FLAGS="
     env: CONFIG_FLAGS=""
+
+  ## User docker containers
+  - docker_hub_base:
+    stage: docker_hub
+    name: "docker_hub: base container"
+    env: PMACCT_VERSION=$(git describe --abbrev=0 --match="v*")
+    if: tag IS present
+    script:
+      - echo "Building the base container..."
+      - docker build -f docker/base/Dockerfile -t ${DOCKER_USERNAME}/base:latest .
+      - echo "Uploading to dockerhub ...";
+      - echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin;
+      - docker push ${DOCKER_USERNAME}/base:latest;
+      - docker tag ${DOCKER_USERNAME}/base:latest ${DOCKER_USERNAME}/base:${PMACCT_VERSION};
+      - docker push ${DOCKER_USERNAME}/base:${PMACCT_VERSION};

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ DOCUMENTATION
   * examples/: Sample configs, maps, AMQP/Kafka consumers, clients 
   * sql/: SQL documentation, default SQL schemas and customization tips
 
+# USING THE DOCKER IMAGE
+
+With docker installed, just pull the base image and you are ready to go:
+
+```bash
+
+ ~# docker pull pmacct/base:latest
+ ~# docker run -it pmacct/base
+
+```
+
 # BUILDING
 
 - Resolve dependencies, ie.:

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,70 @@
+##pmacct (Promiscuous mode IP Accounting package)
+##pmacct is Copyright (C) 2003-2020 by Paolo Lucente
+
+#Author: Marc Sune <marcdevel (at) gmail.com>
+
+#This Dockerfile creates a base docker image with pmacct and other useful
+#tools for network telemetry and monitoring
+
+FROM debian:buster
+MAINTAINER Marc Sune
+
+#Version or git ref(commit, tag, branch...)
+ARG version=HEAD
+
+RUN apt-get update && \
+    apt-get install -y \
+    autoconf \
+    automake \
+    bash \
+    bison \
+    cmake \
+    default-libmysqlclient-dev \
+    flex \
+    gcc \
+    g++ \
+    git \
+    libcurl4-openssl-dev \
+    libjansson-dev \
+    libnetfilter-log-dev \
+    libpcap-dev \
+    libpq-dev \
+    libsnappy-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libstdc++-8-dev \
+    libtool \
+    make \
+    pkg-config \
+    sudo \
+    wget \
+    zlib1g-dev
+
+#Install dependencies
+COPY ci/deps.sh /tmp/
+RUN /tmp/deps.sh
+
+#Install pmacct
+RUN cd /tmp/ && \
+  git clone https://github.com/pmacct/pmacct.git pmacct && \
+  cd pmacct && git checkout ${version} && \
+  export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
+  export AVRO_CFLAGS="-I/usr/local/avro/include" && \
+  sh autogen.sh && ./configure --enable-mysql --enable-pgsql --enable-sqlite3 --enable-kafka --enable-geoipv2 --enable-jansson --enable-rabbitmq --enable-nflog --enable-ndpi --enable-zmq --enable-avro --enable-serdes --enable-redis && \
+  sudo make install && \
+  cd ..
+
+#Cleanup
+RUN apt-get purge -y \
+  autoconf \
+  automake \
+  bison \
+  cmake \
+  gcc \
+  flex \
+  git \
+  make \
+  pkg-config
+RUN rm -rf /tmp*
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
### Short description

This patchset:

* Adds a `Dockerfile` in folder `docker/base` to build a container with `pmacct` already instaled, along with few utilities utilities
* Adds to `.travis-ci.yml` to upload, only when a release is *tagged* the container to {username}/base, with two tags:
  - `latest`: overriding whatever was latest before
  - `vX.Y.Z`: setting the version specific container, so that it can always be used
* Adds section in the `README` to use the docker container

In order to have the Travis - dockerhub integration work, 3 simple steps:

1. Go to dockerhub website and create a public docker registry under `pmacct` username called `base`. It's the name chosen - subject to discussion
2. In your dockerhub user preferences, tab security, create a token to be used as "password" for the travis CI
3. Go to travis-ci, and add `DOCKER_USERNAME` (pmacct) and `DOCKER_PASSWORD` with the token previously generated. Should be ready to go (https://miro.medium.com/max/1400/0*Qneql3m2L0YM4DIt.png)

You can test it by creating a dummy tag `vX.Y.Z` and pushing it to the repo, once merged.

Next steps:

* Have per daemon containers.

### Checklist
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
