### PR TITLE
Add configurable start offset for 'decode_arista_trailer' option

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1883,6 +1883,10 @@ VALUES:         [ true | false ]
 DESC:           Decode output interfaces data present on trailer of libpcap packets passed by Arista.
 DEFAULT:        false
 
+KEY:            arista_trailer_offset [GLOBAL, PMACCTD_ONLY]
+DESC:           When 'decode_arista_trailer' is enabled, set the byte offset from the end of the packet to indicate where the trailer starts.
+DEFAULT:        8
+
 KEY:		[ nfacctd_mcast_groups | sfacctd_mcast_groups ] [GLOBAL, NO_PMACCTD, NO_UACCTD]
 DESC:		Defines one or more IPv4/IPv6 multicast groups to be joined by the daemon. If more groups are
 		supplied, they are expected comma separated. A maximum of 20 multicast groups may be joined by

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -61,6 +61,7 @@ static const struct _dictionary_line dictionary[] = {
   {"uacctd_net", cfg_key_nfacctd_net},
   {"use_ip_next_hop", cfg_key_use_ip_next_hop},
   {"decode_arista_trailer", cfg_key_decode_arista_trailer},
+  {"arista_trailer_offset", cfg_key_arista_trailer_offset},
   {"thread_stack", cfg_key_thread_stack},
   {"plugins", NULL},
   {"plugin_pipe_size", cfg_key_plugin_pipe_size},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -591,6 +591,7 @@ struct configuration {
   char *tunnel0;
   int use_ip_next_hop;
   int decode_arista_trailer;
+  int arista_trailer_offset;
   int dump_max_writers;
   int tmp_asa_bi_flow;
   int tmp_bgp_lookup_compare_ports;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -192,6 +192,23 @@ int cfg_key_decode_arista_trailer(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_arista_trailer_offset(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = atoi(value_ptr);
+  if (value < 8) {
+    Log(LOG_ERR, "WARN: [%s] 'arista_trailer_offset' has to be >= 8.\n", filename);
+    return ERR;
+  }
+
+  for (; list; list = list->next, changes++) list->cfg.arista_trailer_offset = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'arista_trailer_offset'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_aggregate(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -56,6 +56,7 @@ extern int cfg_key_pcap_ifindex(char *, char *, char *);
 extern int cfg_key_pcap_interfaces_map(char *, char *, char *);
 extern int cfg_key_use_ip_next_hop(char *, char *, char *);
 extern int cfg_key_decode_arista_trailer(char *, char *, char *);
+extern int cfg_key_arista_trailer_offset(char *, char *, char *);
 extern int cfg_key_thread_stack(char *, char *, char *);
 extern int cfg_key_pcap_interface(char *, char *, char *);
 extern int cfg_key_pcap_interface_wait(char *, char *, char *);

--- a/src/nl.c
+++ b/src/nl.c
@@ -132,10 +132,10 @@ void pm_pcap_cb(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char *bu
     }
     else pptrs.ifindex_out = 0;
 
-    if (config.decode_arista_trailer) {
-      memcpy(&ifacePresent, buf + pkthdr->len - 8, 4);
+    if (config.decode_arista_trailer && config.arista_trailer_offset) {
+      memcpy(&ifacePresent, buf + pkthdr->len - config.arista_trailer_offset, 4);
         if (ifacePresent == 1) {
-          memcpy(&iface32, buf + pkthdr->len - 4, 4);
+          memcpy(&iface32, buf + pkthdr->len - (config.arista_trailer_offset - 4), 4);
           pptrs.ifindex_out = iface32;
         }
     }


### PR DESCRIPTION
### Short description
Arista has changed the structure of the trailer format in recent releases of EOS by appending additional fields such that the byte offset used to decode the output interface from the Arista trailer (#201) is now offset by 27 bytes (EOS 4.25) instead of 8 bytes (EOS 4.21 and earlier) from the end of the packet. To make this backwards compatible we should add a configurable byte offset to mark the start of the trailer from the end of a packet with a default value of 8 to maintain backwards compatibility. Future releases of EOS will likely append additional fields and `arista_trailer_offset` will allow one to compensate for any changes to the trailer structure.

### Checklist
I have:
- [x ] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
