### PR TITLE
external_libs: fix submodule init for vintage gits

### DIFF
--- a/src/external_libs/Makefile.am
+++ b/src/external_libs/Makefile.am
@@ -3,6 +3,9 @@ BUILT_SOURCES = submodule_deps
 CLEANFILES = .libcdada_mark
 
 #NOTE make sure Makefile targets don't have the same name of the folder
+#NOTE2 some pmacct users _love_ vintage software, and they run versions of git
+#      (like v1.8.3) which don't support initializing submodules from anywhere other
+#      than the root.... sigh
 
 ##
 ## LIBCDADA
@@ -15,8 +18,10 @@ _libcdada:
 	echo "[dep: libcdada] Checking..."; \
 	if [[ ! -f "$(abs_srcdir)/libcdada/.git" ]]; then \
 		echo "[dep: libcdada] Cloning and checking out commit..";\
-		git submodule update --init --recursive libcdada; \
+		cd $(abs_top_srcdir); \
+		git submodule update --init --recursive src/external_libs/libcdada; \
 		if [ $$? != 0 ]; then exit 1; fi;\
+		cd $(abs_builddir); \
 	fi;\
 	if [[ ( ! -f $(abs_builddir)/.libcdada_mark ) || "$(shell cat $(abs_builddir)/.libcdada_mark 2> /dev/null)" != "$(shell cd $(abs_srcdir)/libcdada && git rev-parse HEAD)" ]]; then \
 		echo "[dep: libcdada] Building...";\


### PR DESCRIPTION
### Short description

Some pmacct are confessed vintage SW aficionados. In particular,
Centos7 ships with git v1.8.3.1. Old versions of git can't initialize
a submodule if not done from the root of the supermodule.

Therefore, workaround it by temporally moving to abs_top_srcdir, and
then go back to the builddir.

<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
