### PR TITLE
MySQLv8 problem with DATETIME types

### DIFF
--- a/sql/pmacct-create-db_v8.mysql
+++ b/sql/pmacct-create-db_v8.mysql
@@ -22,7 +22,7 @@ create table acct_v8 (
     packets INT UNSIGNED NOT NULL,
     bytes BIGINT UNSIGNED NOT NULL,
     flows INT UNSIGNED NOT NULL,
-    stamp_inserted DATETIME NOT NULL,
-    stamp_updated DATETIME,
+    stamp_inserted BIGINT UNSIGNED NOT NULL,
+    stamp_updated BIGINT UNSIGNED,
     PRIMARY KEY (agent_id, class_id, mac_src, mac_dst, vlan, as_src, as_dst, ip_src, ip_dst, port_src, port_dst, ip_proto, tos, stamp_inserted)
 );


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When I'm trying to run sfacctd with mysql plugin it throw errors like:
`Incorrect datetime value: '1642073401' for column 'stamp_updated' at row 1`

MySQL datetime is not supposed to store unix timestamps.
Changed columns 'stamp_inserted' and 'stamp_updated' to bigint and now it works.

In other way, we can pass UNIX_TIMESTAMP() function in INSERT's and keep datetime types, but in my opinion timestamps more easy to deal with than mysql date types.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)