### PR TITLE
configure.ac: check for C++ compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1140,6 +1140,11 @@ dnl --------------------------------------
 
 dnl libcdada requires C++ (and needs to add libstdc++ to LDFLAGS
 AC_PROG_CXX
+AC_MSG_CHECKING([for a valid C++ compiler])
+AC_LANG_PUSH([C++])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],[AC_MSG_RESULT(yes)],[AC_MSG_ERROR([No C++ compiler found])])
+AC_LANG_POP([C++])
+
 LIBS="-lcdada -lstdc++ ${LIBS}"
 AS_CASE(["$WITH_EXTERNAL_DEPS"],
   [yes], [],


### PR DESCRIPTION
### Short description

Prior to this commit, if libcdada (C++ dependent) was compiled, and
no C++ compiler was found, the build was failing at the compilation
stage.

This patch makes sure this check is happening during configure time,
and a clear warning is printed to the user

<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
