### PR TITLE
.travis.yml: do not run hub_docker on PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -203,6 +203,7 @@ jobs:
     stage: docker_hub
     name: "docker_hub: base container"
     env: PMACCT_VERSION=$(git describe --abbrev=0 --match="v*")
+    if: type NOT IN (pull_request)
     script:
       - echo "Building the base container..."
       - docker build -f docker/base/Dockerfile -t base:_build .


### PR DESCRIPTION
### Short description

For security reasons, stage hub_docker should never be attempted
to run on a PR. Fortunately, travis is already wise enough not
to load the credentials to not screw things badly, but it makes
the pipeline fail - always - for PRs.

Make sure this stage is only run on legit commits.

### Checklist

I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
