### PR TITLE
adding crc32 as another method of hashing for tee plugin

### DIFF
--- a/examples/tee_receivers.lst.example
+++ b/examples/tee_receivers.lst.example
@@ -22,7 +22,8 @@
 !			robin, 'hash-tag' hashing of tag (pre_tag_map)
 !			against the number of receivers in pool, 'hash-agent'
 !			hashing of the exporter/agent IP address against
-!			the number of receivers in pool.
+!			the number of receivers in pool,
+!           'hash-crc32' same as hash-agent but uses crc32 as hash function.
 ! 'src_port'		SET: When in non-transparent replication mode, use
 !			the specified UDP port to send data to receiver(s) 
 ! 'kafka_broker'	SET: Defines the Kafka broker host to emit to. It

--- a/src/tee_plugin/tee_plugin.h
+++ b/src/tee_plugin/tee_plugin.h
@@ -88,6 +88,7 @@ extern int Tee_prepare_sock(struct sockaddr *, socklen_t, u_int16_t, int, int);
 extern int Tee_parse_hostport(const char *, struct sockaddr *, socklen_t *, int);
 extern struct tee_receiver *Tee_rr_balance(void *, struct pkt_msg *);
 extern struct tee_receiver *Tee_hash_agent_balance(void *, struct pkt_msg *);
+extern struct tee_receiver *Tee_hash_agent_crc32(void *, struct pkt_msg *);
 extern struct tee_receiver *Tee_hash_tag_balance(void *, struct pkt_msg *);
 extern void Tee_select_templates(unsigned char *, int, int, unsigned char *, int *);
 

--- a/src/tee_plugin/tee_recvs.c
+++ b/src/tee_plugin/tee_recvs.c
@@ -136,6 +136,10 @@ int tee_recvs_map_balance_alg_handler(char *filename, struct id_entry *e, char *
       table->pools[table->num].balance.type = TEE_BALANCE_HASH_AGENT;
       table->pools[table->num].balance.func = Tee_hash_agent_balance;
     }
+	else if (!strncmp(value, "hash-crc32", 10)) {
+      table->pools[table->num].balance.type = TEE_BALANCE_HASH_AGENT;
+      table->pools[table->num].balance.func = Tee_hash_agent_crc32;
+	}
     else if (!strncmp(value, "hash-tag", 8)) {
       table->pools[table->num].balance.type = TEE_BALANCE_HASH_TAG;
       table->pools[table->num].balance.func = Tee_hash_tag_balance;


### PR DESCRIPTION
I have added crc32 hash algorithm as an option for tee_plugin.
It's aim is to get a better balancing to receiver nodes.

example of usage receivers.lst:
id=1    ip=127.0.0.1:2001,127.0.0.1:2002,127.0.0.1:2003 balance-alg=hash-crc32