### PR TITLE
    ISSUE 463

### DIFF
--- a/src/bgp/bgp_util.c
+++ b/src/bgp/bgp_util.c
@@ -1504,6 +1504,7 @@ int bgp_peer_sa_addr_cmp(const void *a, const void *b)
 
 void bgp_peer_free(void *a)
 {
+  free((char *)a);
 }
 
 int bgp_peers_bintree_walk_print(const void *nodep, const pm_VISIT which, const int depth, void *extra)


### PR DESCRIPTION
    Fix Memory Leak bgp_peer_free

### Short description
This Pull Request fixes issue #463 by invoking free() on the key allocated by pm_tsearch() and freed by pm_tdestroy()

1. The code and any documentation or other material submitted therewith, (collectively, the “Contribution”) is provided by Akamai Technologies, Inc. (“Akamai”) “AS IS” WITHOUT REPRESENTATIONS OR WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY REPRESENTATIONS OR WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSES. 2. The contributor is authorized to submit only this Contribution, dated [January 21, 2021], on behalf of Akamai, and the contributor is not authorized to submit additional contributions on behalf of Akamai without further authorization by Akamai. 3. Akamai shall not be expected to provide, and shall not provide, support for the Contribution.
--


### Checklist
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [ y] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
