### PR TITLE
Fix build for *BSD systems, gcc-4.2 and submodule updates

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,8 @@ pmacct-build.h_h:
 			echo "`git rev-parse HEAD`" > .pmacct-build.h; \
 			BUILD_DATE="`git log -1 --date=short --pretty=format:%ad | tr -d "-"`"; \
 			BUILD_AUX="`git log -1 --date=short --pretty=format:%ad`";\
-			BUILD_COMMITS="`git log --date=short --pretty=format:%ad | sort | uniq -c | grep $$BUILD_AUX | awk '{print $$1}' | xargs -n 1 expr -1 + `"; \
+			BUILD_COMMITS="`git log --date=short --pretty=format:%ad | sort | uniq -c | grep $$BUILD_AUX | awk '{print $$1}'`"; \
+			BUILD_COMMITS="$$(($$BUILD_COMMITS - 1))"; \
 			BUILD_HASH_SHORT="`git rev-parse --short HEAD`"; \
 			echo "#define PMACCT_BUILD \"$$BUILD_DATE-$$BUILD_COMMITS ($$BUILD_HASH_SHORT)\"" >> pmacct-build.h; \
 		else \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,14 +24,15 @@ BUILT_SOURCES = pmacct-build.h_h
 .PHONY = pmacct-build.h
 
 pmacct-build.h_h:
-	@if [[ ! -f ".pmacct-build.h" || "$(shell cat .pmacct-build.h)" != "$(shell git rev-parse HEAD)" ]]; then \
+	@if [ ! -f ".pmacct-build.h" ] || [ "`cat .pmacct-build.h`" != "`git rev-parse HEAD`" ]; then \
 		echo "#ifndef PMACCT_BUILD_STR" > pmacct-build.h; \
 		echo "#define PMACCT_BUILD_STR" >> pmacct-build.h; \
-		if [[ "x$(shell git rev-parse --is-inside-work-tree 2> /dev/null)" == "xtrue" ]]; then \
-			echo "$(shell git rev-parse HEAD)" > .pmacct-build.h; \
-			BUILD_DATE="$(shell git log -1 --date=short --pretty=format:%ad | tr -d "-")"; \
-			BUILD_COMMITS="$(shell git log --date=short --pretty=format:%ad | sort | uniq -c | grep `git log -1 --date=short --pretty=format:%ad` | awk '{print $$1}' | xargs -n 1 expr -1 + )"; \
-			BUILD_HASH_SHORT="$(shell git rev-parse --short HEAD)"; \
+		if [ "x`git rev-parse --is-inside-work-tree 2> /dev/null`" == "xtrue" ]; then \
+			echo "`git rev-parse HEAD`" > .pmacct-build.h; \
+			BUILD_DATE="`git log -1 --date=short --pretty=format:%ad | tr -d "-"`"; \
+			BUILD_AUX="`git log -1 --date=short --pretty=format:%ad`";\
+			BUILD_COMMITS="`git log --date=short --pretty=format:%ad | sort | uniq -c | grep $$BUILD_AUX | awk '{print $$1}' | xargs -n 1 expr -1 + `"; \
+			BUILD_HASH_SHORT="`git rev-parse --short HEAD`"; \
 			echo "#define PMACCT_BUILD \"$$BUILD_DATE-$$BUILD_COMMITS ($$BUILD_HASH_SHORT)\"" >> pmacct-build.h; \
 		else \
 			echo "#define PMACCT_BUILD \"RELEASE\"" >> pmacct-build.h; \

--- a/src/bgp/bgp.h
+++ b/src/bgp/bgp.h
@@ -20,6 +20,7 @@
 */
 
 /* includes */
+#include <pthread.h>
 #include <sys/poll.h>
 #include "bgp_prefix.h"
 #include "bgp_packet.h"

--- a/src/external_libs/Makefile.am
+++ b/src/external_libs/Makefile.am
@@ -11,19 +11,19 @@ CLEANFILES = .libcdada_mark
 ## LIBCDADA
 ##
 _libcdada:
-	@if [[ -z "$(shell git rev-parse HEAD 2> /dev/null)" ]]; then \
+	if [ -z "`git rev-parse HEAD 2> /dev/null`" ]; then \
 		echo "[dep: libcdada] Skipping, not a git repository!"; \
 		exit 0;\
 	fi;\
 	echo "[dep: libcdada] Checking..."; \
-	if [[ ! -f "$(abs_srcdir)/libcdada/.git" ]]; then \
+	if [ ! -f "$(abs_srcdir)/libcdada/.git" ]; then \
 		echo "[dep: libcdada] Cloning and checking out commit..";\
 		cd $(abs_top_srcdir); \
 		git submodule update --init --recursive src/external_libs/libcdada; \
 		if [ $$? != 0 ]; then exit 1; fi;\
 		cd $(abs_builddir); \
 	fi;\
-	if [[ ( ! -f $(abs_builddir)/.libcdada_mark ) || "$(shell cat $(abs_builddir)/.libcdada_mark 2> /dev/null)" != "$(shell cd $(abs_srcdir)/libcdada && git rev-parse HEAD)" ]]; then \
+	if [ ! -f $(abs_builddir)/.libcdada_mark ] || [ "`cat $(abs_builddir)/.libcdada_mark 2> /dev/null`" != "`cd $(abs_srcdir)/libcdada && git rev-parse HEAD`" ]; then \
 		echo "[dep: libcdada] Building...";\
 		mkdir -p $(abs_builddir)/libcdada/build || true; \
 		cd $(abs_srcdir)/libcdada/ && \
@@ -32,7 +32,7 @@ _libcdada:
 		$(abs_srcdir)/libcdada/configure --disable-shared --host=$(host_alias) @configure_silent_rules_val@ \
 		--prefix=$(abs_builddir)/rootfs && make $(MAKE_JOBS) install;\
 		if [ $$? != 0 ]; then exit 1; fi; \
-		echo "$(shell cd $(abs_srcdir)/libcdada && git rev-parse HEAD)" > $(abs_builddir)/.libcdada_mark;\
+		echo "`cd $(abs_srcdir)/libcdada && git rev-parse HEAD`" > $(abs_builddir)/.libcdada_mark;\
 		if [ $$? != 0 ]; then exit 1; fi; \
 		echo "[dep: libcdada] Done!";\
 	else\
@@ -53,4 +53,4 @@ maintainer-clean-local: _libcdada_maintainer_clean
 	rm -rf $(abs_builddir)/rootfs
 
 #Placed abnormally here, just because vim syntax highlighter has a bug
-MAKE_JOBS := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j \2/p')
+MAKE_JOBS := `ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j \2/p'`

--- a/src/external_libs/Makefile.am
+++ b/src/external_libs/Makefile.am
@@ -11,7 +11,7 @@ CLEANFILES = .libcdada_mark
 ## LIBCDADA
 ##
 _libcdada:
-	if [ -z "`git rev-parse HEAD 2> /dev/null`" ]; then \
+	@if [ -z "`git rev-parse HEAD 2> /dev/null`" ]; then \
 		echo "[dep: libcdada] Skipping, not a git repository!"; \
 		exit 0;\
 	fi;\
@@ -23,7 +23,19 @@ _libcdada:
 		if [ $$? != 0 ]; then exit 1; fi;\
 		cd $(abs_builddir); \
 	fi;\
-	if [ ! -f $(abs_builddir)/.libcdada_mark ] || [ "`cat $(abs_builddir)/.libcdada_mark 2> /dev/null`" != "`cd $(abs_srcdir)/libcdada && git rev-parse HEAD`" ]; then \
+	if [ ! -f $(abs_builddir)/.libcdada_mark ] || \
+		[ "`cat $(abs_builddir)/.libcdada_mark 2> /dev/null`" != "`git ls-tree HEAD $(abs_srcdir)/libcdada/ | awk '{print $$3}'`" ] || \
+		[ "`cat $(abs_builddir)/.libcdada_mark 2> /dev/null`" != "`cd $(abs_srcdir)/libcdada && git rev-parse HEAD`" ]; then \
+		\
+		if [ -z "$$PMACCT_EXT_LIBS_DONT_SYNC" ]; then \
+			echo "[dep: libcdada] Syncing commit...";\
+			cd $(abs_top_srcdir); \
+			git submodule update --init --recursive src/external_libs/libcdada; \
+			if [ $$? != 0 ]; then exit 1; fi;\
+			cd $(abs_builddir); \
+		else\
+			echo "[dep: libcdada] Skipping commit sync..";\
+		fi;\
 		echo "[dep: libcdada] Building...";\
 		mkdir -p $(abs_builddir)/libcdada/build || true; \
 		cd $(abs_srcdir)/libcdada/ && \


### PR DESCRIPTION
### Short description


This MR addresses some portability issues found while compiling in openBSD, with a rather old gcc-4.2. It fixes:

* Substitutes `$(shell <cmd>)` by `` in all Makefiles, fixing `pmacct-build.h` generation and submodule compilation. 
* Bumps `libcdada` dependency to v0.3.4, which fixes compilation warnings in ancient gcc-4.2
* Fixes compilation in *BSD due to missing `pthread.h` in `bgp.h`
* Fixes bug in which, when getting new pmacct commits (`git pull`) on an already cloned repository, and when those commits where updating submodules, the deduction on whether the submodule deps had to be compiled or not was incorrect.

This MR has been tested in:

* Linux (debian9)
* OpenBSD 6.8

### Checklist

I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
