### PR TITLE
src/nl: do not try to handle TCP flow for non-TCP, prevent DDoS

### DIFF
--- a/src/nl.c
+++ b/src/nl.c
@@ -309,9 +309,9 @@ int ip_handler(register struct packet_ptrs *pptrs)
         if (((struct pm_tcphdr *)pptrs->tlh_ptr)->th_flags & TH_FIN) pptrs->tcp_flags |= TH_FIN;
         if (((struct pm_tcphdr *)pptrs->tlh_ptr)->th_flags & TH_RST) pptrs->tcp_flags |= TH_RST;
         if (((struct pm_tcphdr *)pptrs->tlh_ptr)->th_flags & TH_ACK && pptrs->tcp_flags) pptrs->tcp_flags |= TH_ACK;
-      }
 
-      ip_flow_handler(pptrs);
+	ip_flow_handler(pptrs);
+      }
     }
 
     /* XXX: optimize/short circuit here! */
@@ -492,9 +492,9 @@ int ip6_handler(register struct packet_ptrs *pptrs)
         if (((struct pm_tcphdr *)pptrs->tlh_ptr)->th_flags & TH_FIN) pptrs->tcp_flags |= TH_FIN;
         if (((struct pm_tcphdr *)pptrs->tlh_ptr)->th_flags & TH_RST) pptrs->tcp_flags |= TH_RST;
         if (((struct pm_tcphdr *)pptrs->tlh_ptr)->th_flags & TH_ACK && pptrs->tcp_flags) pptrs->tcp_flags |= TH_ACK;
-      }
 
-      ip_flow6_handler(pptrs);
+	ip_flow6_handler(pptrs);
+      }
     }
 
     /* XXX: optimize/short circuit here! */


### PR DESCRIPTION
The uacctd daemon crashes in find_flow when copying tlh_ptr upon receiving an ICMP Echo Request packet (as a result of ping). Thus, anyone who can send an ICMP Echo Request to our system can bring down the traffic accounting system: this is DDoS. The suggested solution is a quick fix that fixes the issue in our case, no detailed study has been done.