### PR TITLE
pmacct: use correct IP option for jumbo payload packets

### DIFF
--- a/src/nl.c
+++ b/src/nl.c
@@ -375,7 +375,7 @@ int ip6_handler(register struct packet_ptrs *pptrs)
 
   /* length checks */
   if (off+IP6HdrSz > caplen) return FALSE; /* IP packet truncated */
-  if (plen == 0 && ((struct ip6_hdr *)pptrs->iph_ptr)->ip6_nxt != IPPROTO_NONE) {
+  if (plen == 0 && ((struct ip6_hdr *)pptrs->iph_ptr)->ip6_nxt == IPPROTO_HOPOPTS) {
     Log(LOG_INFO, "INFO ( %s/core ): NULL IPv6 payload length. Jumbo packets are currently not supported.\n", config.name);
     return FALSE;
   }


### PR DESCRIPTION
According to RFC 2292 'Advanced Sockets API for IPv6' datagrams
with more than 65535 bytes payload require the jumbo payload option,
e.g the length of the payload ist stored in the hop-by-hop header.
In order to exclude jumbo payload packets we have to check if the
IP6 header payload length is zero and the next header is a
hop-by-hop header.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
