### PR TITLE
fix the memleak created by label(MAP) + AVRO + BxP (msglog) ...

### DIFF
--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -37,6 +37,7 @@
 #include "plugin_cmn_avro.h"
 #endif
 
+
 /* functions */
 int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, safi_t safi,
 		     bgp_tag_t *tag, char *event_type, int output, char **output_data,
@@ -655,6 +656,7 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, saf
     avro_value_iface_decref(p_avro_iface);
     avro_writer_reset(p_avro_writer);
     avro_writer_free(p_avro_writer);
+    
     if (bms->dump_kafka_avro_schema_registry) {
       free(p_avro_local_buf);
     }
@@ -843,7 +845,7 @@ int bgp_peer_log_init(struct bgp_peer *peer, bgp_tag_t *tag, int output, int typ
       }
 
       if (config.pre_tag_map && tag) {
-	bgp_tag_print_avro(p_avro_obj, tag);
+        bgp_tag_print_avro(p_avro_obj, tag);
       }
 
       pm_avro_check(avro_value_get_by_name(&p_avro_obj, "event_type", &p_avro_field, NULL));
@@ -2014,7 +2016,7 @@ int bgp_table_dump_event_runner(struct pm_dump_runner *pdr)
     bgp_peer_log_dynname(latest_filename, SRVBUFLEN, config.bgp_table_dump_latest_file, peer);
     link_latest_output_file(latest_filename, last_filename);
   }
-
+  
   duration = time(NULL)-start;
   Log(LOG_INFO, "INFO ( %s/%s ): *** Dumping BGP tables - END (PID: %u RID: %u TABLES: %u ENTRIES: %" PRIu64 " ET: %u) ***\n",
       config.name, bms->log_str, dumper_pid, pdr->id, tables_num, dump_elems, duration);
@@ -2283,7 +2285,7 @@ void p_avro_schema_build_bgp_common(avro_schema_t *schema, avro_schema_t *optlon
     avro_schema_record_field_append((*schema), "tag", (*optlong_s));
 
     if (config.pretag_label_encode_as_map) {
-      compose_label_avro_schema((*schema), TRUE);
+      compose_label_avro_schema_bxp((*schema));
     }
     else {
       avro_schema_record_field_append((*schema), "label", (*optstr_s));
@@ -2369,7 +2371,7 @@ void bgp_tag_print_avro(avro_value_t obj, bgp_tag_t *tag)
 
   if (tag->have_label) {
     if (config.pretag_label_encode_as_map) {
-      compose_label_avro_data(tag->label.val, obj, TRUE);
+      compose_label_avro_data_bxp(tag->label.val, obj);
     }
     else {
       pm_avro_check(avro_value_get_by_name(&obj, "label", &p_avro_field, NULL));

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -35,6 +35,7 @@
 #include "plugin_cmn_avro.h"
 #endif
 
+
 int bmp_log_msg(struct bgp_peer *peer, struct bmp_data *bdata, struct pm_list *tlvs, bgp_tag_t *tag,
 		void *log_data, u_int64_t log_seq, char *event_type, int output, int log_type)
 {
@@ -353,6 +354,7 @@ int bmp_log_msg(struct bgp_peer *peer, struct bmp_data *bdata, struct pm_list *t
     avro_value_iface_decref(p_avro_iface);
     avro_writer_reset(p_avro_writer);
     avro_writer_free(p_avro_writer);
+    
     if (bms->dump_kafka_avro_schema_registry) {
       free(p_avro_local_buf);
     }
@@ -2351,7 +2353,7 @@ void p_avro_schema_build_bmp_common(avro_schema_t *schema, avro_schema_t *optlon
     avro_schema_record_field_append((*schema), "tag", (*optlong_s));
 
     if (config.pretag_label_encode_as_map) {
-      compose_label_avro_schema((*schema), TRUE);
+      compose_label_avro_schema_bxp((*schema));
     }
     else {
       avro_schema_record_field_append((*schema), "label", (*optstr_s));

--- a/src/plugin_cmn_avro.h
+++ b/src/plugin_cmn_avro.h
@@ -46,9 +46,11 @@
 #define	AVRO_ACCT_CLOSE_SID	2
 
 /* prototypes */
-extern void compose_label_avro_schema(avro_schema_t, int);
+extern void compose_label_avro_schema_ipfix(avro_schema_t);
+extern void compose_label_avro_schema_bxp(avro_schema_t);
 extern void compose_tcpflags_avro_schema(avro_schema_t);
-extern int compose_label_avro_data(char *, avro_value_t, int);
+extern int compose_label_avro_data_ipfix(char *, avro_value_t);
+extern int compose_label_avro_data_bxp(char *, avro_value_t);
 extern int compose_tcpflags_avro_data(size_t, avro_value_t);
 
 extern void pm_avro_exit_gracefully(int);

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -1243,7 +1243,9 @@ void compose_json_map_label(json_t *obj, struct chained_cache *cc)
   if (!str_ptr) str_ptr = empty_string;
 
   /* labels normalization */
-  const char *lbls_norm = labels_delim_normalization(str_ptr);
+  cdada_str_t *lbls_cdada = cdada_str_create(str_ptr);
+  cdada_str_replace_all(lbls_cdada, PRETAG_LABEL_KV_SEP, DEFAULT_SEP);
+  const char *lbls_norm = cdada_str(lbls_cdada);
 
   /* linked-list creation */
   cdada_list_t *ptm_ll = ptm_labels_to_linked_list(lbls_norm);
@@ -1252,7 +1254,8 @@ void compose_json_map_label(json_t *obj, struct chained_cache *cc)
   json_t *root_l1 = compose_label_json_data(ptm_ll, ll_size);
 
   json_object_set_new_nocheck(obj, "label", root_l1);
-
+  
+  cdada_str_destroy(lbls_cdada);
   cdada_list_destroy(ptm_ll);
 }
 
@@ -1287,10 +1290,6 @@ json_t * compose_label_json_data(cdada_list_t *ll, int ll_size)
     cdada_list_get(ll, idx_0, &lbl);
     j_str_tmp = json_string(lbl.value);
     json_object_set_new_nocheck(root, lbl.key, j_str_tmp);
-
-    /* one-time use */
-    free(lbl.key);
-    free(lbl.value);
   }
 
   return root;

--- a/src/plugin_common.h
+++ b/src/plugin_common.h
@@ -90,8 +90,8 @@ struct p_table_rr {
 #ifndef STRUCT_PTM_LABEL
 #define STRUCT_PTM_LABEL
 typedef struct {
-  char *key;
-  char *value;
+  char key[128];
+  char value[128];
 } __attribute__((packed)) ptm_label;
 #endif
 
@@ -133,7 +133,6 @@ extern void P_update_time_reference(struct insert_data *);
 extern void P_set_stitch(struct chained_cache *, struct pkt_data *, struct insert_data *);
 extern void P_update_stitch(struct chained_cache *, struct pkt_data *, struct insert_data *);
 
-extern const char *labels_delim_normalization(char *);
 extern cdada_list_t *ptm_labels_to_linked_list(const char *);
 extern cdada_list_t *tcpflags_to_linked_list(size_t);
 


### PR DESCRIPTION
### Changelog

- The function "avro_generic_value_new()" has been deleted from each single sub-function related to label(MAP) | TCP-FLAGs | ... : the AVRO's interfaces & associated values (including their decref) are handled by the upper-level functions. (memory leak main issue).

- The function in charge to serialize the LABEL(MAP) data to KAFKA is now divided into two separated functions: the first one for IPFIX while the second one for BxP (BGP/BMP)

- The exact same approach as above is now adopted for the schema generation, there are now two separated functions: one for IPFIX & one for BxP.

-  The function in charge of generating the linked-list storing the label(MAP) information has been refactored replacing strdup() with strcpy().


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)
