### PR TITLE
Minor safety & code efficiency enhancements related to my recent plugin-common (AVRO & JSON) functions 

### DIFF
--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -1441,12 +1441,13 @@ int compose_label_avro_data_nonopt(char *str_ptr, avro_value_t v_type_record)
   /* linked-list creation */
   ptm_label lbl;
   cdada_list_t *ll = ptm_labels_to_linked_list(lbls_norm);
-  int ll_size = cdada_list_size(ll);
+  size_t ll_size = cdada_list_size(ll);
 
   avro_value_t v_type_string, v_type_map;
 
-  int idx_0;
+  size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&lbl, 0, sizeof(lbl));
     cdada_list_get(ll, idx_0, &lbl);
     if (avro_value_get_by_name(&v_type_record, "label", &v_type_map, NULL) == 0) {
       if (avro_value_add(&v_type_map, lbl.key, &v_type_string, NULL, NULL) == 0) {
@@ -1473,12 +1474,13 @@ int compose_label_avro_data_opt(char *str_ptr, avro_value_t v_type_record)
   /* linked-list creation */
   ptm_label lbl;
   cdada_list_t *ll = ptm_labels_to_linked_list(lbls_norm);
-  int ll_size = cdada_list_size(ll);
+  size_t ll_size = cdada_list_size(ll);
 
   avro_value_t v_type_union, v_type_branch, v_type_string;
 
-  int idx_0;
+  size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&lbl, 0, sizeof(lbl));
     cdada_list_get(ll, idx_0, &lbl);
     /* handling label with value */
     if (lbl.value) {
@@ -1510,12 +1512,13 @@ int compose_tcpflags_avro_data(size_t tcpflags_decimal, avro_value_t v_type_reco
 
   /* linked-list creation */
   cdada_list_t *ll = tcpflags_to_linked_list(tcpflags_decimal);
-  int ll_size = cdada_list_size(ll);
+  size_t ll_size = cdada_list_size(ll);
 
   avro_value_t v_type_array, v_type_string;
 
   size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&tcpstate, 0, sizeof(tcpstate));
     cdada_list_get(ll, idx_0, &tcpstate);
     if (avro_value_get_by_name(&v_type_record, "tcp_flags", &v_type_array, NULL) == 0) {
       /* Serialize only flags set to 1 */
@@ -1540,7 +1543,7 @@ int compose_fwd_status_avro_data(size_t fwdstatus_decimal, avro_value_t v_type_r
 
   /* linked-list creation */
   cdada_list_t *ll = fwd_status_to_linked_list();
-  int ll_size = cdada_list_size(ll);
+  size_t ll_size = cdada_list_size(ll);
 
   avro_value_t v_type_string;
   
@@ -1573,6 +1576,7 @@ int compose_fwd_status_avro_data(size_t fwdstatus_decimal, avro_value_t v_type_r
 
   size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&fwdstate, 0, sizeof(fwdstate));
     cdada_list_get(ll, idx_0, &fwdstate);
     if (avro_value_get_by_name(&v_type_record, "fwd_status", &v_type_string, NULL) == 0) {
       if (fwdstate.decimal == fwdstatus_decimal) {

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -1252,7 +1252,6 @@ void *compose_purge_close_json(char *writer_name, pid_t writer_pid, int purged_e
 }
 #endif
 
-
 void compose_json_map_label(json_t *obj, struct chained_cache *cc)
 {
   char empty_string[] = "", *str_ptr;
@@ -1267,7 +1266,7 @@ void compose_json_map_label(json_t *obj, struct chained_cache *cc)
 
   /* linked-list creation */
   cdada_list_t *ptm_ll = ptm_labels_to_linked_list(lbls_norm);
-  int ll_size = cdada_list_size(ptm_ll);
+  size_t ll_size = cdada_list_size(ptm_ll);
 
   json_t *root_l1 = compose_label_json_data(ptm_ll, ll_size);
 
@@ -1277,12 +1276,11 @@ void compose_json_map_label(json_t *obj, struct chained_cache *cc)
   cdada_list_destroy(ptm_ll);
 }
 
-
 void compose_json_array_tcpflags(json_t *obj, struct chained_cache *cc)
 {
   /* linked-list creation */
   cdada_list_t *ll = tcpflags_to_linked_list(cc->tcp_flags);
-  int ll_size = cdada_list_size(ll);
+  size_t ll_size = cdada_list_size(ll);
 
   json_t *root_l1 = compose_tcpflags_json_data(ll, ll_size);
 
@@ -1291,12 +1289,11 @@ void compose_json_array_tcpflags(json_t *obj, struct chained_cache *cc)
   cdada_list_destroy(ll);
 }
 
-
 void compose_json_string_fwd_status(json_t *obj, struct chained_cache *cc)
 {
   /* linked-list creation */
   cdada_list_t *fwd_status_ll = fwd_status_to_linked_list();
-  int ll_size = cdada_list_size(fwd_status_ll);
+  size_t ll_size = cdada_list_size(fwd_status_ll);
 
   json_t *root_l1 = compose_fwd_status_json_data(cc->pnat->fwd_status, fwd_status_ll, ll_size);
 
@@ -1305,7 +1302,6 @@ void compose_json_string_fwd_status(json_t *obj, struct chained_cache *cc)
   cdada_list_destroy(fwd_status_ll);
 }
 
-
 json_t *compose_label_json_data(cdada_list_t *ll, int ll_size)
 {
   ptm_label lbl;
@@ -1313,8 +1309,9 @@ json_t *compose_label_json_data(cdada_list_t *ll, int ll_size)
   json_t *root = json_object();
   json_t *j_str_tmp = NULL;
 
-  int idx_0;
+  size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&lbl, 0, sizeof(lbl));
     cdada_list_get(ll, idx_0, &lbl);
     j_str_tmp = json_string(lbl.value);
     json_object_set_new_nocheck(root, lbl.key, j_str_tmp);
@@ -1323,7 +1320,6 @@ json_t *compose_label_json_data(cdada_list_t *ll, int ll_size)
   return root;
 }
 
-
 json_t *compose_tcpflags_json_data(cdada_list_t *ll, int ll_size)
 {
   tcpflag tcpstate;
@@ -1331,10 +1327,11 @@ json_t *compose_tcpflags_json_data(cdada_list_t *ll, int ll_size)
   json_t *root = json_array();
   json_t *j_str_tmp = NULL;
 
-  int idx_0;
+  size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&tcpstate, 0, sizeof(tcpstate));
     cdada_list_get(ll, idx_0, &tcpstate);
-    if (strcmp(tcpstate.flag, "NULL") != 0) {
+    if (strncmp(tcpstate.flag, "NULL", (TCP_FLAG_LEN - 1)) != 0) {
       j_str_tmp = json_string(tcpstate.flag);
       json_array_append(root, j_str_tmp);
     }
@@ -1342,7 +1339,6 @@ json_t *compose_tcpflags_json_data(cdada_list_t *ll, int ll_size)
 
   return root;
 }
-
 
 json_t *compose_fwd_status_json_data(size_t fwdstatus_decimal, cdada_list_t *ll, int ll_size)
 {
@@ -1366,8 +1362,9 @@ json_t *compose_fwd_status_json_data(size_t fwdstatus_decimal, cdada_list_t *ll,
     root = json_string("RFC-7270 Misinterpreted");
   }
 
-  int idx_0;
+  size_t idx_0;
   for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&fwdstate, 0, sizeof(fwdstate));
     cdada_list_get(ll, idx_0, &fwdstate);
     if (fwdstate.decimal == fwdstatus_decimal) {
       json_string_set(root, fwdstate.description);

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1095,7 +1095,7 @@ cdada_list_t *fwd_status_to_linked_list()
   const int FWD_STATUS_REASON_CODES = 23;
 
   /* RFC-7270: forwardingStatus with a compliant reason code */
-  const unsigned int fwd_status_decimal[FWD_STATUS_REASON_CODES] = {
+  const unsigned int fwd_status_decimal[] = {
     64, 65, 66,
     128, 129, 130,
     131, 132, 133,

--- a/src/plugin_common.h
+++ b/src/plugin_common.h
@@ -36,6 +36,8 @@
 #define AVERAGE_CHAIN_LEN 10
 #define PRINT_CACHE_ENTRIES 16411
 #define MAX_PTM_LABEL_TOKEN_LEN	128
+#define TCP_FLAG_LEN 5
+#define FWD_TYPES_STR_LEN 50
 
 /* cache element states */
 #define PRINT_CACHE_FREE	0
@@ -99,7 +101,7 @@ typedef struct {
 #ifndef STRUCT_TCPFLAGS
 #define STRUCT_TCPFLAGS
 typedef struct {
-  char flag[5];
+  char flag[TCP_FLAG_LEN];
 } __attribute__((packed)) tcpflag;
 #endif
 
@@ -107,7 +109,7 @@ typedef struct {
 #define NFACCTD_FWDSTATUS
 typedef struct {
   unsigned int decimal;
-  char description[50];
+  char description[FWD_TYPES_STR_LEN];
 } __attribute__((packed)) fwd_status;
 #endif
 


### PR DESCRIPTION
### Summary 

The main aim of this PR is to bring some improvements from both security & code efficiency perspective for what concerning the plugin-common (AVRO & JSON) functions I've recently developed:

- memset to "zeroize" some variables before utilization
- Indexes switched to "size_t" instead of "int" type
- whenever possible switching to safe string functions (example strNcpy instead of strcpy)
- whenever possible setting variables at pre-processor level, using the most appropriate header file, to improve code readability  


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)