### PR TITLE
Implement aggregate_unknown_etype config key and functionality.

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -174,6 +174,14 @@ DESC:		Per-plugin filtering applied against the original packet or flow. Aggrega
 		'pmacctd_force_frag_handling' directive.
 DEFAULT:	none
 
+KEY:		aggregate_unknown_etype [GLOBAL]
+VALUES:		[ true | false ]
+DESC:		By default, Ethernet frames with unknown EtherTypes for which pmacct has not
+		implemented decoding support are ignored by the aggregation engine. Enabling this
+		option allows such frames to be aggregated by the available Ethernet L2 header
+		fields ('src_mac', 'dst_mac', 'vlan', 'cos', 'etype').
+DEFAULT:	false
+
 KEY:		dtls_path [GLOBAL]
 DESC:		Full path to a directory containing files needed to establish a successful DTLS
 		session (key, certificate and CA file); a key.pem file can be generated with the

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -41,6 +41,7 @@ static const struct _dictionary_line dictionary[] = {
   {"snaplen", cfg_key_snaplen},
   {"propagate_signals", cfg_key_propagate_signals},
   {"aggregate_filter", cfg_key_aggregate_filter},
+  {"aggregate_unknown_etype", cfg_key_aggregate_unknown_etype},
   {"dtls_path", cfg_key_dtls_path},
   {"promisc", cfg_key_promisc},
   {"pcap_filter", cfg_key_pcap_filter},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -80,6 +80,7 @@ struct configuration {
   pm_cfgreg_t nfprobe_what_to_count;
   pm_cfgreg_t nfprobe_what_to_count_2;
   char *aggregate_primitives;
+  int aggregate_unknown_etype;
   struct custom_primitives_ptrs cpptrs;
   char *progname;
   char *name;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -508,6 +508,20 @@ int cfg_key_aggregate_filter(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_aggregate_unknown_etype(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  for (; list; list = list->next, changes++) list->cfg.aggregate_unknown_etype = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'aggregate_unknown_etype'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_pre_tag_filter(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -45,6 +45,7 @@ extern int cfg_key_aggregate(char *, char *, char *);
 extern int cfg_key_aggregate_primitives(char *, char *, char *);
 extern int cfg_key_snaplen(char *, char *, char *);
 extern int cfg_key_aggregate_filter(char *, char *, char *);
+extern int cfg_key_aggregate_unknown_etype(char *, char *, char *);
 extern int cfg_key_dtls_path(char *, char *, char *);
 extern int cfg_key_pcap_filter(char *, char *, char *);
 extern int cfg_key_pcap_protocol(char *, char *, char *);

--- a/src/ll.c
+++ b/src/ll.c
@@ -129,6 +129,13 @@ void eth_handler(const struct pcap_pkthdr *h, register struct packet_ptrs *pptrs
     goto recurse;
   }
 
+  if (config.aggregate_unknown_etype) {
+    pptrs->l3_proto = etype;
+    pptrs->l3_handler = unknown_etype_handler;
+    pptrs->iph_ptr = pptrs->packet_ptr + nl;
+    return;
+  }
+
   pptrs->l3_proto = 0;
   pptrs->l3_handler = NULL;
   pptrs->iph_ptr = NULL;

--- a/src/nl.c
+++ b/src/nl.c
@@ -526,6 +526,12 @@ int ip6_handler(register struct packet_ptrs *pptrs)
   return ret;
 }
 
+int unknown_etype_handler(register struct packet_ptrs *pptrs)
+{
+  /* NO-OP - just return TRUE so packet is counted */
+  return TRUE;
+}
+
 int PM_find_id(struct id_table *t, struct packet_ptrs *pptrs, pm_id_t *tag, pm_id_t *tag2)
 {
   int x;

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -1347,6 +1347,7 @@ void counters_handler(struct channels_list_entry *chptr, struct packet_ptrs *ppt
 
   if (pptrs->l3_proto == ETHERTYPE_IP) pdata->pkt_len = ntohs(((struct pm_iphdr *) pptrs->iph_ptr)->ip_len);
   else if (pptrs->l3_proto == ETHERTYPE_IPV6) pdata->pkt_len = ntohs(((struct ip6_hdr *) pptrs->iph_ptr)->ip6_plen)+IP6HdrSz;
+  else if (config.aggregate_unknown_etype) pdata->pkt_len = pptrs->pkthdr->len-ETHER_HDRLEN;
 
   if (pptrs->frag_sum_bytes) {
     pdata->pkt_len += pptrs->frag_sum_bytes;

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -406,6 +406,7 @@ extern void chdlc_handler(const struct pcap_pkthdr *, register struct packet_ptr
 
 extern int ip_handler(register struct packet_ptrs *);
 extern int ip6_handler(register struct packet_ptrs *);
+extern int unknown_etype_handler(register struct packet_ptrs *);
 extern int gtp_tunnel_func(register struct packet_ptrs *);
 extern int gtp_tunnel_configurator(struct tunnel_handler *, char *);
 extern void tunnel_registry_init();


### PR DESCRIPTION
Hello Paolo,

Per our discussion in email, I've made changes to support aggregation/counting of unknown EtherType(s) by `pmacctd`.

### Short description
Added `aggregate_unknown_etype` boolean config key, which defaults to false, and which if enabled makes Ethernet frames with unsupported EtherTypes "visible" to the `pmacctd` aggregation engine.

### Checklist
I have:
- [N/A] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [Y] compiled & tested this code
- [Y] included documentation (including possible behaviour changes)
