### PR TITLE
Proxy protocol support

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -2718,6 +2718,14 @@ DESC:		Enables BGP proxying. Full pathname to a file to cross-connect BGP peers 
 		at runtime by sending the daemon a SIGUSR2 signal (ie. "killall -USR2 nfacctd").
 DEFAULT:	none
 
+KEY:            [ bmp_daemon_parse_proxy_header ]
+VALUES:         [ true | false ]
+DESC:           Defines whether to parse the first packet of a connection looking for a
+                Proxy Protocol header containing client information (IP addresses and TCP ports).
+                The source IP Address and TCP port of the header replaces the peer IP address and
+                peer TCP port obtained from the socket.
+DEFAULT:        False
+
 KEY:		rpki_roas_file [MAP, GLOBAL]
 DESC:		Full pathname to a file containing RPKI ROA data. Data encoding is JSON and format
 		is according to RIPE Validator format. ROA data can be obtained for example from

--- a/src/bgp/bgp.h
+++ b/src/bgp/bgp.h
@@ -203,6 +203,7 @@ struct bgp_peer {
   struct bgp_xconnect xc;
   struct bgp_peer_buf xbuf;
   int xconnect_fd;
+  int parsed_proxy_header;
 };
 
 struct bgp_msg_data {

--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -863,6 +863,16 @@ void skinny_bmp_daemon()
 
     if (!peer) goto select_again;
 
+    /* If first message after connect, check for proxy protocol header */
+    if (config.parse_proxy_header == TRUE && peer->parsed_proxy_header == 0) {
+      ret = parse_proxy_header(peer->fd, &peer->addr, &peer->tcp_port);
+      if (ret < 0) {
+        goto select_again; /* partial header */
+      }
+      addr_to_str(peer->addr_str, &peer->addr);
+    }
+    peer->parsed_proxy_header = 1;
+
     if (!config.pcap_savefile) {
       if (!peer->buf.exp_len) {
 	ret = recv(peer->fd, &peer->buf.base[peer->buf.cur_len], (BMP_CMN_HDRLEN - peer->buf.cur_len), 0);

--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -864,7 +864,7 @@ void skinny_bmp_daemon()
     if (!peer) goto select_again;
 
     /* If first message after connect, check for proxy protocol header */
-    if (config.parse_proxy_header == TRUE && peer->parsed_proxy_header == 0) {
+    if (config.bmp_daemon_parse_proxy_header == TRUE && peer->parsed_proxy_header == 0) {
       ret = parse_proxy_header(peer->fd, &peer->addr, &peer->tcp_port);
       if (ret < 0) {
         goto select_again; /* partial header */

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -586,6 +586,7 @@ static const struct _dictionary_line dictionary[] = {
   {"bmp_dump_kafka_partition_key", cfg_key_bmp_daemon_dump_kafka_partition_key},
   {"bmp_dump_kafka_config_file", cfg_key_bmp_daemon_dump_kafka_config_file},
   {"bmp_dump_kafka_avro_schema_registry", cfg_key_bmp_daemon_dump_kafka_avro_schema_registry},
+  {"bmp_daemon_parse_proxy_header", cfg_key_nfacctd_bmp_daemon_parse_proxy_header},
   {"rpki_roas_file", cfg_key_rpki_roas_file},
   {"rpki_rtr_cache", cfg_key_rpki_rtr_cache},
   {"rpki_rtr_cache_version", cfg_key_rpki_rtr_cache_version},
@@ -615,7 +616,6 @@ static const struct _dictionary_line dictionary[] = {
   {"tmp_asa_bi_flow", cfg_key_tmp_asa_bi_flow},
   {"tmp_bgp_lookup_compare_ports", cfg_key_tmp_bgp_lookup_compare_ports},
   {"tmp_bgp_daemon_route_refresh", cfg_key_tmp_bgp_daemon_route_refresh},
-  {"parse_proxy_header", cfg_key_parse_proxy_header},
   {"", NULL}
 };
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -615,6 +615,7 @@ static const struct _dictionary_line dictionary[] = {
   {"tmp_asa_bi_flow", cfg_key_tmp_asa_bi_flow},
   {"tmp_bgp_lookup_compare_ports", cfg_key_tmp_bgp_lookup_compare_ports},
   {"tmp_bgp_daemon_route_refresh", cfg_key_tmp_bgp_daemon_route_refresh},
+  {"parse_proxy_header", cfg_key_parse_proxy_header},
   {"", NULL}
 };
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -583,7 +583,7 @@ struct configuration {
   int rpki_rtr_cache_version;
   int rpki_rtr_cache_pipe_size;
   int rpki_rtr_cache_ipprec;
-  int parse_proxy_header;
+  int bmp_daemon_parse_proxy_header;
 };
 
 /* prototypes */ 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -583,6 +583,7 @@ struct configuration {
   int rpki_rtr_cache_version;
   int rpki_rtr_cache_pipe_size;
   int rpki_rtr_cache_ipprec;
+  int parse_proxy_header;
 };
 
 /* prototypes */ 

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -8221,3 +8221,17 @@ int cfg_key_print_output_custom_cfg_file(char *filename, char *name, char *value
 
   return changes;
 }
+
+int cfg_key_parse_proxy_header(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  for (; list; list = list->next, changes++) list->cfg.parse_proxy_header = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'parse_proxy_header'. Globalized.\n", filename);
+
+  return changes;
+}

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -8222,7 +8222,7 @@ int cfg_key_print_output_custom_cfg_file(char *filename, char *name, char *value
   return changes;
 }
 
-int cfg_key_parse_proxy_header(char *filename, char *name, char *value_ptr)
+int cfg_key_nfacctd_bmp_daemon_parse_proxy_header(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;
   int value, changes = 0;
@@ -8230,8 +8230,8 @@ int cfg_key_parse_proxy_header(char *filename, char *name, char *value_ptr)
   value = parse_truefalse(value_ptr);
   if (value < 0) return ERR;
 
-  for (; list; list = list->next, changes++) list->cfg.parse_proxy_header = value;
-  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'parse_proxy_header'. Globalized.\n", filename);
+  for (; list; list = list->next, changes++) list->cfg.bmp_daemon_parse_proxy_header = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'bmp_daemon_parse_proxy_header'. Globalized.\n", filename);
 
   return changes;
 }

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -487,6 +487,7 @@ extern int cfg_key_dump_max_writers(char *, char *, char *);
 extern int cfg_key_tmp_asa_bi_flow(char *, char *, char *);
 extern int cfg_key_tmp_bgp_lookup_compare_ports(char *, char *, char *);
 extern int cfg_key_tmp_bgp_daemon_route_refresh(char *, char *, char *);
+extern int cfg_key_parse_proxy_header(char *, char *, char *);
 
 extern void parse_time(char *, char *, int *, int *);
 extern void cfg_set_aggregate(char *, u_int64_t [], u_int64_t, char *);

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -462,6 +462,7 @@ extern int cfg_key_bmp_daemon_dump_kafka_partition(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_kafka_partition_key(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_kafka_config_file(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_kafka_avro_schema_registry(char *, char *, char *);
+extern int cfg_key_nfacctd_bmp_daemon_parse_proxy_header(char *, char *, char *);
 extern int cfg_key_nfacctd_flow_to_rd_map(char *, char *, char *);
 extern int cfg_key_nfacctd_isis(char *, char *, char *);
 extern int cfg_key_nfacctd_isis_ip(char *, char *, char *);
@@ -487,7 +488,6 @@ extern int cfg_key_dump_max_writers(char *, char *, char *);
 extern int cfg_key_tmp_asa_bi_flow(char *, char *, char *);
 extern int cfg_key_tmp_bgp_lookup_compare_ports(char *, char *, char *);
 extern int cfg_key_tmp_bgp_daemon_route_refresh(char *, char *, char *);
-extern int cfg_key_parse_proxy_header(char *, char *, char *);
 
 extern void parse_time(char *, char *, int *, int *);
 extern void cfg_set_aggregate(char *, u_int64_t [], u_int64_t, char *);

--- a/src/network.c
+++ b/src/network.c
@@ -21,7 +21,7 @@ int parse_proxy_header(int fd, struct host_addr *addr, u_int16_t *port)
   }
 
   if (memcmp(hdr.v1.line, "PROXY", 5) == 0) {
-    Log(LOG_DEBUG, "DEBUG Proxy Protocol V1\n");
+    Log(LOG_DEBUG, "DEBUG ( %s/%s ): Proxy Protocol V1\n", config.name, config.type);
 
     char *end = memchr(hdr.v1.line, '\r', ret - 1);
     if (!end || end[1] != '\n')  {
@@ -30,7 +30,7 @@ int parse_proxy_header(int fd, struct host_addr *addr, u_int16_t *port)
     end = '\0';
 
     /* V1 Header contains string: PROXY TCP4 <src ip> <dst ip> <src port> <dst port>\r\n */
-    Log(LOG_INFO, "INFO Replacing: %s:%u\n", ip_address, *port);
+    Log(LOG_INFO, "INFO ( %s/%s ): Replacing: %s:%u\n", config.name, config.type, ip_address, *port);
 
     /* Find the Source IP Address */
     char *s = &hdr.v1.line[11];
@@ -43,14 +43,14 @@ int parse_proxy_header(int fd, struct host_addr *addr, u_int16_t *port)
     s = e + 1;
     *port = strtoul(s, 0, 10);
 
-    Log(LOG_INFO, "                with Proxy Protocol V1 containing: %s:%u\n", ip_address, *port);
+    Log(LOG_INFO, "INFO ( %s/%s ):            with Proxy Protocol V1 containing: %s:%u\n", config.name, config.type, ip_address, *port);
     str_to_addr(ip_address, addr);
 
     /* Consume the proxy protocol header for real, skip header + CRLF */
     size = (end + 2 - hdr.v1.line);
   }
   else if (memcmp(&hdr.v2, v2sig, 12) == 0) {
-    Log(LOG_DEBUG, "DEBUG Proxy Protocol V2\n");
+    Log(LOG_DEBUG, "DEBUG ( %s/%s ): Proxy Protocol V2\n", config.name, config.type);
 
     size = (16 + ntohs(hdr.v2.len));
     if (ret < size) {
@@ -58,31 +58,31 @@ int parse_proxy_header(int fd, struct host_addr *addr, u_int16_t *port)
     }
 
     if (((hdr.v2.ver_cmd & 0xF0) == 0x20) && ((hdr.v2.ver_cmd & 0x0F) == 0x01)) {
-      Log(LOG_DEBUG, "DEBUG Proxy Protocol PROXY command\n");
+      Log(LOG_DEBUG, "DEBUG ( %s/%s ): Proxy Protocol PROXY command\n", config.name, config.type);
 
       if (hdr.v2.fam == 0x11) {
-        Log(LOG_DEBUG, "DEBUG Proxy Protocol TCP/IPv4\n");
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): Proxy Protocol TCP/IPv4\n", config.name, config.type);
 
         /* Replace IP address string originally obtained from socket */
-        Log(LOG_INFO, "INFO Replacing: %s:%u\n", ip_address, *port);
+        Log(LOG_INFO, "INFO ( %s/%s ): Replacing: %s:%u\n", config.name, config.type, ip_address, *port);
         addr->family = AF_INET;
         memcpy(&addr->address.ipv4.s_addr, &hdr.v2.addr.ip4.src_addr, sizeof(hdr.v2.addr.ip4.src_addr));
         *port = ntohs(hdr.v2.addr.ip4.src_port);
 
         addr_to_str(ip_address, addr);
-        Log(LOG_INFO, "                with Proxy Protocol V2 containing: %s:%u\n", ip_address, *port);
+        Log(LOG_INFO, "INFO ( %s/%s ):            with Proxy Protocol V2 containing: %s:%u\n", config.name, config.type, ip_address, *port);
       }
       else {
-        Log(LOG_DEBUG, "DEBUG Proxy Protocol (TODO) Unsupported family: %u\n", hdr.v2.fam);
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): Proxy Protocol (TODO) Unsupported family: %u\n", config.name, config.type, hdr.v2.fam);
       }
     }
     else if (((hdr.v2.ver_cmd & 0xF0) == 0x20) && ((hdr.v2.ver_cmd & 0x0F) == 0x00)) {
       /* LOCAL Command. Health Check. Use real conection endpoints. */
-      Log(LOG_DEBUG, "DEBUG Proxy Protocol LOCAL command\n");
+      Log(LOG_DEBUG, "DEBUG ( %s/%s ): Proxy Protocol LOCAL command\n", config.name, config.type);
     }
   }
   else {
-    Log(LOG_DEBUG, "DEBUG Not Proxy Protocol\n");
+    Log(LOG_DEBUG, "DEBUG ( %s/%s ): Not Proxy Protocol\n", config.name, config.type);
   }
 
   if (size > 0) {

--- a/src/network.c
+++ b/src/network.c
@@ -1,4 +1,94 @@
 #include "pmacct.h"
+#include "addr.h"
 #include "network.h"
 
 struct tunnel_handler tunnel_registry[TUNNEL_REGISTRY_STACKS][TUNNEL_REGISTRY_ENTRIES];
+
+int parse_proxy_header(int fd, struct host_addr *addr, u_int16_t *port)
+{
+  const char v2sig[12] = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A";
+  char ip_address[INET6_ADDRSTRLEN];
+  size_t size = 0;
+  proxy_protocol_header hdr;
+
+  addr_to_str(ip_address, addr);
+
+  int ret = recv(fd, &hdr, sizeof(hdr), MSG_PEEK);
+
+  /* 16 bytes can detect both V1 and V2 protocols */
+  if (ret < 16) {
+    return -1;
+  }
+
+  if (memcmp(hdr.v1.line, "PROXY", 5) == 0) {
+    Log(LOG_DEBUG, "DEBUG Proxy Protocol V1\n");
+
+    char *end = memchr(hdr.v1.line, '\r', ret - 1);
+    if (!end || end[1] != '\n')  {
+      return -1;
+    }
+    end = '\0';
+
+    /* V1 Header contains string: PROXY TCP4 <src ip> <dst ip> <src port> <dst port>\r\n */
+    Log(LOG_INFO, "INFO Replacing: %s:%u\n", ip_address, *port);
+
+    /* Find the Source IP Address */
+    char *s = &hdr.v1.line[11];
+    char *e = strchr(s, ' ');
+    snprintf(ip_address, (e - s + 1), "%s", s);
+
+    /* Find the Source TCP Port */
+    s = e + 1;
+    e = strchr(s, ' ');
+    s = e + 1;
+    *port = strtoul(s, 0, 10);
+
+    Log(LOG_INFO, "                with Proxy Protocol V1 containing: %s:%u\n", ip_address, *port);
+    str_to_addr(ip_address, addr);
+
+    /* Consume the proxy protocol header for real, skip header + CRLF */
+    size = (end + 2 - hdr.v1.line);
+  }
+  else if (memcmp(&hdr.v2, v2sig, 12) == 0) {
+    Log(LOG_DEBUG, "DEBUG Proxy Protocol V2\n");
+
+    size = (16 + ntohs(hdr.v2.len));
+    if (ret < size) {
+      return -1;
+    }
+
+    if (((hdr.v2.ver_cmd & 0xF0) == 0x20) && ((hdr.v2.ver_cmd & 0x0F) == 0x01)) {
+      Log(LOG_DEBUG, "DEBUG Proxy Protocol PROXY command\n");
+
+      if (hdr.v2.fam == 0x11) {
+        Log(LOG_DEBUG, "DEBUG Proxy Protocol TCP/IPv4\n");
+
+        /* Replace IP address string originally obtained from socket */
+        Log(LOG_INFO, "INFO Replacing: %s:%u\n", ip_address, *port);
+        addr->family = AF_INET;
+        memcpy(&addr->address.ipv4.s_addr, &hdr.v2.addr.ip4.src_addr, sizeof(hdr.v2.addr.ip4.src_addr));
+        *port = ntohs(hdr.v2.addr.ip4.src_port);
+
+        addr_to_str(ip_address, addr);
+        Log(LOG_INFO, "                with Proxy Protocol V2 containing: %s:%u\n", ip_address, *port);
+      }
+      else {
+        Log(LOG_DEBUG, "DEBUG Proxy Protocol (TODO) Unsupported family: %u\n", hdr.v2.fam);
+      }
+    }
+    else if (((hdr.v2.ver_cmd & 0xF0) == 0x20) && ((hdr.v2.ver_cmd & 0x0F) == 0x00)) {
+      /* LOCAL Command. Health Check. Use real conection endpoints. */
+      Log(LOG_DEBUG, "DEBUG Proxy Protocol LOCAL command\n");
+    }
+  }
+  else {
+    Log(LOG_DEBUG, "DEBUG Not Proxy Protocol\n");
+  }
+
+  if (size > 0) {
+    /* Consume the proxy protocol header for real */
+    ret = recv(fd, &hdr, size, 0);
+  }
+
+  return 0;
+}

--- a/src/network.h
+++ b/src/network.h
@@ -658,4 +658,40 @@ struct tunnel_entry {
 
 /* global variables */
 extern struct tunnel_handler tunnel_registry[TUNNEL_REGISTRY_STACKS][TUNNEL_REGISTRY_ENTRIES];
+
+/* http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt */
+typedef struct {
+  union {
+    struct {
+        char line[108];
+    } v1;
+    struct {
+        uint8_t sig[12];
+        uint8_t ver_cmd;
+        uint8_t fam;
+        uint16_t len;
+        union {
+            struct {  /* for TCP/UDP over IPv4, len = 12 */
+                uint32_t src_addr;
+                uint32_t dst_addr;
+                uint16_t src_port;
+                uint16_t dst_port;
+            } ip4;
+            struct {  /* for TCP/UDP over IPv6, len = 36 */
+                 uint8_t  src_addr[16];
+                 uint8_t  dst_addr[16];
+                 uint16_t src_port;
+                 uint16_t dst_port;
+            } ip6;
+            struct {  /* for AF_UNIX sockets, len = 216 */
+                 uint8_t src_addr[108];
+                 uint8_t dst_addr[108];
+            } unx;
+        } addr;
+    } v2;
+  };
+} proxy_protocol_header;
+
+int parse_proxy_header(int fd, struct host_addr *addr, u_int16_t *port);
+
 #endif //PMACCT_NETWORK_H


### PR DESCRIPTION
### Contributions
1. The code and any documentation or other material submitted therewith, (collectively, the “Contribution”) is provided by Akamai Technologies, Inc. (“Akamai”) “AS IS” WITHOUT REPRESENTATIONS OR WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY REPRESENTATIONS OR WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSES.
2. The contributor is authorized to submit only this Contribution, dated [July 9, 2020], on behalf of Akamai, and the contributor is not authorized to submit additional contributions on behalf of Akamai without further authorization by Akamai.
3. Akamai shall not be expected to provide, and shall not provide, support for the Contribution.

### Short description
Add support for BMP parsing of a Proxy Protocol header from the first packet of a new connection, replacing the peer's IP address and TCP port determined from the socket with the client's source IP address and TCP port found within the Proxy Protocol header. This functionality is enabled or disabled via a new configuration parameter. Code has been tested only for IPv4 (future TODO for IPv6).

### Checklist
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [y ] compiled & tested this code
- [y ] included documentation (including possible behaviour changes)
