### PR TITLE
Don't set the AS Path for receiving packets in flows in sflow data

### DIFF
--- a/src/sfprobe_plugin/sfprobe_plugin.c
+++ b/src/sfprobe_plugin/sfprobe_plugin.c
@@ -529,11 +529,18 @@ static void readPacket(SflSp *sp, struct pkt_payload *hdr, const unsigned char *
 	gatewayHdrElem.tag = SFLFLOW_EX_GATEWAY;
 	// gatewayHdrElem.flowType.gateway.src_as = htonl(hdr->src_ip.address.ipv4.s_addr);
 	gatewayHdrElem.flowType.gateway.src_as = hdr->src_as;
-	gatewayHdrElem.flowType.gateway.dst_as_path_segments = 1;
-	gatewayHdrElem.flowType.gateway.dst_as_path = &as_path_segment;
-	as_path_segment.type = SFLEXTENDED_AS_SET;
-	as_path_segment.length = 1;
-	as_path_segment.as.set = &hdr->dst_as;
+
+        if (hdr->dst_as == 0) {
+          gatewayHdrElem.flowType.gateway.dst_as_path_segments = 0;
+        }
+        else {
+          gatewayHdrElem.flowType.gateway.dst_as_path_segments = 1;
+          gatewayHdrElem.flowType.gateway.dst_as_path = &as_path_segment;
+          as_path_segment.type = SFLEXTENDED_AS_SET;
+          as_path_segment.length = 1;
+          as_path_segment.as.set = &hdr->dst_as;
+        }
+
 	if (config.what_to_count & COUNT_PEER_DST_IP) {
           switch (hdr->bgp_next_hop.family) {
           case AF_INET:


### PR DESCRIPTION
### Short description
This is a (very late, sorry about that, things didn't turn out quite as expected) followup to https://www.mail-archive.com/pmacct-discussion@pmacct.net/msg04121.html where my sflow collector [NetMeta](https://github.com/monogon-dev/NetMeta) ([goflow](https://github.com/cloudflare/goflow) based) fails to process the ASN information found in sflow packets generated by pmacct.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)

### What am I doing here?
Looking at the goflow2 [source code](https://github.com/netsampler/goflow2/blob/7d4c41a161d707922b30bfbb7752cd35d2f4b4eb/producer/producer_sf.go#L300) it can be seen, that it is populating the source AS field based on the length of the AS Path in the sflow extended gateway data. If it is greater than zero, the source AS field will be set based on the "AS Router" field.
pmacct always sets the AS path to one with the destination AS being the only element even if it's zero, as seen [here](https://github.com/pmacct/pmacct/blob/7e5b36564ed2b7a43f561df4620f2b81f3915546/src/sfprobe_plugin/sfprobe_plugin.c#L535).
However, the "AS Router" field is always zero, at least for me:
![grafik](https://user-images.githubusercontent.com/4244869/177010566-2e895287-487c-4d01-993a-8d36c7de1df7.png)
... this will always have the source AS field set to zero due to goflow (1 & 2) always setting the source AS based on the router AS.
Looking at the memory plugin, pmacct seems to account this correctly (not having an AS path for receiving flows):
![grafik](https://user-images.githubusercontent.com/4244869/177010640-e8428671-255e-447f-8679-4723f8a13fa0.png)

I've added a check to see if the destination AS is not zero in order to put the destination AS into the AS path for sflow packets, which effectively causes the AS path only getting populated for sending flows.

I was looking at putting the full AS path into the sflow data (not just the destination AS as the only element), but the `pkt_payload` struct doesn't seem to carry the AS path itself.

This is just a draft in order to test things further and to see if this is the only needed change for my collector to start processing ASN information. A quick test run with running raw goflow2 and printing the decoded sflow data to console yielded successful results.