### PR TITLE
Add configurable pcap_arista_trailer_flag_value option

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -202,6 +202,11 @@ DESC:		Arista does set a trailer structure to convey extra info (ie. output inte
 		where the trailer starts.
 DEFAULT:	none
 
+KEY:            pcap_arista_trailer_flag_value [GLOBAL, PMACCTD_ONLY]
+DESC:           When 'pcap_arista_trailer_offset' is set, specify the expected value in the arista trailer
+                flag field that indicates the output interface is present (this varies by chipset).
+DEFAULT:        1
+
 KEY:		snaplen (-L) [GLOBAL, NO_NFACCTD, NO_SFACCTD]
 DESC:		Specifies the maximum number of bytes to capture for each packet. This directive has
 		key importance to both classification and connection tracking engines. In fact, some

--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -202,10 +202,10 @@ DESC:		Arista does set a trailer structure to convey extra info (ie. output inte
 		where the trailer starts.
 DEFAULT:	none
 
-KEY:            pcap_arista_trailer_flag_value [GLOBAL, PMACCTD_ONLY]
-DESC:           When 'pcap_arista_trailer_offset' is set, specify the expected value in the arista trailer
-                flag field that indicates the output interface is present (this varies by chipset).
-DEFAULT:        1
+KEY:		pcap_arista_trailer_flag_value [GLOBAL, PMACCTD_ONLY]
+DESC:		When 'pcap_arista_trailer_offset' is set, specify the expected value in the arista trailer
+		flag field that indicates the output interface is present (this varies by chipset).
+DEFAULT:	1
 
 KEY:		snaplen (-L) [GLOBAL, NO_NFACCTD, NO_SFACCTD]
 DESC:		Specifies the maximum number of bytes to capture for each packet. This directive has

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -54,6 +54,7 @@ static const struct _dictionary_line dictionary[] = {
   {"pcap_ifindex", cfg_key_pcap_ifindex},
   {"pcap_interfaces_map", cfg_key_pcap_interfaces_map},
   {"pcap_arista_trailer_offset", cfg_key_pcap_arista_trailer_offset},
+  {"pcap_arista_trailer_flag_value", cfg_key_pcap_arista_trailer_flag_value},
   {"core_proc_name", cfg_key_proc_name},
   {"proc_priority", cfg_key_proc_priority},
   {"pmacctd_as", cfg_key_nfacctd_as_new},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -591,6 +591,7 @@ struct configuration {
   char *tunnel0;
   int use_ip_next_hop;
   int pcap_arista_trailer_offset;
+  int pcap_arista_trailer_flag_value;
   int dump_max_writers;
   int tmp_asa_bi_flow;
   int tmp_bgp_lookup_compare_ports;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -181,6 +181,23 @@ int cfg_key_pcap_arista_trailer_offset(char *filename, char *name, char *value_p
   return changes;
 }
 
+int cfg_key_pcap_arista_trailer_flag_value(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = atoi(value_ptr);
+  if (value < 128) {
+    Log(LOG_ERR, "WARN: [%s] 'pcap_arista_trailer_flag_value' has to be < 128.\n", filename);
+    return ERR;
+  }
+
+  for (; list; list = list->next, changes++) list->cfg.pcap_arista_trailer_flag_value = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'pcap_arista_trailer_flag_value'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_use_ip_next_hop(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -187,7 +187,7 @@ int cfg_key_pcap_arista_trailer_flag_value(char *filename, char *name, char *val
   int value, changes = 0;
 
   value = atoi(value_ptr);
-  if (value < 128) {
+  if (value > 128) {
     Log(LOG_ERR, "WARN: [%s] 'pcap_arista_trailer_flag_value' has to be < 128.\n", filename);
     return ERR;
   }

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -55,6 +55,7 @@ extern int cfg_key_pcap_direction(char *, char *, char *);
 extern int cfg_key_pcap_ifindex(char *, char *, char *);
 extern int cfg_key_pcap_interfaces_map(char *, char *, char *);
 extern int cfg_key_pcap_arista_trailer_offset(char *, char *, char *);
+extern int cfg_key_pcap_arista_trailer_flag_value(char *, char *, char *);
 extern int cfg_key_use_ip_next_hop(char *, char *, char *);
 extern int cfg_key_thread_stack(char *, char *, char *);
 extern int cfg_key_pcap_interface(char *, char *, char *);

--- a/src/nl.c
+++ b/src/nl.c
@@ -134,7 +134,7 @@ void pm_pcap_cb(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char *bu
 
     if (config.pcap_arista_trailer_offset) {
       memcpy(&ifacePresent, buf + pkthdr->len - config.pcap_arista_trailer_offset, 4);
-      if (ifacePresent == 1) {
+      if (ifacePresent == config.pcap_arista_trailer_flag_value) {
         memcpy(&iface32, buf + pkthdr->len - (config.pcap_arista_trailer_offset - 4), 4);
         pptrs.ifindex_out = iface32;
       }


### PR DESCRIPTION
### Short description
In applying #489 to a broader set of hardware in my network I observed that certain chipsets set additional flags in the Arista trailer. `1` which is hardcoded in the source as the expected value to tell pmacct "the output interface field is present in the trailer" ends up not being correct the correct value and needs tuning along with the trailer start offset. For example T2 chipsets would utilize `1` but this should actually be `7` on Jericho. Given it is uncertain what this value should be and it may change over time we should make this configurable as well.

### Checklist
I have:
- [x ] compiled & tested this code
- [x ] included documentation (including possible behaviour changes)
