### PR TITLE
Fixing the way strncat's size value is calculated to generate the mpls-label-stack string/array ... 

### DIFF
--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -870,7 +870,7 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
         snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", pmpls->labels_cycle[idx_0]);
         strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
         strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
-        MAX_MPLS_LABEL_STACK_DELTA = (strlen(label_buf) + strlen(",") + 2);
+        MAX_MPLS_LABEL_STACK_INC = (strlen(label_buf) + strlen(",") + 2);
         printf("MAX_MPLS_LABEL_STACK_DELTA: %d", (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_INC));
       }
 

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -871,7 +871,7 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
         strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
         strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
         MAX_MPLS_LABEL_STACK_INC = (strlen(label_buf) + strlen(",") + 2);
-        printf("MAX_MPLS_LABEL_STACK_DELTA: %d", (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_INC));
+        printf("MAX_MPLS_LABEL_STACK_DELTA: %d\n", (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_INC));
       }
 
       pm_avro_check(avro_value_get_by_name(&value, "mpls_label_stack", &field, NULL));

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -1639,7 +1639,7 @@ int compose_mpls_label_stack_data(u_int32_t *labels_cycle, avro_value_t v_type_r
 {
   const int MAX_IDX_LEN = 4;
   const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN);
-  int MAX_MPLS_LABEL_IDX_LEN_DEC = 0;
+  int max_mpls_label_idx_len_dec = 0;
   char label_buf[MAX_MPLS_LABEL_LEN];
   char label_idx_buf[MAX_MPLS_LABEL_IDX_LEN];
   char idx_buf[MAX_IDX_LEN];
@@ -1655,10 +1655,10 @@ int compose_mpls_label_stack_data(u_int32_t *labels_cycle, avro_value_t v_type_r
         memset(&idx_buf, 0, sizeof(idx_buf));
         memset(&label_idx_buf, 0, sizeof(label_idx_buf));
         snprintf(idx_buf, MAX_IDX_LEN, "%zu", idx_0);
-        strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
-        strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
-        strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
-        MAX_MPLS_LABEL_IDX_LEN_DEC = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
+        strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
+        strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
+        strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
+        max_mpls_label_idx_len_dec = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
         if (avro_value_append(&v_type_array, &v_type_string, NULL) == 0) {
           avro_value_set_string(&v_type_string, label_idx_buf);
         }

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -858,17 +858,20 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
     } 
     else {
       const int MAX_MPLS_LABEL_STACK = 128;
+      int MAX_MPLS_LABEL_STACK_INC = 0;
       char mpls_label_stack[MAX_MPLS_LABEL_STACK];
       char label_buf[MAX_MPLS_LABEL_LEN];
   
       memset(&mpls_label_stack, 0, sizeof(mpls_label_stack));
 
-      int idx_0;
+      size_t idx_0;
       for(idx_0 = 0; idx_0 < MAX_MPLS_LABELS; idx_0++) {
         memset(&label_buf, 0, sizeof(label_buf));
         snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", pmpls->labels_cycle[idx_0]);
-        strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - strlen(label_buf) - 1));
-        strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - strlen(label_buf) - 1));
+        strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
+        strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
+        MAX_MPLS_LABEL_STACK_DELTA = (strlen(label_buf) + strlen(",") + 2);
+        printf("MAX_MPLS_LABEL_STACK_DELTA: %d", (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_INC));
       }
 
       pm_avro_check(avro_value_get_by_name(&value, "mpls_label_stack", &field, NULL));

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -858,7 +858,7 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
     } 
     else {
       const int MAX_MPLS_LABEL_STACK = 128;
-      int MAX_MPLS_LABEL_STACK_INC = 0;
+      int MAX_MPLS_LABEL_STACK_DEC = 0;
       char mpls_label_stack[MAX_MPLS_LABEL_STACK];
       char label_buf[MAX_MPLS_LABEL_LEN];
   
@@ -868,10 +868,9 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
       for(idx_0 = 0; idx_0 < MAX_MPLS_LABELS; idx_0++) {
         memset(&label_buf, 0, sizeof(label_buf));
         snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", pmpls->labels_cycle[idx_0]);
-        strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
-        strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_INC));
-        MAX_MPLS_LABEL_STACK_INC = (strlen(label_buf) + strlen(",") + 2);
-        printf("MAX_MPLS_LABEL_STACK_DELTA: %d\n", (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_INC));
+        strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_DEC));
+        strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - MAX_MPLS_LABEL_STACK_DEC));
+        MAX_MPLS_LABEL_STACK_DEC = (strlen(label_buf) + strlen(",") + 2);
       }
 
       pm_avro_check(avro_value_get_by_name(&value, "mpls_label_stack", &field, NULL));
@@ -1639,7 +1638,8 @@ int compose_fwd_status_avro_data(size_t fwdstatus_decimal, avro_value_t v_type_r
 int compose_mpls_label_stack_data(u_int32_t *labels_cycle, avro_value_t v_type_record)
 {
   const int MAX_IDX_LEN = 4;
-  const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN); 
+  const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN);
+  int MAX_MPLS_LABEL_IDX_LEN_DEC = 0;
   char label_buf[MAX_MPLS_LABEL_LEN];
   char label_idx_buf[MAX_MPLS_LABEL_IDX_LEN];
   char idx_buf[MAX_IDX_LEN];
@@ -1655,9 +1655,10 @@ int compose_mpls_label_stack_data(u_int32_t *labels_cycle, avro_value_t v_type_r
         memset(&idx_buf, 0, sizeof(idx_buf));
         memset(&label_idx_buf, 0, sizeof(label_idx_buf));
         snprintf(idx_buf, MAX_IDX_LEN, "%zu", idx_0);
-        strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - 1));
-        strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - strlen(idx_buf) - 1));
-        strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - strlen(idx_buf) - strlen("-") - 1));
+        strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
+        strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
+        strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
+        MAX_MPLS_LABEL_IDX_LEN_DEC = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
         if (avro_value_append(&v_type_array, &v_type_string, NULL) == 0) {
           avro_value_set_string(&v_type_string, label_idx_buf);
         }

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -1416,7 +1416,7 @@ json_t *compose_mpls_label_stack_json_data(u_int32_t *labels_cycle)
 {
   const int MAX_IDX_LEN = 4;
   const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN);
-   int MAX_MPLS_LABEL_IDX_LEN_DEC = 0;
+  int max_mpls_label_idx_len_dec = 0;
   char label_buf[MAX_MPLS_LABEL_LEN];
   char label_idx_buf[MAX_MPLS_LABEL_IDX_LEN];
   char idx_buf[MAX_IDX_LEN];
@@ -1432,10 +1432,10 @@ json_t *compose_mpls_label_stack_json_data(u_int32_t *labels_cycle)
       memset(&idx_buf, 0, sizeof(idx_buf));
       memset(&label_idx_buf, 0, sizeof(label_idx_buf));
       snprintf(idx_buf, MAX_IDX_LEN, "%zu", idx_0);
-      strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
-      strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
-      strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
-      MAX_MPLS_LABEL_IDX_LEN_DEC = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
+      strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
+      strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
+      strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
+      max_mpls_label_idx_len_dec = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
       j_str_tmp = json_string(label_idx_buf);
       json_array_append(root, j_str_tmp); 
     }

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -1416,6 +1416,7 @@ json_t *compose_mpls_label_stack_json_data(u_int32_t *labels_cycle)
 {
   const int MAX_IDX_LEN = 4;
   const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN);
+   int MAX_MPLS_LABEL_IDX_LEN_DEC = 0;
   char label_buf[MAX_MPLS_LABEL_LEN];
   char label_idx_buf[MAX_MPLS_LABEL_IDX_LEN];
   char idx_buf[MAX_IDX_LEN];
@@ -1431,9 +1432,10 @@ json_t *compose_mpls_label_stack_json_data(u_int32_t *labels_cycle)
       memset(&idx_buf, 0, sizeof(idx_buf));
       memset(&label_idx_buf, 0, sizeof(label_idx_buf));
       snprintf(idx_buf, MAX_IDX_LEN, "%zu", idx_0);
-      strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - 1));
-      strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - strlen(idx_buf) - 1));
-      strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - strlen(idx_buf) - strlen("-") - 1));
+      strncat(label_idx_buf, idx_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
+      strncat(label_idx_buf, "-", (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
+      strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - MAX_MPLS_LABEL_IDX_LEN_DEC));
+      MAX_MPLS_LABEL_IDX_LEN_DEC = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
       j_str_tmp = json_string(label_idx_buf);
       json_array_append(root, j_str_tmp); 
     }

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -960,6 +960,7 @@ void compose_json_fwd_status(json_t *obj, struct chained_cache *cc)
 void compose_json_mpls_label_stack(json_t *obj, struct chained_cache *cc)
 {
   const int MAX_MPLS_LABEL_STACK = 128;
+  int MAX_MPLS_LABEL_STACK_DEC = 0;
   char mpls_label_stack[MAX_MPLS_LABEL_STACK];
   char label_buf[MAX_MPLS_LABEL_LEN];
     
@@ -969,8 +970,9 @@ void compose_json_mpls_label_stack(json_t *obj, struct chained_cache *cc)
   for(idx_0 = 0; idx_0 < MAX_MPLS_LABELS; idx_0++) {
     memset(&label_buf, 0, sizeof(label_buf));
     snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", cc->pmpls->labels_cycle[idx_0]);
-    strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_LEN - strlen(label_buf) - 1));
-    strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_LEN - strlen(label_buf) - 1));
+    strncat(mpls_label_stack, label_buf, (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_DEC));
+    strncat(mpls_label_stack, ",", (MAX_MPLS_LABEL_STACK - MAX_MPLS_LABEL_STACK_DEC));
+    MAX_MPLS_LABEL_STACK_DEC = (strlen(label_buf) + strlen(",") + 2);
   }
 
   json_object_set_new_nocheck(obj, "mpls_label_stack", json_string(mpls_label_stack));

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1017,7 +1017,8 @@ cdada_list_t *ptm_labels_to_linked_list(const char *ptm_labels)
   /* incoming/normalized str to array */
   char ptm_array_labels[PTM_LABELS_LEN + 1];
   memset(&ptm_array_labels, 0, sizeof(ptm_array_labels));
-  strncpy(ptm_array_labels, ptm_labels, (PTM_LABELS_LEN - 1));
+  /* no overflow risk */
+  strcpy(ptm_array_labels, ptm_labels);
 
   cdada_list_t *ptm_linked_list = cdada_list_create(ptm_label);
   ptm_label lbl;


### PR DESCRIPTION
### Summary 

This PR is adding on top of PR #574 & as described within the title is to fix the way strncat's size value is calculated to generate the mpls-label-stack string/array


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)
