### PR TITLE
Base docker build using multistage, which makes runtime more efficient and secure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ env:
   BUILD_DOCKER_TAG_UBUNTU_BIONIC: ci/ubuntu-bionic-for-pmacct
   BUILD_DOCKER_FILE_CENTOS_8: ci/Dockerfile-centos-8-for-pmacct
   BUILD_DOCKER_TAG_CENTOS_8: ci/centos8-for-pmacct
-  BUILD_DOCKER_FILE_BASE_FOR_DOCKERHUB: docker/base/Dockerfile
 
 jobs:
 
@@ -63,21 +62,6 @@ jobs:
           retention-days: 1
           path: |
             /tmp/docker
-
-  builder-base-docker:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Checkout pmacct
-        uses: actions/checkout@v2
-
-      - name: Build same base docker image we use for dockerhub
-        run: |
-          echo "Building the base container..."
-          docker build \
-            --build-arg NUM_WORKERS=$CI_NUM_WORKERS \
-            --build-arg DEPS_DONT_CHECK_CERTIFICATE=$CI_DEPS_DONT_CHECK_CERTIFICATE \
-            -f $BUILD_DOCKER_FILE_BASE_FOR_DOCKERHUB \
-            -t base:_build .
 
   ### Step 2: permutations
   build-and-test:
@@ -162,7 +146,7 @@ jobs:
           PMACCT_VERSION=$(git describe --abbrev=0 --match="v*")
           echo "PMACCT_VERSION=$PMACCT_VERSION"
           echo "Building the base container..."
-          docker build --build-arg NUM_WORKERS=$CI_NUM_WORKERS --build-arg DEPS_DONT_CHECK_CERTIFICATE=$CI_DEPS_DONT_CHECK_CERTIFICATE -f $BUILD_DOCKER_FILE_BASE_FOR_DOCKERHUB -t base:_build .
+          docker build --build-arg NUM_WORKERS=$CI_NUM_WORKERS --build-arg DEPS_DONT_CHECK_CERTIFICATE=$CI_DEPS_DONT_CHECK_CERTIFICATE -f docker/base/Dockerfile -t base:_build .
           echo "Building daemon containers..."
           docker build -f docker/pmacctd/Dockerfile -t pmacctd:_build .
           docker build -f docker/nfacctd/Dockerfile -t nfacctd:_build .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ env:
   BUILD_DOCKER_TAG_UBUNTU_BIONIC: ci/ubuntu-bionic-for-pmacct
   BUILD_DOCKER_FILE_CENTOS_8: ci/Dockerfile-centos-8-for-pmacct
   BUILD_DOCKER_TAG_CENTOS_8: ci/centos8-for-pmacct
+  BUILD_DOCKER_FILE_BASE_FOR_DOCKERHUB: docker/base/Dockerfile
 
 jobs:
 
@@ -62,6 +63,21 @@ jobs:
           retention-days: 1
           path: |
             /tmp/docker
+
+  builder-base-docker:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout pmacct
+        uses: actions/checkout@v2
+
+      - name: Build same base docker image we use for dockerhub
+        run: |
+          echo "Building the base container..."
+          docker build \
+            --build-arg NUM_WORKERS=$CI_NUM_WORKERS \
+            --build-arg DEPS_DONT_CHECK_CERTIFICATE=$CI_DEPS_DONT_CHECK_CERTIFICATE \
+            -f $BUILD_DOCKER_FILE_BASE_FOR_DOCKERHUB \
+            -t base:_build .
 
   ### Step 2: permutations
   build-and-test:
@@ -146,7 +162,7 @@ jobs:
           PMACCT_VERSION=$(git describe --abbrev=0 --match="v*")
           echo "PMACCT_VERSION=$PMACCT_VERSION"
           echo "Building the base container..."
-          docker build --build-arg NUM_WORKERS=$CI_NUM_WORKERS --build-arg DEPS_DONT_CHECK_CERTIFICATE=$CI_DEPS_DONT_CHECK_CERTIFICATE -f docker/base/Dockerfile -t base:_build .
+          docker build --build-arg NUM_WORKERS=$CI_NUM_WORKERS --build-arg DEPS_DONT_CHECK_CERTIFICATE=$CI_DEPS_DONT_CHECK_CERTIFICATE -f $BUILD_DOCKER_FILE_BASE_FOR_DOCKERHUB -t base:_build .
           echo "Building daemon containers..."
           docker build -f docker/pmacctd/Dockerfile -t pmacctd:_build .
           docker build -f docker/nfacctd/Dockerfile -t nfacctd:_build .

--- a/ci/deps.sh
+++ b/ci/deps.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 #    Copyright
 #    (c) 2020 Marc Sune <marcdevel@gmail.com>
@@ -18,7 +18,7 @@
 #    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 # Do not delete
-set -euo pipefail
+set -e
 
 #wget options
 WGET_N_RETRIES=30
@@ -28,13 +28,11 @@ if [ "${DEPS_DONT_CHECK_CERTIFICATE}" ]; then
     WGET_FLAGS="${WGET_FLAGS} --no-check-certificate"
 fi
 echo "WGET_FLAGS: ${WGET_FLAGS}"
+echo "MAKEFLAGS: ${MAKEFLAGS}"
 
 # Don't pollute /
 mkdir -p /tmp
 cd /tmp
-
-# Most of the software installation will probably honor this, which will improve perf
-export MAKEFLAGS="-j$(nproc)"
 
 # Dependencies (not fulfilled by Dockerfile)
 git clone https://github.com/akheron/jansson

--- a/ci/deps.sh
+++ b/ci/deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #    Copyright
 #    (c) 2020 Marc Sune <marcdevel@gmail.com>
@@ -17,8 +17,8 @@
 #    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#Do not delete
-set -e
+# Do not delete
+set -euo pipefail
 
 #wget options
 WGET_N_RETRIES=30
@@ -29,41 +29,44 @@ if [ "${DEPS_DONT_CHECK_CERTIFICATE}" ]; then
 fi
 echo "WGET_FLAGS: ${WGET_FLAGS}"
 
-#Don't pollute /
+# Don't pollute /
 mkdir -p /tmp
 cd /tmp
 
-#Dependencies (not fulfilled by Dockerfile)
+# Most of the software installation will probably honor this, which will improve perf
+export MAKEFLAGS="-j$(nproc)"
+
+# Dependencies (not fulfilled by Dockerfile)
 git clone https://github.com/akheron/jansson
-cd jansson && rm -rf ./.git && autoreconf -i && ./configure && make && sudo make install && cd ..
+cd jansson ; rm -rf ./.git ; autoreconf -i ; ./configure ; make ; sudo make install ; cd ..
 
 git clone https://github.com/edenhill/librdkafka
-cd librdkafka && rm -rf ./.git && ./configure && make && sudo make install && cd ..
+cd librdkafka ; rm -rf ./.git ; ./configure ; make ; sudo make install ; cd ..
 
 wget ${WGET_FLAGS} https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.11.0.tar.gz
 mv v0.11.0.tar.gz rabbitmq-c-0.11.0.tar.gz
 tar xfz rabbitmq-c-0.11.0.tar.gz
-cd rabbitmq-c-0.11.0 && rm -rf ./.git && mkdir build && cd build && cmake -DCMAKE_INSTALL_LIBDIR=lib .. && sudo cmake --build . --target install && cd .. && cd ..
+cd rabbitmq-c-0.11.0 ; rm -rf ./.git ; mkdir build ; cd build ; cmake -DCMAKE_INSTALL_LIBDIR=lib .. ; sudo cmake --build . --target install ; cd .. ; cd ..
 
 git clone --recursive https://github.com/maxmind/libmaxminddb
-cd libmaxminddb && rm -rf ./.git && ./bootstrap && ./configure && make && sudo make install && cd ..
+cd libmaxminddb ; rm -rf ./.git ; ./bootstrap ; ./configure ; make ; sudo make install ; cd ..
 
 git clone -b 3.4-stable https://github.com/ntop/nDPI
-cd nDPI && rm -rf ./.git && ./autogen.sh && ./configure && make && sudo make install && sudo ldconfig && cd ..
+cd nDPI ; rm -rf ./.git ; ./autogen.sh ; ./configure ; make ; sudo make install ; sudo ldconfig ; cd ..
 
 wget ${WGET_FLAGS} https://github.com/zeromq/libzmq/releases/download/v4.3.2/zeromq-4.3.2.tar.gz
 tar xfz zeromq-4.3.2.tar.gz
-cd zeromq-4.3.2 && ./configure && make && sudo make install && cd ..
+cd zeromq-4.3.2 ; ./configure ; make ; sudo make install ; cd ..
 
 wget ${WGET_FLAGS} https://archive.apache.org/dist/avro/avro-1.9.2/c/avro-c-1.9.2.tar.gz
 tar xfz avro-c-1.9.2.tar.gz
-cd avro-c-1.9.2 && mkdir build && cd build && cmake .. && make && sudo make install && cd .. && cd ..
+cd avro-c-1.9.2 ; mkdir build ; cd build ; cmake .. ; make ; sudo make install ; cd .. ; cd ..
 
 git clone https://github.com/confluentinc/libserdes
-cd libserdes && rm -rf ./.git && ./configure && make && sudo make install && cd ..
+cd libserdes ; rm -rf ./.git ; ./configure ; make ; sudo make install ; cd ..
 
 git clone https://github.com/redis/hiredis
-cd hiredis && rm -rf ./.git && make && sudo make install && cd ..
+cd hiredis ; rm -rf ./.git ; make ; sudo make install ; cd ..
 
-#Make sure dynamic linker is up-to-date
+# Make sure dynamic linker is up-to-date
 ldconfig

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -7,8 +7,6 @@
 #tools for network telemetry and monitoring
 
 FROM debian:buster-slim as build-stage
-LABEL maintainer "pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
-
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
 
@@ -21,8 +19,9 @@ ARG NUM_WORKERS=2
 #Do not check certificates in wget for external deps
 ARG DEPS_DONT_CHECK_CERTIFICATE
 
-#Create a single compressed layer, as some dependencies (deps.sh)
-#can be later removed, so try to make it as lightweight as possible
+# This is not the runtime/final image:
+#   * we keep some installation steps in different layers to improve cachability
+#   * this only covers build deps
 RUN apt-get update && \
   apt-get install -y \
     autoconf \
@@ -51,35 +50,41 @@ RUN apt-get update && \
     pkg-config \
     sudo \
     wget \
-    zlib1g-dev && \
-  cd /tmp/pmacct && \
-  DEPS_DONT_CHECK_CERTIFICATE=${DEPS_DONT_CHECK_CERTIFICATE} ./ci/deps.sh && \
-  export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
+    zlib1g-dev
+WORKDIR /tmp/pmacct/
+# Deps
+COPY ci/deps.sh ci/
+RUN ./ci/deps.sh
+# Actual build
+COPY . .
+RUN export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
   export AVRO_CFLAGS="-I/usr/local/avro/include" && \
-  ( make maintainer-clean || /bin/true ) && \
   ./autogen.sh && ./configure --enable-mysql --enable-pgsql     \
-                               --enable-sqlite3 --enable-kafka   \
-                               --enable-geoipv2 --enable-jansson \
-                               --enable-rabbitmq --enable-nflog  \
-                               --enable-ndpi --enable-zmq        \
-                               --enable-avro --enable-serdes     \
-                               --enable-redis --enable-gnutls && \
-  sudo make -j${NUM_WORKERS} install && \
-  cd .. && \
-  apt-get purge -y \
-    autoconf \
-    automake \
-    bison \
-    cmake \
-    gcc \
-    g++ \
-    flex \
-    git \
-    libtool \
-    make \
-    pkg-config && \
-  apt-get autoremove -y && \
-  apt-get -y clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/*
+                              --enable-sqlite3 --enable-kafka   \
+                              --enable-geoipv2 --enable-jansson \
+                              --enable-rabbitmq --enable-nflog  \
+                              --enable-ndpi --enable-zmq        \
+                              --enable-avro --enable-serdes     \
+                              --enable-redis --enable-gnutls && \
+  make -j${NUM_WORKERS} install
 
+FROM debian:buster-slim as base
+LABEL maintainer "pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
+# We don't want man pages
+COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
+COPY --from=build-stage /usr/local/ /usr/local
+# Runtime deps
+RUN apt-get update && \
+  apt-get install -y \
+    libmariadb3 \
+    libnuma1 \
+    libcurl4 \
+    libpcap0.8 \
+    libpq5 \
+    libsnappy1v5 \
+    libsqlite3-0 \
+    libssl1.1 && \
+  apt-get -y clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  ldconfig
 ENTRYPOINT ["/bin/bash"]

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -9,16 +9,6 @@
 FROM debian:buster-slim as build-stage
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
-
-#Copy installer script
-COPY . /tmp/pmacct/
-
-#Parallelism: 2 looks a reasonable default, and bear in mind CI specs
-ARG NUM_WORKERS=2
-
-#Do not check certificates in wget for external deps
-ARG DEPS_DONT_CHECK_CERTIFICATE
-
 # This is not the runtime/final image:
 #   * we keep some installation steps in different layers to improve cachability
 #   * this only covers build deps
@@ -52,8 +42,13 @@ RUN apt-get update && \
     wget \
     zlib1g-dev
 WORKDIR /tmp/pmacct/
-# Deps
+# About to deal with deps installation
 COPY ci/deps.sh ci/
+# Parallelism: 2 looks a reasonable default, and bear in mind CI specs
+ARG NUM_WORKERS=2
+ENV MAKEFLAGS="-j${NUM_WORKERS}"
+# Do not check certificates in wget for external deps
+ARG DEPS_DONT_CHECK_CERTIFICATE
 RUN ./ci/deps.sh
 # Actual build
 COPY . .
@@ -66,7 +61,7 @@ RUN export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
                               --enable-ndpi --enable-zmq        \
                               --enable-avro --enable-serdes     \
                               --enable-redis --enable-gnutls && \
-  make -j${NUM_WORKERS} install
+  make install
 
 FROM debian:buster-slim as base
 LABEL maintainer "pmacct Docker Doctors <docker-doctors (at) pmacct.net>"


### PR DESCRIPTION
### Short description

This PR introduces more build related improvements (so it continues the work we started here: https://github.com/pmacct/pmacct/pull/503):

* we have incorporated an stage in the CI logic / actions that builds in parallel the base image we use for dockerhub, so if we break something in that specific build flavor, we are not going to detect this when merging to master, that is when this specific docker flow is used to publish images to dockerhub.
* in the `ci/deps.sh` we stop using "&&" to concatenate installation commands, as one failing in the middle was not breaking the build process. We also enabled parallelism when building these deps, to improve performance
* And major changes in the base `Dockerfile`:
  * We move to multistage, so we don't need to clean build related deps and we just explicitly declare the ones that are required at runtime
  * In the build stage, we stop installing everything in a single layer, to improve cacheability, and that does not affect to the final/runtime stage anymore
  * With the definition of the previous introduction of `.dockerignore`, we no longer need to call `maintainer-clean`, as files not under version control are excluded.

That results in a base image that is around 300MB, 150MB less than what we already won in the previous batch of improvements. And it's not just about size (that is good for the planet): less runtime software means less chances of security issues.

### Checklist

_Note: no new files introduced, neither source code changed. If there are manual image validation steps, let me know... I've built things locally, already `ldd`'ed most of the assets in the resulting image `/usr/local`, and I didn't find anything linked to non existing libs. And if you want me to update some docs or CHANGELOG, just let me know!_

I have:
- [] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [] compiled & tested this code
- [] included documentation (including possible behaviour changes)
