### PR TITLE
Avoid to cut off log messages

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -59,7 +59,10 @@ void Log(short int level, char *msg, ...)
       strftime(timebuf, SRVBUFLEN, "%Y-%m-%dT%H:%M:%S", tmnow);
       append_rfc3339_timezone(timebuf, SRVBUFLEN, tmnow);
 
-      fprintf(config.logfile_fd, "%s %s", timebuf, syslog_string);
+      fprintf(config.logfile_fd, "%s ", timebuf);
+      va_start(ap, msg);
+      vfprintf(config.logfile_fd, msg, ap);
+      va_end(ap);
       fflush(config.logfile_fd);
     }
   }

--- a/src/log.c
+++ b/src/log.c
@@ -30,8 +30,7 @@ struct _log_notifications log_notifications;
 void Log(short int level, char *msg, ...)
 {
   va_list ap;
-  char syslog_string[LOGSTRLEN];
-  
+
   if ((level == LOG_DEBUG) && (!config.debug && !debug)) return;
 
   if (!config.syslog && !config.logfile_fd) {
@@ -41,11 +40,11 @@ void Log(short int level, char *msg, ...)
     fflush(stderr);
   }
   else {
-    va_start(ap, msg);
-    vsnprintf(syslog_string, LOGSTRLEN, msg, ap);
-    va_end(ap);
-
-    if (config.syslog) syslog(level, "%s", syslog_string);
+    if (config.syslog) {
+      va_start(ap, msg);
+      vsyslog(level, msg, ap);
+      va_end(ap);
+    }
 
     if (config.logfile_fd) {
       char timebuf[SRVBUFLEN];


### PR DESCRIPTION
When log messages are longer than our message buffer the message gets cut off. As the trailing newline also gets cut off the message will be concatenated with the following message which makes the log hard to read. Avoid to cut off the messages by not using an intermediate buffer.

I've tested the changes on top of commit ce0d5557 and to a lesser extend also on top of 57e5b892 and fa0139fb.
