### PR TITLE
Add VRF listening support for the BGP daemon

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -2365,6 +2365,11 @@ DESC:           When listening on all interfaces (default setting for nfacctd_ip
                 knob to true disables the IPv4 (IPv6 IPv4-mapped) part.
 DEFAULT:        false
 
+KEY:            bgp_daemon_interface [GLOBAL]
+DESC:           Defines the interface for the BGP daemon to listen on. This makes it possible to have the BGP
+                communication happen entirely in one VRF by specifying the VRF device name here.
+DEFAULT:        none
+
 KEY:            bgp_daemon_id [GLOBAL]
 DESC:		Defines the BGP Router-ID to the supplied value. Expected value is an IPv4 address. If this
 		feature is not used or an invalid IP address is supplied, ie. IPv6, the bgp_daemon_ip value

--- a/configure.ac
+++ b/configure.ac
@@ -1149,6 +1149,14 @@ AC_TYPE_SIGNAL
 
 AC_CHECK_FUNCS([setproctitle mallopt tdestroy])
 
+dnl Check for SO_BINDTODEVICE
+AC_CHECK_DECL([SO_BINDTODEVICE],
+	AC_DEFINE(HAVE_SO_BINDTODEVICE, 1, [Check if kernel supports SO_BINDTODEVICE]),,
+		[
+		  #include <sys/socket.h>
+		]
+)
+
 dnl Check for SO_REUSEPORT & friends
 AC_CHECK_DECL([SO_REUSEPORT],
 	AC_DEFINE(HAVE_SO_REUSEPORT, 1, [Check if kernel supports SO_REUSEPORT]),,

--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -335,6 +335,13 @@ void skinny_bgp_daemon_online()
   rc = setsockopt(config.bgp_sock, SOL_SOCKET, SO_REUSEADDR, (char *)&yes, (socklen_t) sizeof(yes));
   if (rc < 0) Log(LOG_ERR, "WARN ( %s/%s ): setsockopt() failed for SO_REUSEADDR (errno: %d).\n", config.name, bgp_misc_db->log_str, errno);
 
+#if (defined HAVE_SO_BINDTODEVICE)
+  if (config.bgp_daemon_interface)  {
+    rc = setsockopt(config.bgp_sock, SOL_SOCKET, SO_BINDTODEVICE, config.bgp_daemon_interface, (socklen_t) strlen(config.bgp_daemon_interface));
+    if (rc < 0) Log(LOG_ERR, "WARN ( %s/%s ): setsockopt() failed for SO_BINDTODEVICE (errno: %d).\n", config.name, bgp_misc_db->log_str, errno);
+  }
+#endif
+
   if (config.bgp_daemon_ipv6_only) {
     int yes=1;
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -440,6 +440,7 @@ static const struct _dictionary_line dictionary[] = {
   {"tee_kafka_config_file", cfg_key_tee_kafka_config_file},
   {"bgp_daemon", cfg_key_bgp_daemon},
   {"bgp_daemon_ip", cfg_key_bgp_daemon_ip},
+  {"bgp_daemon_interface", cfg_key_bgp_daemon_interface},
   {"bgp_daemon_ipv6_only", cfg_key_bgp_daemon_ipv6_only},
   {"bgp_daemon_id", cfg_key_bgp_daemon_id},
   {"bgp_daemon_as", cfg_key_bgp_daemon_as},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -341,6 +341,7 @@ struct configuration {
   char *bgp_daemon_msglog_kafka_avro_schema_registry;
   char *bgp_daemon_id;
   char *bgp_daemon_ip;
+  char *bgp_daemon_interface;
   int bgp_daemon_ipv6_only;
   as_t bgp_daemon_as;
   int bgp_daemon_port;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -3879,6 +3879,17 @@ int cfg_key_bgp_daemon_ip(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_bgp_daemon_interface(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int changes = 0;
+
+  for (; list; list = list->next, changes++) list->cfg.bgp_daemon_interface = value_ptr;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'bgp_daemon_interface'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_bgp_daemon_ipv6_only(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -346,6 +346,7 @@ extern int cfg_key_bgp_daemon_msglog_kafka_config_file(char *, char *, char *);
 extern int cfg_key_bgp_daemon_msglog_kafka_avro_schema_registry(char *, char *, char *);
 extern int cfg_key_bgp_daemon_max_peers(char *, char *, char *);
 extern int cfg_key_bgp_daemon_ip(char *, char *, char *);
+extern int cfg_key_bgp_daemon_interface(char *, char *, char *);
 extern int cfg_key_bgp_daemon_ipv6_only(char *, char *, char *);
 extern int cfg_key_bgp_daemon_id(char *, char *, char *);
 extern int cfg_key_bgp_daemon_as(char *, char *, char *);


### PR DESCRIPTION
### Short description
This commit adds the new option called `bgp_daemon_interface`. This option allows user to specify an interface for the BGP daemon to bind to using `SO_BINDTODEVICE`. This can be used for example to place the BGP listening into a VRF by specifying the VRF master device name in that option, as documented in [the Linux kernel VRF documentation](https://www.kernel.org/doc/Documentation/networking/vrf.txt) and somewhat explained in https://github.com/pmacct/pmacct/issues/538 which enables to set up a BGP (fulltable) peering in one VRF alone without having to leak any routes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
