### PR TITLE
submodules: fix cross-compilation and pass enable/disable-silent-rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1131,6 +1131,10 @@ else
 fi
 
 AM_CONDITIONAL([WITH_EXTERNAL_DEPS], [test "x$WITH_EXTERNAL_DEPS" = "xyes"])
+AS_CASE(["$AM_DEFAULT_VERBOSITY"],
+  [0], [AC_SUBST([configure_silent_rules_val], [--enable-silent-rules])],
+  [1], [AC_SUBST([configure_silent_rules_val], [--disable-silent-rules])],
+  [AC_SUBST([configure_silent_rules_val], [--enable-silent-rules])])
 
 dnl --------------------------------------
 

--- a/src/external_libs/Makefile.am
+++ b/src/external_libs/Makefile.am
@@ -24,7 +24,7 @@ _libcdada:
 		cd $(abs_srcdir)/libcdada/ && \
 		./autogen.sh &&\
 		cd $(abs_builddir)/libcdada/build && \
-		$(abs_srcdir)/libcdada/configure --disable-shared --host=$(host_alias) \
+		$(abs_srcdir)/libcdada/configure --disable-shared --host=$(host_alias) @configure_silent_rules_val@ \
 		--prefix=$(abs_builddir)/rootfs && make $(MAKE_JOBS) install;\
 		if [ $$? != 0 ]; then exit 1; fi; \
 		echo "$(shell cd $(abs_srcdir)/libcdada && git rev-parse HEAD)" > $(abs_builddir)/.libcdada_mark;\

--- a/src/external_libs/Makefile.am
+++ b/src/external_libs/Makefile.am
@@ -24,7 +24,7 @@ _libcdada:
 		cd $(abs_srcdir)/libcdada/ && \
 		./autogen.sh &&\
 		cd $(abs_builddir)/libcdada/build && \
-		$(abs_srcdir)/libcdada/configure --disable-shared \
+		$(abs_srcdir)/libcdada/configure --disable-shared --host=$(host_alias) \
 		--prefix=$(abs_builddir)/rootfs && make $(MAKE_JOBS) install;\
 		if [ $$? != 0 ]; then exit 1; fi; \
 		echo "$(shell cd $(abs_srcdir)/libcdada && git rev-parse HEAD)" > $(abs_builddir)/.libcdada_mark;\


### PR DESCRIPTION
### Short description

This commit:

* Fixes cross-compilation of git submodule libraries by correctly setting `--host=` using `$host_alias` result of the parent `pmacct`'s `configure.ac`
* Passes by the value of `--enable/--disable-silent-rules` to the git submodule build system, by defining a new `AC_SUBST` (`@configure_silent_rules_val@`). Default remains `--enable-silent-rules`, as `pmacct`'s package.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
