### PR TITLE
bmp: fix using unconfirmed BGP ADD-PATH capability

### DIFF
--- a/src/bgp/bgp_msg.c
+++ b/src/bgp/bgp_msg.c
@@ -305,7 +305,7 @@ int bgp_parse_open_msg(struct bgp_msg_data *bmd, char *bgp_packet_ptr, time_t no
 			cap_data.sndrcv);
 		  }
 		  if ((cap_data.sndrcv == 2 /* send */) || (cap_data.sndrcv == 3 /* send and receive */)) {
-		    peer->cap_add_paths[ntohs(cap_data.afi)][cap_data.safi] = TRUE; 
+		    peer->cap_add_paths[ntohs(cap_data.afi)][cap_data.safi] = online;
 		    if (online) {
 		      if (!cap_set) {
 			/* we need to send BGP_CAPABILITY_ADD_PATHS first */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`pmbmpd` runs bgp in "offline" mode. Therefore for OPEN message it doesn't confirm ADD-PATH capabilities to peers. As a result bgp peers don't send path identifiers in UPDATE messages.

According to [RFC 7911](https://tools.ietf.org/html/rfc7911) this confirmation is required:

> A BGP speaker MUST follow the procedures defined in [RFC4271] when
   generating an UPDATE message for a particular <AFI, SAFI> to a peer
   unless the BGP speaker advertises the ADD-PATH Capability to the peer
   indicating its ability to send multiple paths for the <AFI, SAFI>,
   and also receives the ADD-PATH Capability from the peer indicating
   its ability to receive multiple paths for the <AFI, SAFI>, in which
   case the speaker MUST generate a route update for the <AFI, SAFI>
   based on the combination of the address prefix and the Path
   Identifier, and use the extended NLRI encodings specified in this
   document.  The peer SHALL act accordingly in processing an UPDATE
   message related to a particular <AFI, SAFI>.

When `pmbmpd` parses UPDATE messages, it incorrectly tries to get path identifiers from them.

This PR disables this capability for "offline" mode.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
