### PR TITLE
ARRAY TCP-Flags data structure for both JSON & AVRO encodings

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -349,6 +349,7 @@ static const struct _dictionary_line dictionary[] = {
   {"pre_tag2_filter", cfg_key_pre_tag2_filter},
   {"pre_tag_label_filter", cfg_key_pre_tag_label_filter},
   {"pre_tag_label_encode_as_map", cfg_key_pre_tag_label_encode_as_map},
+  {"tcpflags_encode_as_array", cfg_key_tcpflags_encode_as_array},
   {"post_tag", cfg_key_post_tag},
   {"post_tag2", cfg_key_post_tag2},
   {"sampling_rate", cfg_key_sampling_rate},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -539,6 +539,7 @@ struct configuration {
   struct pretag_filter pt2f;
   struct pretag_label_filter ptlf;
   int pretag_label_encode_as_map;
+  int tcpflags_encode_as_array;
   int maps_refresh;
   int maps_index;
   int maps_entries;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -607,6 +607,28 @@ int cfg_key_pre_tag_label_encode_as_map(char *filename, char *name, char *value_
   return changes;
 }
 
+int cfg_key_tcpflags_encode_as_array(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.tcpflags_encode_as_array = value;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.tcpflags_encode_as_array = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_pcap_filter(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -281,6 +281,7 @@ extern int cfg_key_pre_tag_filter(char *, char *, char *);
 extern int cfg_key_pre_tag2_filter(char *, char *, char *);
 extern int cfg_key_pre_tag_label_filter(char *, char *, char *);
 extern int cfg_key_pre_tag_label_encode_as_map(char *, char *, char *);
+extern int cfg_key_tcpflags_encode_as_array(char *, char *, char *);
 extern int cfg_key_post_tag(char *, char *, char *);
 extern int cfg_key_post_tag2(char *, char *, char *);
 extern int cfg_key_sampling_rate(char *, char *, char *);

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -218,7 +218,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2)
 
   if (wtc & COUNT_TCPFLAGS) {
     if (config.tcpflags_encode_as_array) {
-      compose_tcpflags_avro_schema(schema);
+      compose_tcpflags_avro_schema(schema, FALSE);
     }
     else {
       avro_schema_record_field_append(schema, "tcp_flags", avro_schema_string());

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -61,7 +61,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2)
 
   if (wtc_2 & COUNT_LABEL) {
     if (config.pretag_label_encode_as_map) {
-      compose_label_avro_schema(schema);
+      compose_label_avro_schema(schema, FALSE);
     }
     else {
       avro_schema_record_field_append(schema, "label", avro_schema_string());
@@ -218,7 +218,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2)
 
   if (wtc & COUNT_TCPFLAGS) {
     if (config.tcpflags_encode_as_array) {
-      compose_tcpflags_avro_schema(schema, FALSE);
+      compose_tcpflags_avro_schema(schema);
     }
     else {
       avro_schema_record_field_append(schema, "tcp_flags", avro_schema_string());

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -1361,7 +1361,7 @@ void pm_avro_exit_gracefully(int status)
 }
 
 
-void compose_label_avro_schema(avro_schema_t sc_type_record)
+void compose_label_avro_schema(avro_schema_t sc_type_record, int opt)
 {
   sc_type_string = avro_schema_string();
   sc_type_map = avro_schema_map(sc_type_string);

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -36,7 +36,7 @@
 #ifdef WITH_AVRO
 /* global variables */
 avro_schema_t p_avro_acct_schema, p_avro_acct_init_schema, p_avro_acct_close_schema;
-avro_schema_t sc_type_map, sc_type_string;
+avro_schema_t sc_type_array, sc_type_map, sc_type_string;
 
 /* functions */
 avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2)
@@ -61,7 +61,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2)
 
   if (wtc_2 & COUNT_LABEL) {
     if (config.pretag_label_encode_as_map) {
-      compose_label_avro_schema(schema, FALSE);
+      compose_label_avro_schema(schema);
     }
     else {
       avro_schema_record_field_append(schema, "label", avro_schema_string());
@@ -216,8 +216,14 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2)
     
 #endif
 
-  if (wtc & COUNT_TCPFLAGS)
-    avro_schema_record_field_append(schema, "tcp_flags", avro_schema_string());
+  if (wtc & COUNT_TCPFLAGS) {
+    if (config.tcpflags_encode_as_array) {
+      compose_tcpflags_avro_schema(schema);
+    }
+    else {
+      avro_schema_record_field_append(schema, "tcp_flags", avro_schema_string());
+    }
+  }
 
   if (wtc & COUNT_IP_PROTO)
     avro_schema_record_field_append(schema, "ip_proto", avro_schema_string());
@@ -806,8 +812,14 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
 
   if (wtc & COUNT_TCPFLAGS) {
     sprintf(misc_str, "%u", tcp_flags);
-    pm_avro_check(avro_value_get_by_name(&value, "tcp_flags", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, misc_str));
+
+    if (config.tcpflags_encode_as_array) {
+      compose_tcpflags_avro_data(tcp_flags, value);
+    }
+    else {
+      pm_avro_check(avro_value_get_by_name(&value, "tcp_flags", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, misc_str));
+    }
   }
 
   if (wtc & COUNT_IP_PROTO) {
@@ -1349,7 +1361,7 @@ void pm_avro_exit_gracefully(int status)
 }
 
 
-void compose_label_avro_schema(avro_schema_t sc_type_record, int opt)
+void compose_label_avro_schema(avro_schema_t sc_type_record)
 {
   sc_type_string = avro_schema_string();
   sc_type_map = avro_schema_map(sc_type_string);
@@ -1359,6 +1371,19 @@ void compose_label_avro_schema(avro_schema_t sc_type_record, int opt)
   avro_schema_decref(sc_type_map);
   avro_schema_decref(sc_type_string);
 }
+
+
+void compose_tcpflags_avro_schema(avro_schema_t sc_type_record)
+{
+  sc_type_string = avro_schema_string();
+  sc_type_array = avro_schema_array(sc_type_string);
+  avro_schema_record_field_append(sc_type_record, "tcp_flags", sc_type_array);
+
+  /* free-up memory */
+  avro_schema_decref(sc_type_array);
+  avro_schema_decref(sc_type_string);
+}
+
 
 int compose_label_avro_data(char *str_ptr, avro_value_t v_type_record, int opt)
 {
@@ -1375,7 +1400,7 @@ int compose_label_avro_data(char *str_ptr, avro_value_t v_type_record, int opt)
     cdada_list_get(ll, idx_0, &lbl);
   }
 
-  avro_value_t v_type_string, v_type_map;
+  avro_value_t v_type_map, v_type_string;
   avro_value_iface_t *if_type_map, *if_type_string;
 
   if_type_map = avro_generic_class_from_schema(sc_type_map);
@@ -1383,11 +1408,6 @@ int compose_label_avro_data(char *str_ptr, avro_value_t v_type_record, int opt)
 
   avro_generic_value_new(if_type_map, &v_type_map);
   avro_generic_value_new(if_type_string, &v_type_string);
-  
-  size_t  map_size;
-  avro_value_get_size(&v_type_map, &map_size);
-
-  /* XXX: tackle opt TRUE/FALSE most probably here */
 
   int idx_1;
   for (idx_1 = 0; idx_1 < ll_size; idx_1++) {
@@ -1399,12 +1419,49 @@ int compose_label_avro_data(char *str_ptr, avro_value_t v_type_record, int opt)
     }
   }
 
-  avro_value_get_size(&v_type_map, &map_size);
-
   /* free-up memory */
   cdada_list_destroy(ll);
   avro_value_iface_decref(if_type_map);
   avro_value_iface_decref(if_type_string);
-  
+
+  return 0;
+}
+
+
+int compose_tcpflags_avro_data(size_t tcpflags_decimal, avro_value_t v_type_record)
+{
+  tcpflag tcpstate;
+
+  /* linked-list creation */
+  cdada_list_t *ll = tcpflags_to_linked_list(tcpflags_decimal);
+  int ll_size = cdada_list_size(ll);
+
+  avro_value_t v_type_array, v_type_string;
+  avro_value_iface_t *if_type_array, *if_type_string;
+
+  if_type_array = avro_generic_class_from_schema(sc_type_array);
+  if_type_string = avro_generic_class_from_schema(sc_type_string);
+
+  avro_generic_value_new(if_type_array, &v_type_array);
+  avro_generic_value_new(if_type_string, &v_type_string);
+
+  size_t idx_0;
+  for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    cdada_list_get(ll, idx_0, &tcpstate);
+    if (avro_value_get_by_name(&v_type_record, "tcp_flags", &v_type_array, NULL) == 0) {
+      /* Serialize only flags set to 1 */
+      if (strcmp(tcpstate.flag, "NULL") != 0) {
+        if (avro_value_append(&v_type_array, &v_type_string, NULL) == 0) {
+          avro_value_set_string(&v_type_string, tcpstate.flag);
+        }
+      }
+    }
+  }
+
+  /* free-up memory */
+  cdada_list_destroy(ll);
+  avro_value_iface_decref(if_type_array);
+  avro_value_iface_decref(if_type_string);
+
   return 0;
 }

--- a/src/plugin_cmn_avro.h
+++ b/src/plugin_cmn_avro.h
@@ -46,8 +46,10 @@
 #define	AVRO_ACCT_CLOSE_SID	2
 
 /* prototypes */
-extern void compose_label_avro_schema(avro_schema_t, int);
+extern void compose_label_avro_schema(avro_schema_t);
+extern void compose_tcpflags_avro_schema(avro_schema_t);
 extern int compose_label_avro_data(char *, avro_value_t, int);
+extern int compose_tcpflags_avro_data(size_t, avro_value_t);
 
 extern void pm_avro_exit_gracefully(int);
 

--- a/src/plugin_cmn_avro.h
+++ b/src/plugin_cmn_avro.h
@@ -46,7 +46,7 @@
 #define	AVRO_ACCT_CLOSE_SID	2
 
 /* prototypes */
-extern void compose_label_avro_schema(avro_schema_t);
+extern void compose_label_avro_schema(avro_schema_t, int);
 extern void compose_tcpflags_avro_schema(avro_schema_t);
 extern int compose_label_avro_data(char *, avro_value_t, int);
 extern int compose_tcpflags_avro_data(size_t, avro_value_t);

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -66,7 +66,6 @@ void compose_json(u_int64_t wtc, u_int64_t wtc_2)
     else {
       cjhandler[idx] = compose_json_label;
     }
-
     idx++;
   }
 
@@ -314,7 +313,12 @@ void compose_json(u_int64_t wtc, u_int64_t wtc_2)
 #endif
 
   if (wtc & COUNT_TCPFLAGS) {
-    cjhandler[idx] = compose_json_tcp_flags;
+    if (config.tcpflags_encode_as_array) {
+      cjhandler[idx] = compose_json_array_tcpflags;
+    }
+    else {
+      cjhandler[idx] = compose_json_tcp_flags;
+    }
     idx++;
   }
 
@@ -1230,6 +1234,7 @@ void *compose_purge_close_json(char *writer_name, pid_t writer_pid, int purged_e
 }
 #endif
 
+
 void compose_json_map_label(json_t *obj, struct chained_cache *cc)
 {
   char empty_string[] = "", *str_ptr;
@@ -1251,23 +1256,57 @@ void compose_json_map_label(json_t *obj, struct chained_cache *cc)
   cdada_list_destroy(ptm_ll);
 }
 
+
+void compose_json_array_tcpflags(json_t *obj, struct chained_cache *cc)
+{
+  char misc_str[VERYSHORTBUFLEN];
+
+  sprintf(misc_str, "%u", cc->tcp_flags);
+
+  /* linked-list creation */
+  cdada_list_t *ll = tcpflags_to_linked_list(cc->tcp_flags);
+  int ll_size = cdada_list_size(ll);
+
+  json_t *root_l1 = compose_tcpflags_json_data(ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "tcp_flags", root_l1);
+
+  cdada_list_destroy(ll);
+}
+
+
 json_t * compose_label_json_data(cdada_list_t *ll, int ll_size)
 {
   ptm_label lbl;
 
-  int idx_0;
-  for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
-    cdada_list_get(ll, idx_0, &lbl);
-  }
-
   json_t *root = json_object();
   json_t *j_str_tmp = NULL;
 
-  int idx_1;
-  for (idx_1 = 0; idx_1 < ll_size; idx_1++) {
-    cdada_list_get(ll, idx_1, &lbl);
+  int idx_0;
+  for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    cdada_list_get(ll, idx_0, &lbl);
     j_str_tmp = json_string(lbl.value);
     json_object_set_new_nocheck(root, lbl.key, j_str_tmp);
+  }
+
+  return root;
+}
+
+
+json_t * compose_tcpflags_json_data(cdada_list_t *ll, int ll_size)
+{
+  tcpflag tcpstate;
+
+  json_t *root = json_array();
+  json_t *j_str_tmp = NULL;
+
+  int idx_0;
+  for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    cdada_list_get(ll, idx_0, &tcpstate);
+    if (strcmp(tcpstate.flag, "NULL") != 0) {
+      j_str_tmp = json_string(tcpstate.flag);
+      json_array_append(root, j_str_tmp);
+    }
   }
 
   return root;

--- a/src/plugin_cmn_json.h
+++ b/src/plugin_cmn_json.h
@@ -32,8 +32,10 @@ typedef void (*compose_json_handler)(json_t *, struct chained_cache *);
 extern compose_json_handler cjhandler[N_PRIMITIVES];
 
 /* prototypes */
-extern json_t *compose_label_json_data(cdada_list_t *ll, int ll_size);
 extern void compose_json_map_label(json_t *, struct chained_cache *);
+extern void compose_json_array_tcpflags(json_t *, struct chained_cache *);
+extern json_t *compose_label_json_data(cdada_list_t *ll, int ll_size);
+extern json_t *compose_tcpflags_json_data(cdada_list_t *ll, int ll_size);
 
 extern void compose_json_event_type(json_t *, struct chained_cache *);
 extern void compose_json_tag(json_t *, struct chained_cache *);

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1015,7 +1015,7 @@ cdada_list_t *ptm_labels_to_linked_list(const char *ptm_labels)
 {
   /* Max amount of tokens per string: 128 Labels */
   const int MAX_TOCKENS = 256;
-  
+
   /* strtok doesn't like const string */
   char *no_const_ptm_labels = strdup(ptm_labels);
 
@@ -1040,4 +1040,39 @@ cdada_list_t *ptm_labels_to_linked_list(const char *ptm_labels)
   }
 
   return ptm_linked_list;
+}
+
+
+cdada_list_t *tcpflags_to_linked_list(size_t tcpflags_decimal)
+{
+  /* Generate the tcpflag's binary array */
+  const char tcpflags_mask[6][5] = {"URG", "ACK", "PSH", "RST", "SYN", "FIN"};
+  size_t tcpflags_binary[6] = {0};
+
+  /* tcpflags binary format (valid decimals between 1 & 63) */
+  size_t idx_0;
+  if ((tcpflags_decimal > 0) && (tcpflags_decimal) < 64) {
+    for (idx_0 = 5; tcpflags_decimal > 0 && idx_0 >= 0; idx_0--) {
+      tcpflags_binary[idx_0] = (tcpflags_decimal % 2);
+      tcpflags_decimal /= 2;
+    }
+  }
+
+  /* Generate the tcpflags' linked-list */
+  cdada_list_t *tcpflag_linked_list = cdada_list_create(tcpflag);
+  tcpflag tcpstate;
+
+  size_t idx_1;
+  for (idx_1 = 0; idx_1 < 6; idx_1++) {
+    memset(&tcpstate, 0, sizeof(tcpstate));
+    if (!tcpflags_binary[idx_1]) {
+      strcpy(tcpstate.flag, "NULL");
+    }
+    else {
+      strcpy(tcpstate.flag, tcpflags_mask[idx_1]);
+    }
+    cdada_list_push_back(tcpflag_linked_list, &tcpstate);
+  }
+
+  return tcpflag_linked_list;
 }

--- a/src/plugin_common.h
+++ b/src/plugin_common.h
@@ -95,6 +95,13 @@ typedef struct {
 } __attribute__((packed)) ptm_label;
 #endif
 
+#ifndef STRUCT_TCPFLAGS
+#define STRUCT_TCPFLAGS
+typedef struct {
+  char flag[5];
+} __attribute__((packed)) tcpflag;
+#endif
+
 /* prototypes */
 extern void P_set_signals();
 extern void P_init_default_values();
@@ -126,8 +133,9 @@ extern void P_update_time_reference(struct insert_data *);
 extern void P_set_stitch(struct chained_cache *, struct pkt_data *, struct insert_data *);
 extern void P_update_stitch(struct chained_cache *, struct pkt_data *, struct insert_data *);
 
-extern cdada_list_t *ptm_labels_to_linked_list(const char *);
 extern const char *labels_delim_normalization(char *);
+extern cdada_list_t *ptm_labels_to_linked_list(const char *);
+extern cdada_list_t *tcpflags_to_linked_list(size_t);
 
 /* global vars */
 extern void (*insert_func)(struct primitives_ptrs *, struct insert_data *); /* pointer to INSERT function */


### PR DESCRIPTION
### Summary of the new functionalities                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                              
The current implementation of PMACCT is encoding the six TCP's Control bits into decimal format. It's the responsibility                                                                                                                                                                                                      
of an external entity to decode them into the human-readable format  [URG, ACK, PSH, RST, SYN, FIN](https://datatracker.ietf.org/doc/html/rfc793#section-3.1).                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                              
The main aim of the new implementation is to embed the decoding action within PMACCT.                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                              
The TCP-Flags can be, for example, serialized to KAFKA (via the kafka-plugin) using either JSON or AVRO. The new implementation                                                                                                                                                                                               
is taking care of loading the active TCP-Flags into an array before proceeding with the actual serialization.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                              
### Main 'Decoding' Steps (Per TCP Flow):                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                              
- PMACCT is returning the decimal representation of the TCP's Control bits                                                                                                                                                                                                                                                    
- An intermediate step is translating from decimal to binary                                                                                                                                                                                                                                                                  
- Finally, only the active TCP-Flags are loaded into an array data structure ready to be serialized                                                                                                                                                                                                                           
```                                                                                                                                                                                                                                                                                                                           
4 ---> [0, 0, 0, 1, 0, 0] ---> ['RST']                                                                                                                                                                                                                                                                                        
```
### JSON output
- Current
```JSON
{                                                                                                                                                              
  "tcp_flags": "decimal_value",                                                                                                                                               
  "other1": "other1",
  "other2": "other2",
  "other3": "other3"
} 
```

- Future
```JSON
{                                                                                                                                                              
  "tcp_flags": [                                                                                                                                             
    "URG",                                                                                                                                                  
    "ACK",                                                                                                                                                  
    "PSH",
    "RST",                                                                                                                                                     
    "SYN",                                                                                                                                                     
    "FIN"                                                                                                                                                     
  ],                                                                                                                                                            
  "other1": "other1",
  "other2": "other2",
  "other3": "other3"
} 
```

### AVRO schema
- Current
```JSON
{                                                                                                                                                                                                                                                                                                                             
  "type": "record",                                                                                                                                                                                                                                                                                                           
  "name": "acct_data",                                                                                                                                                                                                                                                                                                        
  "fields": [                                                                                                                                                                                                                                                                                                                 
    {                                                                                                                                                                                                                                                                                                                         
      "name": "tcp_flags",                                                                                                                                                                                                                                                                                                        
      "type": {                                                                                                                                                                                                                                                                                                               
        "type": "string"                                                                                                                                                                                                                                                                                                      
      }                                                                                                                                                                                                                                                                                                                       
    }
  ]
}
```

- Future
```JSON
{                                                                                                                                                              
  "type": "record",                                                                                                                                                                                                                                 
  "name": "acct_data",                                                                                                                                        
  "fields": [                                                                                                                                                 
    {                                                                                                                                                          
      "name": "tcp_flags",                                                                                                                                     
      "type": {                                                                                                                                               
        "type": "array",                                                                                                                                       
        "items": {                                                                                                                                             
          "type": "string"                                                                                                                                     
        }                                                                                                                                                      
      }                                                                                                                                                        
    }                                                                                                                                                          
  ] 
}       
```
### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)