### PR TITLE
    ISSUE # 436 Valgrind detected a memory leak in bgp_aspath.c

### DIFF
--- a/src/bgp/bgp_aspath.c
+++ b/src/bgp/bgp_aspath.c
@@ -503,7 +503,10 @@ aspath_make_str_count (struct aspath *as)
   char *str_buf;
 
   /* Empty aspath. */
-  if (!as->segments) str_buf = aspath_make_empty();
+  if (!as->segments) {
+    str_buf = aspath_make_empty();
+    return str_buf;
+  }
 
   seg = as->segments;
   


### PR DESCRIPTION
1. The code and any documentation or other material submitted therewith, (collectively, the “Contribution”) is provided by Akamai Technologies, Inc. (“Akamai”) “AS IS” WITHOUT REPRESENTATIONS OR WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY REPRESENTATIONS OR WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSES.
2. The contributor is authorized to submit only this Contribution, dated [October 28, 2020], on behalf of Akamai, and the contributor is not authorized to submit additional contributions on behalf of Akamai without further authorization by Akamai.
3. Akamai shall not be expected to provide, and shall not provide, support for the Contribution.


    add return after generating str_path via aspath_make_empty

### Short description
The memory allocated by aspath_make_empty() into str_buf was leaked as str_buf was subsequently reassigned.
The code has been changed to return str_buf instead.

### Checklist
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [ y] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
