### PR TITLE
build: speed up incremental builds after git changes

### DIFF
--- a/examples/lg/pmbgp.c
+++ b/examples/lg/pmbgp.c
@@ -23,6 +23,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "pmacct-data.h"
 #include "addr.h"
 #ifdef WITH_ZMQ

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #ifdef WITH_KAFKA
 #include "kafka_common.h"
 #endif

--- a/src/pmacct.c
+++ b/src/pmacct.c
@@ -23,6 +23,7 @@
 
 /* include */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "pmacct-data.h"
 #include "imt_plugin.h"
 #include "bgp/bgp_packet.h"

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -85,7 +85,6 @@
 #endif
 
 #include "pmacct-version.h"
-#include "pmacct-build.h"
 #include "pmacct-defines.h"
 
 #if defined (WITH_GEOIP)

--- a/src/pmacctd.c
+++ b/src/pmacctd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "pmacct-data.h"
 #include "pmacct-dlt.h"
 #include "pretag_handlers.h"

--- a/src/pmbgpd.c
+++ b/src/pmbgpd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "plugin_hooks.h"
 #include "bgp/bgp.h"
 #include "bgp/bgp_lg.h"

--- a/src/pmbmpd.c
+++ b/src/pmbmpd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "bgp/bgp.h"
 #include "bmp/bmp.h"
 #include "pmbmpd.h"

--- a/src/pmtelemetryd.c
+++ b/src/pmtelemetryd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "bgp/bgp.h"
 #include "telemetry/telemetry.h"
 #include "pmtelemetryd.h"

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "sflow.h"
 #include "bgp/bgp_packet.h"
 #include "bgp/bgp.h"

--- a/src/uacctd.c
+++ b/src/uacctd.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "uacctd.h"
 #include "pmacct-data.h"
 #include "pretag_handlers.h"

--- a/src/util.c
+++ b/src/util.c
@@ -21,6 +21,7 @@
 
 /* includes */
 #include "pmacct.h"
+#include "pmacct-build.h"
 #include "util-data.h"
 #ifdef WITH_KAFKA
 #include "kafka_common.h"


### PR DESCRIPTION
Avoid to rebuild too many object files after git changes. Include the generated header file pmacct-build.h only in source files where the build information actually is used.