### PR TITLE
Renaming the variable "labels_cycle" to "label_stack" 

### DIFF
--- a/src/mongodb_plugin.c
+++ b/src/mongodb_plugin.c
@@ -753,7 +753,7 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index, int safe_acti
       if (config.what_to_count_2 & COUNT_MPLS_LABEL_STACK) {
 	char mpls_label_stack[MAX_MPLS_LABEL_STACK];
 
-	mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, pmpls->labels_cycle);
+	mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, pmpls->label_stack);
 	bson_append_int(bson_elem, "mpls_label_stack", mpls_label_stack);
       }
       if (config.what_to_count_2 & COUNT_MPLS_STACK_DEPTH) bson_append_int(bson_elem, "mpls_stack_depth", pmpls->mpls_stack_depth);

--- a/src/network.h
+++ b/src/network.h
@@ -588,7 +588,7 @@ struct pkt_mpls_primitives {
   u_int32_t mpls_label_top;
   u_int32_t mpls_label_bottom;
   u_int8_t mpls_stack_depth;
-  u_int32_t labels_cycle[MAX_MPLS_LABELS]; /* XXX: can be optimized using variable-length primitives */
+  u_int32_t label_stack[MAX_MPLS_LABELS]; /* XXX: can be optimized using variable-length primitives */
 };
 
 struct pkt_tunnel_primitives {

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -1065,7 +1065,7 @@ void mpls_label_stack_handler(struct channels_list_entry *chptr, struct packet_p
       lvalue = ntohl(*label);
       
       if (idx < MAX_MPLS_LABELS) {
-	pmpls->labels_cycle[idx] = MPLS_LABEL(lvalue);
+	pmpls->label_stack[idx] = MPLS_LABEL(lvalue);
 	idx++;
       }
 
@@ -3550,33 +3550,33 @@ void NF_mpls_label_stack_handler(struct channels_list_entry *chptr, struct packe
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_mpls_primitives *pmpls = (struct pkt_mpls_primitives *) ((*data) + chptr->extras.off_pkt_mpls_primitives);
-  memset(&pmpls->labels_cycle, 0, sizeof(pmpls->labels_cycle));
+  memset(&pmpls->label_stack, 0, sizeof(pmpls->label_stack));
 
   switch(hdr->version) {
   case 10:
   case 9:
     if (tpl->tpl[NF9_MPLS_LABEL_1].len == 3) {
-      pmpls->labels_cycle[0] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_1].off);
+      pmpls->label_stack[0] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_1].off);
     } 
 
     if (tpl->tpl[NF9_MPLS_LABEL_2].len == 3) {
-      pmpls->labels_cycle[1] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_2].off);
+      pmpls->label_stack[1] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_2].off);
     }
 
     if (tpl->tpl[NF9_MPLS_LABEL_3].len == 3) {
-      pmpls->labels_cycle[2] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_3].off);
+      pmpls->label_stack[2] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_3].off);
     } 
     
     if (tpl->tpl[NF9_MPLS_LABEL_4].len == 3) {
-      pmpls->labels_cycle[3] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_4].off);
+      pmpls->label_stack[3] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_4].off);
     } 
     
     if (tpl->tpl[NF9_MPLS_LABEL_5].len == 3) {
-      pmpls->labels_cycle[4] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_5].off);
+      pmpls->label_stack[4] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_5].off);
     } 
     
     if (tpl->tpl[NF9_MPLS_LABEL_6].len == 3) {
-      pmpls->labels_cycle[5] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_6].off);
+      pmpls->label_stack[5] = decode_mpls_label(pptrs->f_data+tpl->tpl[NF9_MPLS_LABEL_6].off);
     }
     break;
   default:
@@ -5530,7 +5530,7 @@ void SF_mpls_label_stack_handler(struct channels_list_entry *chptr, struct packe
       lvalue = ntohl(*label);
 
       if (idx < MAX_MPLS_LABELS) {
-	pmpls->labels_cycle[idx] = MPLS_LABEL(lvalue);
+	pmpls->label_stack[idx] = MPLS_LABEL(lvalue);
 	idx++;
       }
 

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -854,12 +854,12 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int8_t flo
 
   if (wtc_2 & COUNT_MPLS_LABEL_STACK) {
     if (config.mpls_label_stack_encode_as_array) {
-      compose_mpls_label_stack_data(pmpls->labels_cycle, value);
+      compose_mpls_label_stack_data(pmpls->label_stack, value);
     } 
     else {
       char mpls_label_stack[MAX_MPLS_LABEL_STACK];
 
-      mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, pmpls->labels_cycle);
+      mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, pmpls->label_stack);
       pm_avro_check(avro_value_get_by_name(&value, "mpls_label_stack", &field, NULL));
       pm_avro_check(avro_value_set_string(&field, mpls_label_stack));
     }
@@ -1622,7 +1622,7 @@ int compose_fwd_status_avro_data(size_t fwdstatus_decimal, avro_value_t v_type_r
   return 0;
 }
 
-int compose_mpls_label_stack_data(u_int32_t *labels_cycle, avro_value_t v_type_record)
+int compose_mpls_label_stack_data(u_int32_t *label_stack, avro_value_t v_type_record)
 {
   const int MAX_IDX_LEN = 4;
   const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN);
@@ -1636,7 +1636,7 @@ int compose_mpls_label_stack_data(u_int32_t *labels_cycle, avro_value_t v_type_r
   size_t idx_0;
   for (idx_0 = 0; idx_0 < MAX_MPLS_LABELS; idx_0++) {
     memset(&label_buf, 0, sizeof(label_buf));
-    snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", *(labels_cycle + idx_0));
+    snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", *(label_stack + idx_0));
     if (avro_value_get_by_name(&v_type_record, "mpls_label_stack", &v_type_array, NULL) == 0) {
       if (strncmp("0", label_buf, 1)) {
         memset(&idx_buf, 0, sizeof(idx_buf));

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -961,7 +961,7 @@ void compose_json_mpls_label_stack(json_t *obj, struct chained_cache *cc)
 {
   char mpls_label_stack[MAX_MPLS_LABEL_STACK];
 
-  mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, cc->pmpls->labels_cycle);
+  mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, cc->pmpls->label_stack);
   json_object_set_new_nocheck(obj, "mpls_label_stack", json_string(mpls_label_stack));
 }
 
@@ -1322,7 +1322,7 @@ void compose_json_string_fwd_status(json_t *obj, struct chained_cache *cc)
 
 void compose_json_array_mpls_label_stack(json_t *obj, struct chained_cache *cc)
 {
-  json_t *root_l1 = compose_mpls_label_stack_json_data(cc->pmpls->labels_cycle);
+  json_t *root_l1 = compose_mpls_label_stack_json_data(cc->pmpls->label_stack);
 
   json_object_set_new_nocheck(obj, "mpls_label_stack", root_l1);
 }
@@ -1399,7 +1399,7 @@ json_t *compose_fwd_status_json_data(size_t fwdstatus_decimal, cdada_list_t *ll,
   return root;
 }
 
-json_t *compose_mpls_label_stack_json_data(u_int32_t *labels_cycle)
+json_t *compose_mpls_label_stack_json_data(u_int32_t *label_stack)
 {
   const int MAX_IDX_LEN = 4;
   const int MAX_MPLS_LABEL_IDX_LEN = (MAX_IDX_LEN + MAX_MPLS_LABEL_LEN);
@@ -1414,7 +1414,7 @@ json_t *compose_mpls_label_stack_json_data(u_int32_t *labels_cycle)
   size_t idx_0;
   for (idx_0 = 0; idx_0 < MAX_MPLS_LABELS; idx_0++) {
     memset(&label_buf, 0, sizeof(label_buf));
-    snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", *(labels_cycle + idx_0));
+    snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", *(label_stack + idx_0));
     if (strncmp("0", label_buf, 1)) {
       memset(&idx_buf, 0, sizeof(idx_buf));
       memset(&label_idx_buf, 0, sizeof(label_idx_buf));

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1149,7 +1149,7 @@ cdada_list_t *fwd_status_to_linked_list()
   return fwd_status_linked_list;
 }
 
-void mpls_label_stack_to_str(char *mpls_label_stack, int mls_len, u_int32_t *labels_cycle)
+void mpls_label_stack_to_str(char *mpls_label_stack, int mls_len, u_int32_t *label_stack)
 {
   int max_mpls_label_stack_dec = 0, idx_0;
   char label_buf[MAX_MPLS_LABEL_LEN];
@@ -1158,7 +1158,7 @@ void mpls_label_stack_to_str(char *mpls_label_stack, int mls_len, u_int32_t *lab
 
   for(idx_0 = 0; idx_0 < MAX_MPLS_LABELS; idx_0++) {
     memset(&label_buf, 0, sizeof(label_buf));
-    snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", labels_cycle[idx_0]);
+    snprintf(label_buf, MAX_MPLS_LABEL_LEN, "%u", label_stack[idx_0]);
     strncat(mpls_label_stack, label_buf, (mls_len - max_mpls_label_stack_dec));
     strncat(mpls_label_stack, "_", (mls_len - max_mpls_label_stack_dec));
     max_mpls_label_stack_dec = (strlen(label_buf) + strlen("_") + 2);

--- a/src/print_plugin.c
+++ b/src/print_plugin.c
@@ -1148,7 +1148,7 @@ void P_cache_purge(struct chained_cache *queue[], int index, int safe_action)
         if (config.what_to_count_2 & COUNT_MPLS_LABEL_STACK) {
 	  char mpls_label_stack[MAX_MPLS_LABEL_STACK];
 
-	  mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, pmpls->labels_cycle);
+	  mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, pmpls->label_stack);
 	  fprintf(f, "%s%s", write_sep(sep, &count), mpls_label_stack);
 	}
         if (config.what_to_count_2 & COUNT_MPLS_STACK_DEPTH) fprintf(f, "%s%u", write_sep(sep, &count), pmpls->mpls_stack_depth);

--- a/src/sql_handlers.c
+++ b/src/sql_handlers.c
@@ -347,7 +347,7 @@ void count_mpls_label_stack_handler(const struct db_cache *cache_elem, struct in
 {
   char mpls_label_stack[MAX_MPLS_LABEL_STACK];
 
-  mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, cache_elem->pmpls->labels_cycle);
+  mpls_label_stack_to_str(mpls_label_stack, MAX_MPLS_LABEL_STACK, cache_elem->pmpls->label_stack);
   snprintf(*ptr_where, SPACELEFT(where_clause), where[num].string, mpls_label_stack);
   snprintf(*ptr_values, SPACELEFT(values_clause), values[num].string, mpls_label_stack);
   *ptr_where += strlen(*ptr_where);


### PR DESCRIPTION
### Summary 

This PR is adding on top of PR #574 & as described within the title is to renaming the variable "labels_cycle" to the more appropriate name "label_stack"


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)