### PR TITLE
Do not set partition to RD_KAFKA_PARTITION_UA if static kafka_partition was configured

### DIFF
--- a/src/kafka_plugin.c
+++ b/src/kafka_plugin.c
@@ -462,7 +462,7 @@ void kafka_cache_purge(struct chained_cache *queue[], int index, int safe_action
     exit_gracefully(1);
   }
 
-  if (!config.kafka_partition_dynamic) config.kafka_partition = RD_KAFKA_PARTITION_UA;
+  if (!config.kafka_partition_dynamic && !config.kafka_partition) config.kafka_partition = RD_KAFKA_PARTITION_UA;
 
   p_kafka_set_partition(&kafkap_kafka_host, config.kafka_partition);
 


### PR DESCRIPTION
### Short description
A check for `config.kafka_partition` was missing. This lead to the plugin always using the default partitioner instead of sending to the configured fixed partition.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [N/A] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [V] compiled & tested this code
- [N/A] included documentation (including possible behaviour changes)
