### PR TITLE
Add contextual out-of-bounds checks for maxLength

### DIFF
--- a/src/rpki/rpki_msg.c
+++ b/src/rpki/rpki_msg.c
@@ -96,7 +96,7 @@ int rpki_roas_file_load(char *file, struct bgp_table *rib_v4, struct bgp_table *
 	  }
 	  else maxlen = json_integer_value(maxlen_json);
 
-	  if (maxlen < p.prefixlen) {
+	  if (maxlen > (p.family == AF_INET ? 32 : 128) || maxlen < p.prefixlen) {
 	    char prefix_str[PREFIX_STRLEN];
 
 	    prefix2str(&p, prefix_str, PREFIX_STRLEN);
@@ -285,7 +285,7 @@ void rpki_rtr_parse_ipv4_prefix(struct rpki_rtr_handle *cache, struct rpki_rtr_i
 
   asn = ntohl(p4m->asn);
 
-  if (p4m->max_len < p.prefixlen) {
+  if (p4m->max_len > 32 || p4m->max_len < p.prefixlen) {
     char prefix_str[PREFIX_STRLEN];
 
     prefix2str((struct prefix *) &p, prefix_str, PREFIX_STRLEN);
@@ -323,7 +323,7 @@ void rpki_rtr_parse_ipv6_prefix(struct rpki_rtr_handle *cache, struct rpki_rtr_i
 
   asn = ntohl(p6m->asn);
 
-  if (p6m->max_len < p.prefixlen) {
+  if (p6m->max_len > 128 || p6m->max_len < p.prefixlen) {
     char prefix_str[PREFIX_STRLEN];
 
     prefix2str((struct prefix *) &p, prefix_str, PREFIX_STRLEN);


### PR DESCRIPTION
### Short description

The RTR PDU element for maxLength is `uint8`, therefor it might be possible to transmit incorrect RTR data. `pmacct` should be aware of this situation

### Checklist
- [x] compiled
- [ ] tested this code