### PR TITLE
Add preprocess support for maxp and maxb in non-SQL plugins

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1466,7 +1466,7 @@ DESC:		Allows to process aggregates (via a comma-separated list of conditionals 
 
 		KEY: maxp
 		DESC: check. Aggregates on the queue are evaluated one-by-one; each object is marked valid
-		      only if the number of packets is '<' maxp value. SQL plugins only.
+		      only if the number of packets is '<' maxp value. All plugins.
 
 		KEY: maxf
 		DESC: check. Aggregates on the queue are evaluated one-by-one; each object is marked valid
@@ -1474,7 +1474,7 @@ DESC:		Allows to process aggregates (via a comma-separated list of conditionals 
 
 		KEY: maxb
 		DESC: check. Aggregates on the queue are evaluated one-by-one; each object is marked valid
-		      only if the bytes counter is '<' maxb value. SQL plugins only. 
+		      only if the bytes counter is '<' maxb value. All plugins. 
 
 		KEY: maxbpp
 		DESC: check. Aggregates on the queue are evaluated one-by-one; each object is marked valid

--- a/src/preprocess-data.h
+++ b/src/preprocess-data.h
@@ -43,6 +43,8 @@ static const struct _preprocess_dictionary_line print_prep_dict[] = {
   {"minp"},
   {"minf"},
   {"minb"},
+  {"maxp"},
+  {"maxb"},
   {"minbpp"},
   {"minppf"},
   {""}

--- a/src/preprocess-internal.h
+++ b/src/preprocess-internal.h
@@ -43,6 +43,8 @@ extern int action_adjb(struct db_cache *[], int *, int);
 extern int P_check_minp(struct chained_cache *[], int *, int);
 extern int P_check_minb(struct chained_cache *[], int *, int);
 extern int P_check_minf(struct chained_cache *[], int *, int);
+extern int P_check_maxp(struct chained_cache *[], int *, int);
+extern int P_check_maxb(struct chained_cache *[], int *, int);
 extern int P_check_minbpp(struct chained_cache *[], int *, int);
 extern int P_check_minppf(struct chained_cache *[], int *, int);
 

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -241,6 +241,12 @@ void set_preprocess_funcs(char *string, struct preprocess *prep, int dictionary)
       sql_idx++;
       prep->checkno++;
     }
+    else if (dictionary == PREP_DICT_PRINT) {
+      P_preprocess_funcs[p_idx] = P_check_maxp;
+      prep->num++;
+      p_idx++;
+      prep->checkno++;
+    }
   }
 
   if (prep->maxf) {
@@ -257,6 +263,12 @@ void set_preprocess_funcs(char *string, struct preprocess *prep, int dictionary)
       sql_preprocess_funcs[sql_idx] = check_maxb;
       prep->num++;
       sql_idx++;
+      prep->checkno++;
+    }
+    else if (dictionary == PREP_DICT_PRINT) {
+      P_preprocess_funcs[p_idx] = P_check_maxb;
+      prep->num++;
+      p_idx++;
       prep->checkno++;
     }
   }
@@ -778,6 +790,36 @@ int P_check_minf(struct chained_cache *queue[], int *num, int seq)
   for (x = 0; x < *num; x++) {
     if (queue[x]->valid == PRINT_CACHE_INVALID || queue[x]->valid == PRINT_CACHE_COMMITTED) {
       if (queue[x]->flow_counter >= prep.minf) queue[x]->prep_valid++;
+
+      P_check_validity(queue[x], seq);
+    }
+  }
+
+  return FALSE;
+}
+
+int P_check_maxp(struct chained_cache *queue[], int *num, int seq)
+{
+  int x;
+
+  for (x = 0; x < *num; x++) {
+    if (queue[x]->valid == PRINT_CACHE_INVALID || queue[x]->valid == PRINT_CACHE_COMMITTED) {
+      if (queue[x]->packet_counter < prep.maxp) queue[x]->prep_valid++;
+
+      P_check_validity(queue[x], seq);
+    }
+  }
+
+  return FALSE;
+}
+
+int P_check_maxb(struct chained_cache *queue[], int *num, int seq)
+{
+  int x;
+
+  for (x = 0; x < *num; x++) {
+    if (queue[x]->valid == PRINT_CACHE_INVALID || queue[x]->valid == PRINT_CACHE_COMMITTED) {
+      if (queue[x]->bytes_counter < prep.maxb) queue[x]->prep_valid++;
 
       P_check_validity(queue[x], seq);
     }

--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -88,6 +88,8 @@ extern int action_adjb(struct db_cache *[], int *, int);
 extern int P_check_minp(struct chained_cache *[], int *, int);
 extern int P_check_minb(struct chained_cache *[], int *, int);
 extern int P_check_minf(struct chained_cache *[], int *, int);
+extern int P_check_maxp(struct chained_cache *[], int *, int);
+extern int P_check_maxb(struct chained_cache *[], int *, int);
 extern int P_check_minbpp(struct chained_cache *[], int *, int);
 extern int P_check_minppf(struct chained_cache *[], int *, int);
 


### PR DESCRIPTION
### Short description
The `<plugin>_preprocess` configuration directive supports a number of options for filtering aggregates. Filtering on the maximum number of packets (`maxp`) and maximum number of bytes (`maxb`) is currently only supported for SQL plugins. This pull request adds support to non-SQL plugins. It has been tested with nfacctd and Kafka, but I believe should work with other plugins just as the min equivalents already do.

Our specific use case for this was our network wants to be able to send "small" flows to a different Kafka topic (and ultimately a different processing pipeline) than larger flows. The existing min options got us part of the way there by allowing us to only forward the larger flows to kafka, but the max options allows us to forward the small flows using a second kafka plugin configuration (as opposed to dropping them or forwarding all traffic the separating at a later step in the pipeline).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
