### PR TITLE
build: fix git safe directory errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Build docker image for Ubuntu Bionic
         run: |
           cd pmacct
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE/src/external_libs/libcdada
+          git rev-parse HEAD
           docker build -f $BUILD_DOCKER_FILE_UBUNTU_BIONIC -t $BUILD_DOCKER_TAG_UBUNTU_BIONIC .
           mkdir -p /tmp/docker/
           docker save -o /tmp/docker/builder_ubuntu.tar $BUILD_DOCKER_TAG_UBUNTU_BIONIC
@@ -51,6 +54,9 @@ jobs:
       - name: Build docker image for Centos 8
         run: |
           cd pmacct
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE/src/external_libs/libcdada
+          git rev-parse HEAD
           docker build -f $BUILD_DOCKER_FILE_UBUNTU_BIONIC -t $BUILD_DOCKER_TAG_UBUNTU_BIONIC .
           mkdir -p /tmp/docker/
           docker save -o /tmp/docker/builder_centos.tar $BUILD_DOCKER_TAG_UBUNTU_BIONIC
@@ -118,6 +124,9 @@ jobs:
       - name: Build in '${{ matrix.builder-name }}' with '${{ matrix.CONFIG_FLAGS }}'
         run: |
           cd pmacct
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE/src/external_libs/libcdada
+          git rev-parse HEAD
           docker load -i /tmp/docker/${{ matrix.builder-name }}.tar
           CONTAINER_ID=$(docker run --rm -it -d -v `pwd`:`pwd` -w `pwd` -e CONFIG_FLAGS $BUILD_DOCKER_TAG_UBUNTU_BIONIC:latest)
           echo "Launched container id:" $CONTAINER_ID
@@ -135,6 +144,9 @@ jobs:
 
       - name: Build containers
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE/src/external_libs/libcdada
+          git rev-parse HEAD
           echo "Fix mess with tags in actions/checkout..."
           git fetch -f && git fetch -f --tags
           echo "Deducing PMACCT_VERSION..."

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -24,6 +24,11 @@ set -e
 export AVRO_LIBS="-L/usr/local/avro/lib -lavro"
 export AVRO_CFLAGS="-I/usr/local/avro/include"
 
+#New versions of git complain with "unsafe directory "otherwise due to patches
+#for CVE-2022-24765, CVE-2022-24767
+git config --global --add safe.directory `pwd`
+git config --global --add safe.directory `pwd`/src/external_libs/libcdada
+
 #Build & install
 ./autogen.sh
 ./configure --disable-silent-rules $CONFIG_FLAGS || (cat config.log && /bin/false)


### PR DESCRIPTION
### Short description

As a result of patches introduced in `git` to protect against
the defects CVE-2022-24765, CVE-2022-24767, pipelines started to
fail due to the new `git` versions being rolled out, with the error
`Error: fatal: unsafe repository`.

This commit fixes this by setting the appropriate exceptions for
the repository itself and for the git submodules

### Checklist

I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
