### PR TITLE
configure.ac: fix external-deps help format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1110,7 +1110,7 @@ fi
 
 AC_MSG_CHECKING([whether external dependencies (git submodules) should be compiled])
 AC_ARG_WITH(external-deps,
-		AS_HELP_STRING([--without-external-deps], ["Don't build external dependencies (git submodules). Specially useful for package maintainers [default=with]"]),
+		AS_HELP_STRING([--without-external-deps], [Do not build external dependencies (git submodules), specially useful for package maintainers [default=with]]),
 			[WITH_EXTERNAL_DEPS="$withval"],
 			[WITH_EXTERNAL_DEPS="$WITH_EXTERNAL_DEPS_DEFAULT"]
 			)


### PR DESCRIPTION
Fix formatting on --without-external-deps help string.

(very minor thing)

### Short description

### Checklist
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
