### PR TITLE
Collecting data via gRPC dialout with pmtelemetryd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ pmacct_examples__DATA = examples/allow.lst.example examples/bgp_agent.map.exampl
 	examples/primitives.lst.example examples/probe_netflow.conf.example \
 	examples/probe_sflow.conf.example examples/sampling.map.example \
 	examples/tee_receivers.lst.example examples/nfacctd-sql.conf.example \
-	examples/pmacctd-sql.conf.example examples/pmacctd-sqlite3.conf.example 
+	examples/pmacctd-sql.conf.example examples/pmacctd-sqlite3.conf.example
 pmacct_examples_kafka__DATA = examples/kafka/kafka_consumer.py
 pmacct_examples_amqp__DATA = examples/amqp/amqp_receiver.py
 pmacct_examples_avro__DATA = examples/avro/avro_file_decoder.py

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-dnl configuration file for pmacct 
+dnl configuration file for pmacct
 
 m4_include([VERSION]) #Force reconf on VERSION change
 AC_INIT([pmacct], m4_esyscmd_s(cat VERSION), [paolo@pmacct.net])
@@ -40,7 +40,7 @@ dnl: shared object handling
 AC_MSG_CHECKING([whether to disable linking against shared objects])
 AC_ARG_ENABLE(so,
         [  --disable-so                     Disable linking against shared objects (default: no)],
-	[ 
+        [
         if test x$enableval = x"yes" ; then
           AC_MSG_RESULT(no)
           AC_CHECK_FUNC(dlopen, [ USING_DLOPEN="yes" ], [])
@@ -53,12 +53,12 @@ AC_ARG_ENABLE(so,
           fi
         else
           AC_MSG_RESULT(yes)
-	  if test "x$ac_cv_prog_gcc" = xyes ; then
-		LDFLAGS="-static ${LDFLAGS}"
-	  fi
+          if test "x$ac_cv_prog_gcc" = xyes ; then
+                LDFLAGS="-static ${LDFLAGS}"
+          fi
         fi
         ],
-	[
+        [
         AC_MSG_RESULT(no)
         AC_CHECK_FUNC(dlopen, [ USING_DLOPEN="yes" ], [])
         AC_CHECK_LIB(dl, dlopen,
@@ -68,7 +68,7 @@ AC_ARG_ENABLE(so,
         if test x"$USING_DLOPEN" != x"yes"; then
                 AC_MSG_ERROR(Unable to find dlopen(). Try with --disable-so)
         fi
-	]
+        ]
 )
 dnl finish: shared object handling
 
@@ -98,14 +98,14 @@ dnl some systems have __progname ; if this is the case and we play around argv
 dnl we need to enable a minor hack to make things work nicely.
 dnl
 AC_MSG_CHECKING(for __progname)
-AC_TRY_LINK([ extern char *__progname; ], 
+AC_TRY_LINK([ extern char *__progname; ],
 [ __progname = "test"; ],
 [AC_MSG_RESULT(yes); AC_DEFINE(PROGNAME, 1)], [AC_MSG_RESULT(no)])
 
 dnl
-dnl Check for architecture endianess: big | little 
+dnl Check for architecture endianess: big | little
 dnl
-dnl XXX: switch to manually define this feature 
+dnl XXX: switch to manually define this feature
 ac_cv_endianess="unknown"
 if test x"$ac_cv_endianess" = x"unknown"; then
   AC_MSG_CHECKING(endianess)
@@ -158,14 +158,14 @@ if test x"$ac_cv_unaligned" = x"unknown"; then
 
     unsigned char a[[5]] = { 1, 2, 3, 4, 5 };
     int main () {
-    	unsigned int i;
+        unsigned int i;
         pid_t pid;
         int status;
         /* avoid "core dumped" message */
         pid = fork();
         if (pid <  0) exit(2);
         if (pid > 0) {
-        	/* parent */
+                /* parent */
                 pid = waitpid(pid, &status, 0);
                 if (pid < 0) exit(3);
                 exit(!WIFEXITED(status));
@@ -177,7 +177,7 @@ if test x"$ac_cv_unaligned" = x"unknown"; then
     }
 EOF
   ${CC-cc} -o conftest $CFLAGS $CPPFLAGS $LDFLAGS \
-	conftest.c $LIBS >/dev/null 2>&1
+        conftest.c $LIBS >/dev/null 2>&1
   if test ! -x conftest ; then
     ac_cv_unaligned="fail"
   else
@@ -197,49 +197,49 @@ fi
 AC_MSG_CHECKING([whether to enable L2 features])
 AC_ARG_ENABLE(l2,
         [  --enable-l2                      Enable Layer-2 features and support (default: yes)],
-	[
-        	if test x$enableval = x"yes" ; then
-        		AC_MSG_RESULT(yes)
-	  		AC_DEFINE(HAVE_L2, 1) 
-        	else
-			AC_MSG_RESULT(no)
-        	fi
-	],
-	[
-        	AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_L2, 1) 
-		COMPILE_ARGS="${COMPILE_ARGS} '--enable-l2'"
-	]
+        [
+                if test x$enableval = x"yes" ; then
+                        AC_MSG_RESULT(yes)
+                        AC_DEFINE(HAVE_L2, 1)
+                else
+                        AC_MSG_RESULT(no)
+                fi
+        ],
+        [
+                AC_MSG_RESULT(yes)
+                AC_DEFINE(HAVE_L2, 1)
+                COMPILE_ARGS="${COMPILE_ARGS} '--enable-l2'"
+        ]
 )
 
 AC_CHECK_FUNCS(inet_pton)
 if test x"$ac_cv_func_inet_pton" = x"no"; then
-	AC_MSG_ERROR(ERROR: missing inet_pton())
+        AC_MSG_ERROR(ERROR: missing inet_pton())
 fi
 
 AC_CHECK_FUNCS(inet_ntop)
 if test x"$ac_cv_func_inet_ntop" = x"no"; then
-	AC_MSG_ERROR(ERROR: missing inet_ntop())
+        AC_MSG_ERROR(ERROR: missing inet_ntop())
 fi
 
 AC_ARG_WITH(pcap-includes,
   [  --with-pcap-includes=DIR         Search the specified directory for header files],
   [
-	AC_LINEARIZE_PATH($withval, withval=$absdir)
-	INCLUDES="${INCLUDES} -I$withval"
-	PCAPINCLS=$withval
-	PCAPINCLUDESFOUND=1
+        AC_LINEARIZE_PATH($withval, withval=$absdir)
+        INCLUDES="${INCLUDES} -I$withval"
+        PCAPINCLS=$withval
+        PCAPINCLUDESFOUND=1
   ])
 
 if test x"$PCAPINCLS" != x""; then
   AC_MSG_CHECKING(your own pcap includes)
-  if test -r $PCAPINCLS/pcap.h; then 
+  if test -r $PCAPINCLS/pcap.h; then
     AC_MSG_RESULT(ok)
     AC_DEFINE(HAVE_PCAP_H, 1)
     PCAPINCLUDESFOUND=1
   else
     AC_MSG_RESULT(no)
-    AC_MSG_ERROR(ERROR: missing pcap.h in $PCAPINCLS) 
+    AC_MSG_ERROR(ERROR: missing pcap.h in $PCAPINCLS)
   fi
 fi
 
@@ -270,7 +270,7 @@ if test x"$PCAPINCLUDESFOUND" = x""; then
     AC_MSG_RESULT([found in /usr/local/include])
     INCLUDES="${INCLUDES} -I/usr/local/include"
     PCAPINCLUDESFOUND=1
-    AC_DEFINE(HAVE_PCAP_H, 1) 
+    AC_DEFINE(HAVE_PCAP_H, 1)
   elif test -r /usr/local/include/pcap/pcap.h; then
     AC_MSG_RESULT([found in /usr/local/include])
     INCLUDES="${INCLUDES} -I/usr/local/include"
@@ -285,11 +285,11 @@ fi
 
 AC_ARG_WITH(pcap-libs,
   [  --with-pcap-libs=DIR             Search the specified directory for pcap library],
-  [	
-	AC_LINEARIZE_PATH($withval, withval=$absdir)
-	LIBS="${LIBS} -L$withval"
-	PCAPLIB=$withval
-	PCAPLIBFOUND=1
+  [
+        AC_LINEARIZE_PATH($withval, withval=$absdir)
+        LIBS="${LIBS} -L$withval"
+        PCAPLIB=$withval
+        PCAPLIBFOUND=1
   ])
 
 if test x"$PCAPLIB" != x""; then
@@ -465,40 +465,40 @@ AC_ARG_ENABLE(mongodb,
   yes)
     AC_MSG_RESULT(yes)
     PKG_CHECK_MODULES([MONGODB], [libmongoc],, [
-	AC_MSG_CHECKING([default locations for libmongoc])
-	if test -r /usr/lib/libmongoc.a -o -r /usr/lib/libmongoc.so; then
-		MONGODB_LIBS="-L/usr/lib -lmongoc"
-		AC_MSG_RESULT([found in /usr/lib])
-	elif test -r /usr/lib64/libmongoc.a -o -r /usr/lib64/libmongoc.so; then
-		MONGODB_LIBS="-L/usr/lib64 -lmongoc"
-		AC_MSG_RESULT([found in /usr/lib64])
-	elif test -r /usr/local/lib/libmongoc.a -o -r /usr/local/lib/libmongoc.so; then
-		MONGODB_LIBS="-L/usr/local/lib -lmongoc"
-		AC_MSG_RESULT([found in /usr/local/lib])
-	else
-		AC_MSG_RESULT([not found])
+        AC_MSG_CHECKING([default locations for libmongoc])
+        if test -r /usr/lib/libmongoc.a -o -r /usr/lib/libmongoc.so; then
+                MONGODB_LIBS="-L/usr/lib -lmongoc"
+                AC_MSG_RESULT([found in /usr/lib])
+        elif test -r /usr/lib64/libmongoc.a -o -r /usr/lib64/libmongoc.so; then
+                MONGODB_LIBS="-L/usr/lib64 -lmongoc"
+                AC_MSG_RESULT([found in /usr/lib64])
+        elif test -r /usr/local/lib/libmongoc.a -o -r /usr/local/lib/libmongoc.so; then
+                MONGODB_LIBS="-L/usr/local/lib -lmongoc"
+                AC_MSG_RESULT([found in /usr/local/lib])
+        else
+                AC_MSG_RESULT([not found])
                 _save_LIBS="$LIBS"
                 LIBS="$LIBS $MONGODB_LIBS"
-		AC_CHECK_LIB([mongoc], [mongo_connect], [], [AC_MSG_ERROR([
-			ERROR: missing MongoDB library (0.8 version). Refer to: https://github.com/mongodb/mongo-c-driver-legacy
-		])])
+                AC_CHECK_LIB([mongoc], [mongo_connect], [], [AC_MSG_ERROR([
+                        ERROR: missing MongoDB library (0.8 version). Refer to: https://github.com/mongodb/mongo-c-driver-legacy
+                ])])
                 LIBS="$_save_LIBS"
-	fi
+        fi
 
-	AC_MSG_CHECKING([default locations for mongo.h])
-	if test -r /usr/include/mongo.h; then
-		MONGODB_CFLAGS="-I/usr/include"
-		AC_MSG_RESULT([found in /usr/include])
-	elif test -r /usr/local/include/mongo.h; then
-		MONGODB_CFLAGS="-I/usr/local/include"
-		AC_MSG_RESULT([found in /usr/local/include])
-	else
-		AC_MSG_RESULT([not found])
+        AC_MSG_CHECKING([default locations for mongo.h])
+        if test -r /usr/include/mongo.h; then
+                MONGODB_CFLAGS="-I/usr/include"
+                AC_MSG_RESULT([found in /usr/include])
+        elif test -r /usr/local/include/mongo.h; then
+                MONGODB_CFLAGS="-I/usr/local/include"
+                AC_MSG_RESULT([found in /usr/local/include])
+        else
+                AC_MSG_RESULT([not found])
                 _save_CFLAGS="$CFLAGS"
                 CFLAGS="$CFLAGS $MONGODB_CFLAGS"
-		AC_CHECK_HEADER([mongo.h], [], [AC_MSG_ERROR(ERROR: missing MongoDB headers)])
+                AC_CHECK_HEADER([mongo.h], [], [AC_MSG_ERROR(ERROR: missing MongoDB headers)])
                 CFLAGS="$_save_CFLAGS"
-	fi
+        fi
     ])
     PLUGINS="${PLUGINS} mongodb"
     USING_MONGODB="yes"
@@ -955,7 +955,7 @@ AC_ARG_ENABLE(unyte-udp-notif,
       _save_LIBS="$LIBS"
       LIBS="$LIBS $UNYTE_UDP_NOTIF_LIBS -lpthread"
       AC_CHECK_LIB([unyte-udp-notif], [unyte_udp_start_collector], [], [AC_MSG_ERROR([
-	ERROR: missing unyte-udp-notif library. Refer to: https://github.com/insa-unyte/udp-notif-c-collector
+        ERROR: missing unyte-udp-notif library. Refer to: https://github.com/insa-unyte/udp-notif-c-collector
       ])])
       LIBS="$_save_LIBS"
       _save_CFLAGS="$CFLAGS"
@@ -974,6 +974,41 @@ AC_ARG_ENABLE(unyte-udp-notif,
   ]
 )
 dnl finish: unyte udp notif handling
+
+dnl start: grpc-collector handling
+AC_MSG_CHECKING(whether to enable grpc-collector support)
+AC_ARG_ENABLE(grpc-collector,
+  [  --enable-grpc-collector         Enable grpc-collector support (default: no)],
+  [ case "$enableval" in
+  yes)
+    AC_MSG_RESULT(yes)
+    PKG_CHECK_MODULES([GRPC_COLLECTOR], [grpc-collector >= v1.0.0], [
+      AC_SUBST(GRPC_COLLECTOR_CFLAGS)
+      AC_SUBST(GRPC_COLLECTOR_LIBS)
+      SUPPORTS="${SUPPORTS} grpc-collector"
+      USING_GRPC_COLLECTOR="yes"
+      PMACCT_CFLAGS="$PMACCT_CFLAGS $GRPC_COLLECTOR_CFLAGS"
+      GRPC_COLLECTOR_LIBS="$GRPC_COLLECTOR_LIBS -lgrpc_collector -lpthread"
+      AC_DEFINE(WITH_GRPC_COLLECTOR, 1)
+      _save_LIBS="$LIBS"
+      LIBS="$LIBS $GRPC_COLLECTOR_LIBS"
+      LIBS="$_save_LIBS"
+      _save_CFLAGS="$CFLAGS"
+      CFLAGS="$CFLAGS $GRPC_COLLECTOR_CFLAGS"
+      AC_CHECK_HEADER([grpc_collector_bridge/grpc_collector_bridge.h], [], [AC_MSG_ERROR(ERROR: missing grpc-collector headers)])
+      CFLAGS="$_save_CFLAGS"
+    ],
+    [AC_MSG_ERROR([ERROR: missing grpc-collector pkg-config. Refer to: https://github.com/scuzzilla/mdt-dialout-collector])])
+    ;;
+  no)
+    AC_MSG_RESULT(no)
+    ;;
+  esac ],
+  [
+    AC_MSG_RESULT(no)
+  ]
+)
+dnl finish: grpc-collector handling
 
 dnl start: eBPF handling
 AC_MSG_CHECKING(whether to enable eBPF support)
@@ -1012,18 +1047,18 @@ AC_ARG_ENABLE(ebpf,
 dnl finish: ebpf handling
 
 if test x"$USING_DLOPEN" = x"yes"; then
-	AC_DEFINE(HAVE_DLOPEN, 1)
+        AC_DEFINE(HAVE_DLOPEN, 1)
 else
-	# Adding linking to libdl here 1) if required and 2) in case of --disable-so
-	if test x"$USING_MYSQL" = x"yes" -o x"$USING_SQLITE3" = x"yes"; then
-		AC_CHECK_LIB([dl], [dlopen], [LIBS="${LIBS} -ldl"], [AC_MSG_ERROR([
-		  ERROR: missing libdl devel.
-		])])
-	fi
+        # Adding linking to libdl here 1) if required and 2) in case of --disable-so
+        if test x"$USING_MYSQL" = x"yes" -o x"$USING_SQLITE3" = x"yes"; then
+                AC_CHECK_LIB([dl], [dlopen], [LIBS="${LIBS} -ldl"], [AC_MSG_ERROR([
+                  ERROR: missing libdl devel.
+                ])])
+        fi
 fi
 
 if test x"$USING_SQL" = x"yes"; then
-	AC_CHECK_LIB([z], [zlibVersion], [], [AC_MSG_ERROR([ERROR: missing zlib. Requirement for building SQL plugins.])])
+        AC_CHECK_LIB([z], [zlibVersion], [], [AC_MSG_ERROR([ERROR: missing zlib. Requirement for building SQL plugins.])])
 fi
 
 LIBS="${LIBS} -lm -lpthread"
@@ -1069,22 +1104,22 @@ AC_MSG_RESULT(no))
 
 AC_MSG_CHECKING(whether to link IPv4/IPv6 traffic accounting accounting binaries)
 AC_ARG_ENABLE(traffic-bins,
-	[  --enable-traffic-bins            Link IPv4/IPv6 traffic accounting binaries (default: yes)],
-	[
-	  if test x$enableval = x"yes" ; then
-	    AC_MSG_RESULT(yes)
-	    AC_DEFINE(HAVE_TRAFFIC_BINS, 1)
-	    USING_TRAFFIC_BINS="yes"
-	  else
-	    AC_MSG_RESULT(no)
-	  fi
-	],
-	[
-	  AC_MSG_RESULT(yes)
-	  AC_DEFINE(HAVE_TRAFFIC_BINS, 1)
-	  USING_TRAFFIC_BINS="yes"
-	  COMPILE_ARGS="${COMPILE_ARGS} '--enable-traffic-bins'"
-	]
+        [  --enable-traffic-bins            Link IPv4/IPv6 traffic accounting binaries (default: yes)],
+        [
+          if test x$enableval = x"yes" ; then
+            AC_MSG_RESULT(yes)
+            AC_DEFINE(HAVE_TRAFFIC_BINS, 1)
+            USING_TRAFFIC_BINS="yes"
+          else
+            AC_MSG_RESULT(no)
+          fi
+        ],
+        [
+          AC_MSG_RESULT(yes)
+          AC_DEFINE(HAVE_TRAFFIC_BINS, 1)
+          USING_TRAFFIC_BINS="yes"
+          COMPILE_ARGS="${COMPILE_ARGS} '--enable-traffic-bins'"
+        ]
 )
 
 AC_MSG_CHECKING(whether to link BGP daemon binaries)
@@ -1094,7 +1129,7 @@ AC_ARG_ENABLE(bgp-bins,
           if test x$enableval = x"yes" ; then
             AC_MSG_RESULT(yes)
             AC_DEFINE(HAVE_BGP_BINS, 1)
-	    USING_BGP_BINS="yes"
+            USING_BGP_BINS="yes"
           else
             AC_MSG_RESULT(no)
           fi
@@ -1102,7 +1137,7 @@ AC_ARG_ENABLE(bgp-bins,
         [
           AC_MSG_RESULT(yes)
           AC_DEFINE(HAVE_BGP_BINS, 1)
-	  USING_BGP_BINS="yes"
+          USING_BGP_BINS="yes"
           COMPILE_ARGS="${COMPILE_ARGS} '--enable-bgp-bins'"
         ]
 )
@@ -1114,7 +1149,7 @@ AC_ARG_ENABLE(bmp-bins,
           if test x$enableval = x"yes" ; then
             AC_MSG_RESULT(yes)
             AC_DEFINE(HAVE_BMP_BINS, 1)
-	    USING_BMP_BINS="yes"
+            USING_BMP_BINS="yes"
           else
             AC_MSG_RESULT(no)
           fi
@@ -1122,7 +1157,7 @@ AC_ARG_ENABLE(bmp-bins,
         [
           AC_MSG_RESULT(yes)
           AC_DEFINE(HAVE_BMP_BINS, 1)
-	  USING_BMP_BINS="yes"
+          USING_BMP_BINS="yes"
           COMPILE_ARGS="${COMPILE_ARGS} '--enable-bmp-bins'"
         ]
 )
@@ -1134,7 +1169,7 @@ AC_ARG_ENABLE(st-bins,
           if test x$enableval = x"yes" ; then
             AC_MSG_RESULT(yes)
             AC_DEFINE(HAVE_ST_BINS, 1)
-	    USING_ST_BINS="yes"
+            USING_ST_BINS="yes"
           else
             AC_MSG_RESULT(no)
           fi
@@ -1142,7 +1177,7 @@ AC_ARG_ENABLE(st-bins,
         [
           AC_MSG_RESULT(yes)
           AC_DEFINE(HAVE_ST_BINS, 1)
-	  USING_ST_BINS="yes"
+          USING_ST_BINS="yes"
           COMPILE_ARGS="${COMPILE_ARGS} '--enable-st-bins'"
         ]
 )
@@ -1154,27 +1189,27 @@ AC_CHECK_FUNCS([setproctitle mallopt tdestroy strlcpy vfork])
 
 dnl Check for SO_BINDTODEVICE
 AC_CHECK_DECL([SO_BINDTODEVICE],
-	AC_DEFINE(HAVE_SO_BINDTODEVICE, 1, [Check if kernel supports SO_BINDTODEVICE]),,
-		[
-		  #include <sys/socket.h>
-		]
+        AC_DEFINE(HAVE_SO_BINDTODEVICE, 1, [Check if kernel supports SO_BINDTODEVICE]),,
+                [
+                  #include <sys/socket.h>
+                ]
 )
 
 dnl Check for SO_REUSEPORT & friends
 AC_CHECK_DECL([SO_REUSEPORT],
-	AC_DEFINE(HAVE_SO_REUSEPORT, 1, [Check if kernel supports SO_REUSEPORT]),,
-		[
-		  #include <sys/types.h>
-		  #include <sys/socket.h>
-		]
+        AC_DEFINE(HAVE_SO_REUSEPORT, 1, [Check if kernel supports SO_REUSEPORT]),,
+                [
+                  #include <sys/types.h>
+                  #include <sys/socket.h>
+                ]
 )
 
 AC_CHECK_DECL([SO_ATTACH_REUSEPORT_EBPF],
-	AC_DEFINE(HAVE_SO_ATTACH_REUSEPORT_EBPF, 1, [Check if kernel supports SO_ATTACH_REUSEPORT_EBPF]),,
-		[
-		  #include <sys/types.h>
-		  #include <sys/socket.h>
-		]
+        AC_DEFINE(HAVE_SO_ATTACH_REUSEPORT_EBPF, 1, [Check if kernel supports SO_ATTACH_REUSEPORT_EBPF]),,
+                [
+                  #include <sys/types.h>
+                  #include <sys/socket.h>
+                ]
 )
 
 dnl --------------------------------------
@@ -1184,22 +1219,22 @@ dnl --------------------------------------
 dnl First check whether to build git submodule deps
 WITH_EXTERNAL_DEPS_DEFAULT=yes
 if [ test ! -f "$srcdir/src/external_libs/libcdada/include/cdada.h" ] && [ test -z `git rev-parse HEAD 2> /dev/null` ]; then
-	WITH_EXTERNAL_DEPS_DEFAULT=no
+        WITH_EXTERNAL_DEPS_DEFAULT=no
 fi
 
 AC_MSG_CHECKING([whether external dependencies (git submodules) should be compiled])
 AC_ARG_WITH(external-deps,
-		AS_HELP_STRING([--without-external-deps], [Do not build external dependencies (git submodules), specially useful for package maintainers [default=with]]),
-			[WITH_EXTERNAL_DEPS="$withval"],
-			[WITH_EXTERNAL_DEPS="$WITH_EXTERNAL_DEPS_DEFAULT"]
-			)
+                AS_HELP_STRING([--without-external-deps], [Do not build external dependencies (git submodules), specially useful for package maintainers [default=with]]),
+                        [WITH_EXTERNAL_DEPS="$withval"],
+                        [WITH_EXTERNAL_DEPS="$WITH_EXTERNAL_DEPS_DEFAULT"]
+                        )
 if test x"$WITH_EXTERNAL_DEPS" = x"yes"; then
-	dnl Compiled-in dependencies
-	INCLUDES="-I${ac_pwd}/src/external_libs/rootfs/include ${INCLUDES} "
-	LDFLAGS="-L${ac_pwd}/src/external_libs/rootfs/lib ${LDFLAGS}"
-	AC_MSG_RESULT(yes)
+        dnl Compiled-in dependencies
+        INCLUDES="-I${ac_pwd}/src/external_libs/rootfs/include ${INCLUDES} "
+        LDFLAGS="-L${ac_pwd}/src/external_libs/rootfs/lib ${LDFLAGS}"
+        AC_MSG_RESULT(yes)
 else
-	AC_MSG_RESULT(no)
+        AC_MSG_RESULT(no)
 fi
 
 AM_CONDITIONAL([WITH_EXTERNAL_DEPS], [test "x$WITH_EXTERNAL_DEPS" = "xyes"])
@@ -1226,28 +1261,28 @@ AS_CASE(["$WITH_EXTERNAL_DEPS"],
 dnl set debug level
 AC_MSG_CHECKING([whether to enable debugging compiler options])
 AC_ARG_ENABLE(debug,
-	[  --enable-debug                   Enable debugging compiler options (default: no)],
-	[
-		if test x$enableval = x"yes" ; then
-			AC_MSG_RESULT(yes)
-			tmp_CFLAGS=`echo $CFLAGS | sed 's/O2/O0/g'`
-			CFLAGS="$tmp_CFLAGS"
-			CFLAGS="$CFLAGS -g -Wall -Werror"
-		else
-			CFLAGS="$CFLAGS -Wall -Werror"
-			AC_MSG_RESULT(no)
-		fi
-	],
-	[
-		AC_MSG_RESULT(no)
-	]
+        [  --enable-debug                   Enable debugging compiler options (default: no)],
+        [
+                if test x$enableval = x"yes" ; then
+                        AC_MSG_RESULT(yes)
+                        tmp_CFLAGS=`echo $CFLAGS | sed 's/O2/O0/g'`
+                        CFLAGS="$tmp_CFLAGS"
+                        CFLAGS="$CFLAGS -g -Wall -Werror"
+                else
+                        CFLAGS="$CFLAGS -Wall -Werror"
+                        AC_MSG_RESULT(no)
+                fi
+        ],
+        [
+                AC_MSG_RESULT(no)
+        ]
 )
 
 dnl Necessary for autogenerated build string
 INCLUDES="${INCLUDES} -I$(pwd)/src"
 
 dnl final checks
-dnl trivial solution to portability issue 
+dnl trivial solution to portability issue
 AC_DEFINE_UNQUOTED(COMPILE_ARGS, "$COMPILE_ARGS")
 CFLAGS="${CFLAGS} ${INCLUDES}"
 INCLUDES=""
@@ -1292,6 +1327,7 @@ AM_CONDITIONAL([WITH_AVRO], [test x"$USING_AVRO" = x"yes"])
 AM_CONDITIONAL([WITH_SERDES], [test x"$USING_SERDES" = x"yes"])
 AM_CONDITIONAL([WITH_NDPI], [test x"$USING_NDPI" = x"yes"])
 AM_CONDITIONAL([WITH_UNYTE_UDP_NOTIF], [test x"$USING_UNYTE_UDP_NOTIF" = x"yes"])
+AM_CONDITIONAL([WITH_GRPC_COLLECTOR], [test x"$USING_GRPC_COLLECTOR" = x"yes"])
 AM_CONDITIONAL([WITH_EBPF], [test x"$USING_EBPF" = x"yes"])
 AM_CONDITIONAL([WITH_NFLOG], [test x"$USING_NFLOG" = x"yes"])
 AM_CONDITIONAL([WITH_DLOPEN], [test x"$USING_DLOPEN" = x"yes"])
@@ -1301,15 +1337,15 @@ AM_CONDITIONAL([USING_BMP_BINS], [test x"$USING_BMP_BINS" = x"yes"])
 AM_CONDITIONAL([USING_ST_BINS], [test x"$USING_ST_BINS" = x"yes"])
 
 AC_CONFIG_FILES([
-	    src/pmacct-version.h
+            src/pmacct-version.h
 ])
 
 AC_OUTPUT([ Makefile \
-	    src/Makefile src/external_libs/Makefile \
-	    src/nfprobe_plugin/Makefile \
-	    src/sfprobe_plugin/Makefile src/bgp/Makefile \
-	    src/tee_plugin/Makefile src/isis/Makefile \
-	    src/bmp/Makefile src/rpki/Makefile \
-	    src/telemetry/Makefile src/ndpi/Makefile \
-	    src/filters/Makefile examples/lg/Makefile \
-	    src/ebpf/Makefile examples/custom/Makefile ])
+            src/Makefile src/external_libs/Makefile \
+            src/nfprobe_plugin/Makefile \
+            src/sfprobe_plugin/Makefile src/bgp/Makefile \
+            src/tee_plugin/Makefile src/isis/Makefile \
+            src/bmp/Makefile src/rpki/Makefile \
+            src/telemetry/Makefile src/ndpi/Makefile \
+            src/filters/Makefile examples/lg/Makefile \
+            src/ebpf/Makefile examples/custom/Makefile ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -145,6 +145,10 @@ if WITH_UNYTE_UDP_NOTIF
 libdaemons_la_LIBADD  += @UNYTE_UDP_NOTIF_LIBS@
 libdaemons_la_CFLAGS  += @UNYTE_UDP_NOTIF_CFLAGS@
 endif
+if WITH_GRPC_COLLECTOR
+libdaemons_la_LIBADD  += @GRPC_COLLECTOR_LIBS@
+libdaemons_la_CFLAGS  += @GRPC_COLLECTOR_CFLAGS@
+endif
 if WITH_EBPF
 libdaemons_la_LIBADD  += @EBPF_LIBS@
 libdaemons_la_CFLAGS  += @EBPF_CFLAGS@

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -103,7 +103,7 @@ static const struct _dictionary_line dictionary[] = {
   {"sql_table_schema", cfg_key_sql_table_schema},
   {"sql_table_version", cfg_key_sql_table_version},
   {"sql_table_type", cfg_key_sql_table_type},
-  {"sql_conn_ca_file", cfg_key_sql_conn_ca_file}, 
+  {"sql_conn_ca_file", cfg_key_sql_conn_ca_file},
   {"sql_host", cfg_key_sql_host},
   {"sql_port", cfg_key_sql_port},
   {"sql_data", cfg_key_sql_data},
@@ -295,6 +295,7 @@ static const struct _dictionary_line dictionary[] = {
   {"telemetry_daemon_udp_notif_ipv6_only", cfg_key_telemetry_udp_notif_ipv6_only},
   {"telemetry_daemon_udp_notif_nmsgs", cfg_key_telemetry_udp_notif_nmsgs},
   {"telemetry_daemon_udp_notif_rp_ebpf_prog", cfg_key_telemetry_udp_notif_rp_ebpf_prog},
+  {"telemetry_daemon_grpc_collector_socket", cfg_key_telemetry_grpc_collector_socket},
   {"telemetry_daemon_zmq_address", cfg_key_telemetry_zmq_address},
   {"telemetry_daemon_kafka_broker_host", cfg_key_telemetry_kafka_broker_host},
   {"telemetry_daemon_kafka_broker_port", cfg_key_telemetry_kafka_broker_port},
@@ -357,7 +358,7 @@ static const struct _dictionary_line dictionary[] = {
   {"maps_index", cfg_key_maps_index},
   {"maps_entries", cfg_key_maps_entries},
   {"maps_row_len", cfg_key_maps_row_len},
-  {"pre_tag_map", cfg_key_pre_tag_map},	
+  {"pre_tag_map", cfg_key_pre_tag_map},
   {"pre_tag_map_dont_recirculate", cfg_key_pre_tag_map_dont_recirculate},
   {"pre_tag_filter", cfg_key_pre_tag_filter},
   {"pre_tag2_filter", cfg_key_pre_tag2_filter},
@@ -366,7 +367,7 @@ static const struct _dictionary_line dictionary[] = {
   {"post_tag", cfg_key_post_tag},
   {"post_tag2", cfg_key_post_tag2},
   {"sampling_rate", cfg_key_sampling_rate},
-  {"sampling_map", cfg_key_sampling_map},	
+  {"sampling_map", cfg_key_sampling_map},
   {"sfacctd_proc_name", cfg_key_proc_name},
   {"sfacctd_port", cfg_key_nfacctd_port},
   {"sfacctd_ip", cfg_key_nfacctd_ip},
@@ -464,7 +465,7 @@ static const struct _dictionary_line dictionary[] = {
   {"bgp_daemon_port", cfg_key_bgp_daemon_port},
   {"bgp_daemon_rp_ebpf_prog", cfg_key_bgp_daemon_rp_ebpf_prog},
   {"bgp_daemon_add_path_ignore", cfg_key_bgp_daemon_add_path_ignore},
-  {"bgp_daemon_tag_map", cfg_key_bgp_daemon_tag_map},	
+  {"bgp_daemon_tag_map", cfg_key_bgp_daemon_tag_map},
   {"bgp_daemon_pipe_size", cfg_key_bgp_daemon_pipe_size},
   {"bgp_daemon_max_peers", cfg_key_bgp_daemon_max_peers},
   {"bgp_daemon_msglog_output", cfg_key_bgp_daemon_msglog_output},
@@ -564,7 +565,7 @@ static const struct _dictionary_line dictionary[] = {
   {"bmp_daemon_ipv6_only", cfg_key_bmp_daemon_ipv6_only},
   {"bmp_daemon_port", cfg_key_bmp_daemon_port},
   {"bmp_daemon_rp_ebpf_prog", cfg_key_bmp_daemon_rp_ebpf_prog},
-  {"bmp_daemon_tag_map", cfg_key_bmp_daemon_tag_map},	
+  {"bmp_daemon_tag_map", cfg_key_bmp_daemon_tag_map},
   {"bmp_daemon_pipe_size", cfg_key_bmp_daemon_pipe_size},
   {"bmp_daemon_max_peers", cfg_key_bmp_daemon_max_peers},
   {"bmp_daemon_allow_file", cfg_key_bmp_daemon_allow_file},
@@ -664,32 +665,32 @@ static const struct _dictionary_line dictionary[] = {
 };
 
 static struct plugin_type_entry plugin_types_list[] = {
-  {PLUGIN_ID_CORE, 	"core", 	NULL},
-  {PLUGIN_ID_MEMORY, 	"memory", 	imt_plugin},
-  {PLUGIN_ID_PRINT,	"print",	print_plugin},
-  {PLUGIN_ID_NFPROBE,	"nfprobe",	nfprobe_plugin},
-  {PLUGIN_ID_SFPROBE,	"sfprobe",	sfprobe_plugin},
+  {PLUGIN_ID_CORE,      "core",         NULL},
+  {PLUGIN_ID_MEMORY,    "memory",       imt_plugin},
+  {PLUGIN_ID_PRINT,     "print",        print_plugin},
+  {PLUGIN_ID_NFPROBE,   "nfprobe",      nfprobe_plugin},
+  {PLUGIN_ID_SFPROBE,   "sfprobe",      sfprobe_plugin},
 #ifdef WITH_MYSQL
-  {PLUGIN_ID_MYSQL,	"mysql",	mysql_plugin},
+  {PLUGIN_ID_MYSQL,     "mysql",        mysql_plugin},
 #endif
 #ifdef WITH_PGSQL
-  {PLUGIN_ID_PGSQL,	"pgsql",	pgsql_plugin},
+  {PLUGIN_ID_PGSQL,     "pgsql",        pgsql_plugin},
 #endif
 #ifdef WITH_SQLITE3
-  {PLUGIN_ID_SQLITE3,	"sqlite3",	sqlite3_plugin},
+  {PLUGIN_ID_SQLITE3,   "sqlite3",      sqlite3_plugin},
 #endif
 #ifdef WITH_MONGODB
-  {PLUGIN_ID_UNKNOWN,	"mongodb",		mongodb_legacy_warning}, /* Legacy plugin */
-  {PLUGIN_ID_MONGODB,  	"mongodb_legacy",	mongodb_plugin}, /* Legacy plugin */
+  {PLUGIN_ID_UNKNOWN,   "mongodb",              mongodb_legacy_warning}, /* Legacy plugin */
+  {PLUGIN_ID_MONGODB,   "mongodb_legacy",       mongodb_plugin}, /* Legacy plugin */
 #endif
 #ifdef WITH_RABBITMQ
-  {PLUGIN_ID_AMQP,	"amqp",		amqp_plugin},
+  {PLUGIN_ID_AMQP,      "amqp",         amqp_plugin},
 #endif
 #ifdef WITH_KAFKA
   {PLUGIN_ID_KAFKA,     "kafka",        kafka_plugin},
 #endif
-  {PLUGIN_ID_TEE,	"tee",		tee_plugin},
-  {PLUGIN_ID_UNKNOWN,	"",		NULL},
+  {PLUGIN_ID_TEE,       "tee",          tee_plugin},
+  {PLUGIN_ID_UNKNOWN,   "",             NULL},
 };
 
 //Global variables
@@ -708,7 +709,7 @@ void evaluate_configuration(char *filename, int rows)
 
   while (index < rows) {
     if (*cfg[index] == '\0') valid_line = FALSE;
-    else valid_line = TRUE; 
+    else valid_line = TRUE;
 
     if (valid_line) {
       /* debugging the line if required */
@@ -732,17 +733,17 @@ void evaluate_configuration(char *filename, int rows)
       /* parsing keys */
       for (dindex = 0; strcmp(dictionary[dindex].key, ""); dindex++) {
         if (!strcmp(dictionary[dindex].key, key)) {
-	  res = FALSE;
+          res = FALSE;
           if ((*dictionary[dindex].func)) {
-	    res = (*dictionary[dindex].func)(filename, name, value);
-	    if (res < 0) Log(LOG_WARNING, "WARN: [%s:%u] Invalid value. Ignored.\n", filename, index+1);
-	    else if (!res) Log(LOG_WARNING, "WARN: [%s:%u] Unknown symbol '%s'. Ignored.\n", filename, index+1, name);
-	  }
-	  else Log(LOG_WARNING, "WARN: [%s:%u] Unable to handle key: %s. Ignored.\n", filename, index+1, key);
-	  key_found = TRUE;
-	  break;
+            res = (*dictionary[dindex].func)(filename, name, value);
+            if (res < 0) Log(LOG_WARNING, "WARN: [%s:%u] Invalid value. Ignored.\n", filename, index+1);
+            else if (!res) Log(LOG_WARNING, "WARN: [%s:%u] Unknown symbol '%s'. Ignored.\n", filename, index+1, name);
+          }
+          else Log(LOG_WARNING, "WARN: [%s:%u] Unable to handle key: %s. Ignored.\n", filename, index+1, key);
+          key_found = TRUE;
+          break;
         }
-	else key_found = FALSE;
+        else key_found = FALSE;
       }
 
       if (!key_found) Log(LOG_WARNING, "WARN: [%s:%u] Unknown key: %s. Ignored.\n", filename, index+1, key);
@@ -759,7 +760,7 @@ int parse_configuration_file(char *filename)
 {
   struct stat st;
   char localbuf[10240];
-  char cmdline [] = "cmdline"; 
+  char cmdline [] = "cmdline";
   FILE *file;
   int num = 0, cmdlineflag = FALSE, rows_cmdline = rows, idx, ret;
   rows = 0;
@@ -768,7 +769,7 @@ int parse_configuration_file(char *filename)
      file and store lines into a first char* array; merge commandline options, if
      required, placing them at the tail - in order to override directives placed
      in the configuration file */
-  if (filename) { 
+  if (filename) {
     ret = stat(filename, &st);
     if (ret < 0) {
       Log(LOG_ERR, "ERROR: [%s] file not found.\n", filename);
@@ -776,30 +777,30 @@ int parse_configuration_file(char *filename)
     }
     else {
       if (!S_ISREG(st.st_mode)) {
-	Log(LOG_ERR, "ERROR: [%s] path is not a regular file.\n", filename);
-	return ERR;
+        Log(LOG_ERR, "ERROR: [%s] path is not a regular file.\n", filename);
+        return ERR;
       }
     }
 
     if ((file = fopen(filename, "r"))) {
       while (!feof(file)) {
         if (rows == LARGEBUFLEN) {
-	  Log(LOG_ERR, "ERROR: [%s] maximum number of %d lines reached.\n", filename, LARGEBUFLEN);
-	  break;
+          Log(LOG_ERR, "ERROR: [%s] maximum number of %d lines reached.\n", filename, LARGEBUFLEN);
+          break;
         }
-	memset(localbuf, 0, sizeof(localbuf));
-        if (fgets(localbuf, sizeof(localbuf), file) == NULL) break;	
+        memset(localbuf, 0, sizeof(localbuf));
+        if (fgets(localbuf, sizeof(localbuf), file) == NULL) break;
         else {
-	  localbuf[sizeof(localbuf)-1] = '\0';
+          localbuf[sizeof(localbuf)-1] = '\0';
           cfg[rows] = malloc(strlen(localbuf)+2);
-	  if (!cfg[rows]) {
-	    Log(LOG_ERR, "ERROR: [%s] malloc() failed (parse_configuration_file). Exiting.\n", filename);
-	    exit(1);
-	  }
+          if (!cfg[rows]) {
+            Log(LOG_ERR, "ERROR: [%s] malloc() failed (parse_configuration_file). Exiting.\n", filename);
+            exit(1);
+          }
           strcpy(cfg[rows], localbuf);
           cfg[rows][strlen(localbuf)+1] = '\0';
           rows++;
-        } 
+        }
       }
     }
     fclose(file);
@@ -822,7 +823,7 @@ int parse_configuration_file(char *filename)
   /* 3rd stage: plugin structures creation; we discard
      plugin names if 'pmacctd' has been invoked commandline;
      if any plugin has been activated we default to a single
-     'imt' plugin */ 
+     'imt' plugin */
   if (!cmdlineflag) parse_core_process_name(filename, rows, FALSE);
   else parse_core_process_name(filename, rows, TRUE);
 
@@ -830,13 +831,13 @@ int parse_configuration_file(char *filename)
   else num = parse_plugin_names(filename, rows, TRUE);
 
   if (!num && config.acct_type < ACCT_FWDPLANE_MAX) {
-    Log(LOG_WARNING, "WARN: [%s] No plugin has been activated; defaulting to in-memory table.\n", filename); 
+    Log(LOG_WARNING, "WARN: [%s] No plugin has been activated; defaulting to in-memory table.\n", filename);
     num = create_plugin(filename, "default_memory", "memory");
   }
 
   if (debug) {
     struct plugins_list_entry *list = plugins_list;
-    
+
     while (list) {
       Log(LOG_DEBUG, "DEBUG: [%s] plugin name/type: '%s'/'%s'.\n", filename, list->name, list->type.string);
       list = list->next;
@@ -845,8 +846,8 @@ int parse_configuration_file(char *filename)
 
   /* 4th stage: setting some default value */
   set_default_values();
-  
-  /* 5th stage: parsing keys and building configurations */ 
+
+  /* 5th stage: parsing keys and building configurations */
   evaluate_configuration(filename, rows);
 
   return SUCCESS;
@@ -867,7 +868,7 @@ void sanitize_cfg(int rows, char *filename)
     /* checking the whole line: if it's void, it will be removed */
     if (isblankline(cfg[rindex])) memset(cfg[rindex], 0, strlen(cfg[rindex]));
 
-    /* 
+    /*
        a pair of syntax checks on the whole line:
        - does the line contain at least a ':' verb ?
        - are the square brackets weighted both in key and value ?
@@ -877,44 +878,44 @@ void sanitize_cfg(int rows, char *filename)
       int symbol = FALSE, cindex = 0, got_first = 0, got_first_colon = 0;
 
       if (!strchr(cfg[rindex], ':')) {
-	Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: missing ':'. Exiting.\n", filename, rindex+1); 
-	exit(1);
+        Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: missing ':'. Exiting.\n", filename, rindex+1);
+        exit(1);
       }
 
       while(cindex <= len) {
         if (cfg[rindex][cindex] == '[') symbol++;
         else if (cfg[rindex][cindex] == ']') {
-	  symbol--;
-	  got_first++;
-	}
-	
-	if (cfg[rindex][cindex] == ':' && !got_first_colon) {
-	  got_first_colon = TRUE;
+          symbol--;
+          got_first++;
+        }
 
-	  if (symbol) {
-	    Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: illegal brackets. Exiting.\n", filename, rindex+1);
-	    exit(1);
-	  }
-	}
+        if (cfg[rindex][cindex] == ':' && !got_first_colon) {
+          got_first_colon = TRUE;
 
-	if (cfg[rindex][cindex] == '\0') {
-	  if (symbol && !got_first) {
+          if (symbol) {
+            Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: illegal brackets. Exiting.\n", filename, rindex+1);
+            exit(1);
+          }
+        }
+
+        if (cfg[rindex][cindex] == '\0') {
+          if (symbol && !got_first) {
             Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: not weighted brackets (1). Exiting.\n", filename, rindex+1);
-	    exit(1);
-	  }
-	}
+            exit(1);
+          }
+        }
 
-	if (symbol < 0 && !got_first) {
-	  Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: not weighted brackets (2). Exiting.\n", filename, rindex+1);
-	  exit(1);
-	}
+        if (symbol < 0 && !got_first) {
+          Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: not weighted brackets (2). Exiting.\n", filename, rindex+1);
+          exit(1);
+        }
 
-	if (symbol > 1 && !got_first) {
-	  Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: nested symbols not allowed. Exiting.\n", filename, rindex+1);
-	  exit(1);
-	}
-	
-	cindex++;
+        if (symbol > 1 && !got_first) {
+          Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: nested symbols not allowed. Exiting.\n", filename, rindex+1);
+          exit(1);
+        }
+
+        cindex++;
       }
     }
 
@@ -927,23 +928,23 @@ void sanitize_cfg(int rows, char *filename)
       char *valueptr = NULL;
 
       while(cindex <= len) {
-	if (!value) {
+        if (!value) {
           if (cfg[rindex][cindex] == '[') symbol++;
           else if (cfg[rindex][cindex] == ']') symbol--;
-	  else if (cfg[rindex][cindex] == ':') {
-	    value++;
-	    valueptr = &localbuf[lbindex+1];
-	  }
-	}
+          else if (cfg[rindex][cindex] == ':') {
+            value++;
+            valueptr = &localbuf[lbindex+1];
+          }
+        }
         if ((!symbol) && (!value)) {
-	  if (!isspace(cfg[rindex][cindex])) {
-	    localbuf[lbindex] = cfg[rindex][cindex]; 
-	    lbindex++;
-	  }
+          if (!isspace(cfg[rindex][cindex])) {
+            localbuf[lbindex] = cfg[rindex][cindex];
+            lbindex++;
+          }
         }
         else {
-	  localbuf[lbindex] = cfg[rindex][cindex];
-	  lbindex++;
+          localbuf[lbindex] = cfg[rindex][cindex];
+          lbindex++;
         }
         cindex++;
       }
@@ -959,22 +960,22 @@ void sanitize_cfg(int rows, char *filename)
 
       while (cindex < rows) {
         if (cfg[rindex][cindex] == '[') symbol++;
-	else if (cfg[rindex][cindex] == ']') {
-	  symbol--;
-	  key--;
-	}
+        else if (cfg[rindex][cindex] == ']') {
+          symbol--;
+          key--;
+        }
 
-	if (cfg[rindex][cindex] == ':') break;
+        if (cfg[rindex][cindex] == ':') break;
 
-	if (!symbol) {
-	  if (isalpha(cfg[rindex][cindex])) key = TRUE;
-	}
-	else {
-	  if (!key) {
+        if (!symbol) {
+          if (isalpha(cfg[rindex][cindex])) key = TRUE;
+        }
+        else {
+          if (!key) {
             Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: symbol not referring to any key. Exiting.\n", filename, rindex+1);
-	    exit(1);
-	  }
-	}
+            exit(1);
+          }
+        }
         cindex++;
       }
     }
@@ -984,26 +985,26 @@ void sanitize_cfg(int rows, char *filename)
     len = strlen(cfg[rindex]);
     if (len) {
       if (cfg[rindex][0] == ':') {
-	Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: missing key. Exiting.\n", filename, rindex+1);
-	exit(1);
+        Log(LOG_ERR, "ERROR: [%s:%u] Syntax error: missing key. Exiting.\n", filename, rindex+1);
+        exit(1);
       }
     }
 
-    /* checking key field: converting key to lower chars */ 
+    /* checking key field: converting key to lower chars */
     len = strlen(cfg[rindex]);
     if (len) {
       int symbol = FALSE, cindex = 0;
 
       while(cindex <= len) {
         if (cfg[rindex][cindex] == '[') symbol++;
-	else if (cfg[rindex][cindex] == ']') symbol--;
+        else if (cfg[rindex][cindex] == ']') symbol--;
 
-	if (cfg[rindex][cindex] == ':') break;
-	if (!symbol) {
-	  if (isalpha(cfg[rindex][cindex]))
-	    cfg[rindex][cindex] = tolower(cfg[rindex][cindex]);
-	}
-	cindex++;
+        if (cfg[rindex][cindex] == ':') break;
+        if (!symbol) {
+          if (isalpha(cfg[rindex][cindex]))
+            cfg[rindex][cindex] = tolower(cfg[rindex][cindex]);
+        }
+        cindex++;
       }
     }
 
@@ -1028,7 +1029,7 @@ void parse_core_process_name(char *filename, int rows, int ignore_names)
       if (!strncmp(key, "core_proc_name", sizeof("core_proc_name"))) {
         start = end+1;
         strlcpy(name, start, SRVBUFLEN);
-	found = TRUE;
+        found = TRUE;
         break;
       }
     }
@@ -1040,7 +1041,7 @@ void parse_core_process_name(char *filename, int rows, int ignore_names)
 }
 
 /* parse_plugin_names() leaves cfg array untouched: parses the key 'plugins'
-   if it exists and creates the plugins linked list */ 
+   if it exists and creates the plugins linked list */
 int parse_plugin_names(char *filename, int rows, int ignore_names)
 {
   int index = 0, num = 0, found = 0, default_name = FALSE;
@@ -1055,12 +1056,12 @@ int parse_plugin_names(char *filename, int rows, int ignore_names)
     start = cfg[index];
     end = strchr(cfg[index], ':');
     if (end > start) {
-      strlcpy(key, cfg[index], (end-start)+1); 
+      strlcpy(key, cfg[index], (end-start)+1);
       if (!strncmp(key, "plugins", sizeof("plugins"))) {
-	start = end+1;
-	strcpy(value, start); 
-	found = TRUE;
-	break;
+        start = end+1;
+        strcpy(value, start);
+        found = TRUE;
+        break;
       }
     }
     index++;
@@ -1078,12 +1079,12 @@ int parse_plugin_names(char *filename, int rows, int ignore_names)
       if ((start_name = strchr(token, '[')) && (end_name = strchr(token, ']'))) {
         if (end_name > (start_name+1)) {
           strlcpy(name, (start_name+1), (end_name-start_name));
-	  trim_spaces(name);
-	  *start_name = '\0';
-	}
+          trim_spaces(name);
+          *start_name = '\0';
+        }
       }
       else default_name = TRUE;
-	
+
       /* Having already plugins name and type, we'll filter out reserved symbols */
       trim_spaces(token);
       lower_string(token);
@@ -1175,7 +1176,7 @@ int create_plugin(char *filename, char *name, char *type)
   }
 
   memset(plugin, 0, sizeof(struct plugins_list_entry));
-  
+
   strcpy(plugin->name, name);
   plugin->id = id;
   memcpy(&plugin->type, ptype, sizeof(struct plugin_type_entry));
@@ -1184,7 +1185,7 @@ int create_plugin(char *filename, char *name, char *type)
   /* inserting our object in plugin's linked list */
   if (plugins_list) {
     ptr = plugins_list;
-    while(ptr->next) ptr = ptr->next; 
+    while(ptr->next) ptr = ptr->next;
     ptr->next = plugin;
   }
   else plugins_list = plugin;
@@ -1207,11 +1208,11 @@ int delete_plugin_by_id(int id)
       list = aux;
     }
     else {
-      if (list->id > highest_id) highest_id = list->id; 
+      if (list->id > highest_id) highest_id = list->id;
     }
     aux = list;
-    list = list->next; 
-  } 
+    list = list->next;
+  }
 
   return highest_id;
 }
@@ -1223,8 +1224,8 @@ struct plugins_list_entry *search_plugin_by_pipe(int pipe)
   if (pipe < 0) return NULL;
 
   while (list) {
-    if (list->pipe[1] == pipe) return list; 
-    else list = list->next; 
+    if (list->pipe[1] == pipe) return list;
+    else list = list->next;
   }
 
   return NULL;

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -26,9 +26,9 @@
 
 /* defines */
 #define CFG_LINE_LEN(x) (SRVBUFLEN-strlen(x))
-#define MAX_CUSTOM_PRIMITIVES		64
-#define MAX_CUSTOM_PRIMITIVE_NAMELEN	64
-#define MAX_CUSTOM_PRIMITIVE_PD_PTRS	8
+#define MAX_CUSTOM_PRIMITIVES           64
+#define MAX_CUSTOM_PRIMITIVE_NAMELEN    64
+#define MAX_CUSTOM_PRIMITIVE_PD_PTRS    8
 
 /* structures */
 struct _dictionary_line {
@@ -75,8 +75,8 @@ struct custom_primitives_ptrs {
 };
 
 struct configuration {
-  pm_cfgreg_t what_to_count;	/* first registry */
-  pm_cfgreg_t what_to_count_2;	/* second registry */
+  pm_cfgreg_t what_to_count;    /* first registry */
+  pm_cfgreg_t what_to_count_2;  /* second registry */
   pm_cfgreg_t nfprobe_what_to_count;
   pm_cfgreg_t nfprobe_what_to_count_2;
   char *aggregate_primitives;
@@ -97,8 +97,8 @@ struct configuration {
   int redis_db;
   int sock;
   int bgp_sock;
-  int acct_type; 
-  int data_type; 
+  int acct_type;
+  int data_type;
   int pipe_homegrown;
   u_int64_t pipe_size;
   u_int64_t buffer_size;
@@ -261,6 +261,7 @@ struct configuration {
   int telemetry_udp_notif_ipv6_only;
   int telemetry_udp_notif_nmsgs;
   char *telemetry_udp_notif_rp_ebpf_prog;
+  char *telemetry_grpc_collector_socket;
   int telemetry_ipv6_only;
   char *telemetry_zmq_address;
   char *telemetry_kafka_broker_host;
@@ -534,9 +535,9 @@ struct configuration {
   int buckets;
   int daemon;
   int active_plugins;
-  char *logfile; 
-  FILE *logfile_fd; 
-  char *pidfile; 
+  char *logfile;
+  FILE *logfile_fd;
+  char *pidfile;
   int networks_mask;
   char *networks_file;
   int networks_file_filter;
@@ -641,7 +642,7 @@ struct configuration {
   int bmp_daemon_parse_proxy_header;
 };
 
-/* prototypes */ 
+/* prototypes */
 extern void evaluate_configuration(char *, int);
 extern int parse_configuration_file(char *);
 extern int parse_plugin_names(char *, int, int);

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -76,9 +76,9 @@ int cfg_key_debug(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) { 
-	list->cfg.debug = value;
-	changes++;
-	break;
+        list->cfg.debug = value;
+        changes++;
+        break;
       }
     }
   }
@@ -286,7 +286,7 @@ int cfg_key_aggregate(char *filename, char *name, char *value_ptr)
     }
     else if (!strcmp(count_token, "class")) { // XXX: to conciliate and merge with 'class_frame'
       if (config.acct_type == ACCT_NF) {
-	cfg_set_aggregate(filename, value, COUNT_INT_CLASS, count_token);
+        cfg_set_aggregate(filename, value, COUNT_INT_CLASS, count_token);
       }
       else if (config.acct_type == ACCT_PM || config.acct_type == ACCT_SF) {
 #if defined (WITH_NDPI)
@@ -542,7 +542,7 @@ int cfg_key_pre_tag_filter(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	changes = load_tags(filename, &list->cfg.ptf, value_ptr);
+        changes = load_tags(filename, &list->cfg.ptf, value_ptr);
         break;
       }
     }
@@ -1102,39 +1102,39 @@ int cfg_key_sql_table(char *filename, char *name, char *value_ptr)
       ptr = c;
       switch (*c) {
       case 'd':
-	num++;
-	break;
+        num++;
+        break;
       case 'H':
-	num++;
-	break;
+        num++;
+        break;
       case 'm':
-	num++;
-	break;
+        num++;
+        break;
       case 'M':
-	num++;
-	break;
+        num++;
+        break;
       case 'w':
-	num++;
-	break;
+        num++;
+        break;
       case 'W':
-	num++;
-	break;
+        num++;
+        break;
       case 'Y':
-	num++;
-	break;
+        num++;
+        break;
       case 's':
-	num++;
-	break;
+        num++;
+        break;
       case 'S':
-	num++;
-	break;
+        num++;
+        break;
       case 'z':
-	num++;
-	break;
+        num++;
+        break;
       default:
-	Log(LOG_ERR, "ERROR: [%s] sql_table, %%%c not supported.\n", filename, *c);
-	exit(1);
-	break;
+        Log(LOG_ERR, "ERROR: [%s] sql_table, %%%c not supported.\n", filename, *c);
+        exit(1);
+        break;
       } 
     } 
 
@@ -1202,8 +1202,8 @@ int cfg_key_print_output_file(char *filename, char *name, char *value_ptr)
         num++;
         break;
       case 'S':
-	num++;
-	break;
+        num++;
+        break;
       case 'z':
         num++;
         break;
@@ -1558,8 +1558,8 @@ int cfg_key_sql_trigger_time(char *filename, char *name, char *value_ptr)
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
         list->cfg.sql_trigger_time = t;
-	list->cfg.sql_trigger_time_howmany = t_howmany;
-	changes++;
+        list->cfg.sql_trigger_time_howmany = t_howmany;
+        changes++;
         break;
       }
     }
@@ -1870,9 +1870,9 @@ int cfg_key_sql_preprocess_type(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.sql_preprocess_type = value;
-	changes++;
-	break;
+        list->cfg.sql_preprocess_type = value;
+        changes++;
+        break;
       }
     }
   }
@@ -2401,9 +2401,9 @@ int cfg_key_sql_locking_style(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.sql_locking_style = value_ptr;
-	changes++;
-	break;
+        list->cfg.sql_locking_style = value_ptr;
+        changes++;
+        break;
       }
     }
   }
@@ -2424,8 +2424,8 @@ int cfg_key_sql_use_copy(char *filename, char *name, char *value_ptr)
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
         list->cfg.sql_use_copy = value;
-	changes++;
-	break;
+        changes++;
+        break;
       }
     }
   }
@@ -2617,8 +2617,8 @@ int cfg_key_plugin_pipe_zmq_profile(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	value = p_zmq_plugin_pipe_set_profile(&list->cfg, value_ptr);
-	if (value < 0) return ERR;
+        value = p_zmq_plugin_pipe_set_profile(&list->cfg, value_ptr);
+        if (value < 0) return ERR;
 
         changes++;
         break;
@@ -3640,8 +3640,8 @@ int cfg_key_nfacctd_time_new(char *filename, char *name, char *value_ptr)
   for (; list; list = list->next, changes++) {
     if (!list->cfg.nfacctd_time) {
       if (value) {
-	list->cfg.nfacctd_time = NF_TIME_NEW;
-	list->cfg.nfacctd_time_new = TRUE;
+        list->cfg.nfacctd_time = NF_TIME_NEW;
+        list->cfg.nfacctd_time_new = TRUE;
       }
     }
     else Log(LOG_WARNING, "WARN: [%s] Possibly 'nfacctd_time_secs: true' set. 'nfacctd_time_new' ignored.\n", filename);
@@ -3676,9 +3676,9 @@ int cfg_key_nfacctd_mcast_groups(char *filename, char *name, char *value_ptr)
 
   for (; list; list = list->next, changes++); /* Nothing to do because of the global array, just rolling changes counters */
   if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for keys '%s_mcast_groups'. Globalized.\n",
-		  filename, config.progname);
+                  filename, config.progname);
   if (more) Log(LOG_WARNING, "WARN: [%s] Only the first %u (on a total of %u) multicast groups will be joined.\n",
-		  filename, MAX_MCAST_GROUPS, MAX_MCAST_GROUPS+more);
+                  filename, MAX_MCAST_GROUPS, MAX_MCAST_GROUPS+more);
 
   return changes;
 }
@@ -3824,7 +3824,7 @@ int cfg_key_bgp_daemon_peer_src_as_type(char *filename, char *name, char *value_
   else if (!strncmp(value_ptr, "map", strlen("map"))) value = BGP_SRC_PRIMITIVES_MAP;
   else if (!strncmp(value_ptr, "bgp", strlen("bgp"))) value = BGP_SRC_PRIMITIVES_BGP;
   else if (!strncmp(value_ptr, "fallback", strlen("fallback")) ||
-	   !strncmp(value_ptr, "longest", strlen("longest"))) {
+           !strncmp(value_ptr, "longest", strlen("longest"))) {
     value = BGP_SRC_PRIMITIVES_KEEP;
     value |= BGP_SRC_PRIMITIVES_BGP;
   }
@@ -4037,8 +4037,8 @@ int cfg_key_bgp_daemon_follow_nexthop(char *filename, char *name, char *value_pt
     for (list = plugins_list; list; list = list->next) {
       valid = str2prefix(count_token, &list->cfg.bgp_daemon_follow_nexthop[idx]);
       if (!valid) {
-	Log(LOG_WARNING, "WARN: [%s] bgp_follow_nexthop: invalid IP prefix '%s'.\n", filename, count_token);
-	break;
+        Log(LOG_WARNING, "WARN: [%s] bgp_follow_nexthop: invalid IP prefix '%s'.\n", filename, count_token);
+        break;
       }
     }
     if (valid) idx++;
@@ -5749,8 +5749,8 @@ int cfg_key_nfacctd_as_new(char *filename, char *name, char *value_ptr)
       value |= NF_AS_BGP;
     }
     else value |= NF_AS_BGP; /* NF_AS_KEEP does not apply to ACCT_PM and ACCT_UL;
-			        we set value to NF_AS_BGP since we can't fallback
-			        to any alternative method as of yet */
+                                we set value to NF_AS_BGP since we can't fallback
+                                to any alternative method as of yet */
   }
   else {
     Log(LOG_ERR, "WARN: [%s] Invalid AS aggregation value '%s'\n", filename, value_ptr);
@@ -6002,9 +6002,9 @@ int cfg_key_nfprobe_timeouts(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.nfprobe_timeouts = value_ptr;
-	changes++;
-	break;
+        list->cfg.nfprobe_timeouts = value_ptr;
+        changes++;
+        break;
       }
     }
   }
@@ -6028,8 +6028,8 @@ int cfg_key_nfprobe_hoplimit(char *filename, char *name, char *value_ptr)
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
         list->cfg.nfprobe_hoplimit = value;
-	changes++;
-	break;
+        changes++;
+        break;
       }
     }
   }
@@ -6052,9 +6052,9 @@ int cfg_key_nfprobe_maxflows(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.nfprobe_maxflows = value;
-	changes++;
-	break;
+        list->cfg.nfprobe_maxflows = value;
+        changes++;
+        break;
       }
     }
   }
@@ -6158,7 +6158,7 @@ int cfg_key_nfprobe_version(char *filename, char *name, char *value_ptr)
       if (!strcmp(name, list->name)) {
         list->cfg.nfprobe_version = value;
         changes++;
-	break;
+        break;
       }
     }
   }
@@ -6222,7 +6222,7 @@ int cfg_key_nfprobe_ip_precedence(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.nfprobe_ipprec = value;
+        list->cfg.nfprobe_ipprec = value;
         changes++;
         break;
       }
@@ -6259,8 +6259,8 @@ int cfg_key_nfprobe_direction(char *filename, char *name, char *value_ptr)
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
         list->cfg.nfprobe_direction = value;
-	changes++;
-	break;
+        changes++;
+        break;
       }
     }
   }
@@ -6293,10 +6293,10 @@ int cfg_key_nfprobe_ifindex(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.nfprobe_ifindex = value;
-	list->cfg.nfprobe_ifindex_type = value2;
-	changes++;
-	break;
+        list->cfg.nfprobe_ifindex = value;
+        list->cfg.nfprobe_ifindex_type = value2;
+        changes++;
+        break;
       }
     }
   }
@@ -6445,9 +6445,9 @@ int cfg_key_sfprobe_ifspeed(char *filename, char *name, char *value_ptr)
   else {
     for (; list; list = list->next) {
       if (!strcmp(name, list->name)) {
-	list->cfg.sfprobe_ifspeed = value;
-	changes++;
-	break;
+        list->cfg.sfprobe_ifspeed = value;
+        changes++;
+        break;
       }
     }
   }
@@ -6628,11 +6628,11 @@ void parse_time(char *filename, char *value, int *mu, int *howmany)
     if (*mu == COUNT_SECONDLY) {
       if (k % 60) {
         Log(LOG_WARNING, "WARN: [%s] Ignoring invalid time value: %d (residual secs afters conversion in mins)\n", filename, k);
-	goto exit_lane;
+        goto exit_lane;
       }
       else {
-	k = k / 60;
-	*mu = COUNT_MINUTELY;
+        k = k / 60;
+        *mu = COUNT_MINUTELY;
       }
     }
     *howmany = k;
@@ -7995,6 +7995,17 @@ int cfg_key_telemetry_udp_notif_rp_ebpf_prog(char *filename, char *name, char *v
 
   for (; list; list = list->next, changes++) list->cfg.telemetry_udp_notif_rp_ebpf_prog = value_ptr;
   if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'telemetry_daemon_udp_notif_rp_ebpf_prog'. Globalized.\n", filename);
+
+  return changes;
+}
+
+int cfg_key_telemetry_grpc_collector_socket(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int changes = 0;
+
+  for (; list; list = list->next, changes++) list->cfg.telemetry_grpc_collector_socket = value_ptr;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'telemetry_daemon_collector_socket'. Globalized.\n", filename);
 
   return changes;
 }

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -222,6 +222,7 @@ extern int cfg_key_telemetry_udp_notif_interface(char *, char *, char *);
 extern int cfg_key_telemetry_udp_notif_ipv6_only(char *, char *, char *);
 extern int cfg_key_telemetry_udp_notif_nmsgs(char *, char *, char *);
 extern int cfg_key_telemetry_udp_notif_rp_ebpf_prog(char *, char *, char *);
+extern int cfg_key_telemetry_grpc_collector_socket(char *, char *, char *);
 extern int cfg_key_telemetry_ipv6_only(char *, char *, char *);
 extern int cfg_key_telemetry_zmq_address(char *, char *, char *);
 extern int cfg_key_telemetry_kafka_broker_host(char *, char *, char *);

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -43,7 +43,7 @@ telemetry_misc_structs *telemetry_misc_db;
 telemetry_peer *telemetry_peers;
 void *telemetry_peers_cache;
 telemetry_peer_timeout *telemetry_peers_timeout;
-int zmq_input = 0, kafka_input = 0, unyte_udp_notif_input = 0;
+int zmq_input = 0, kafka_input = 0, unyte_udp_notif_input = 0, grpc_collector_input = 0;
 telemetry_tag_t telemetry_logdump_tag;
 struct sockaddr_storage telemetry_logdump_tag_peer;
 
@@ -114,6 +114,15 @@ int telemetry_daemon(void *t_data_void)
   char udp_notif_null_ip_address[] = "0.0.0.0";
 #endif
 
+#if defined WITH_GRPC_COLLECTOR
+  void *seg_ptr = NULL;
+  void *ctx = zmq_ctx_new();
+  void *zmq_pull = zmq_socket(ctx, ZMQ_PULL);
+  zmq_bind(zmq_pull, config.telemetry_grpc_collector_socket);
+
+  start_grpc_dialout_collector();
+#endif
+
   if (!t_data) {
     Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon(): missing telemetry data. Terminating.\n", config.name, t_data->log_str);
     exit_gracefully(1);
@@ -144,11 +153,18 @@ int telemetry_daemon(void *t_data_void)
 #endif
   }
 
+  if (config.telemetry_grpc_collector_socket) {
+#if defined WITH_GRPC_COLLECTOR
+    capture_methods++;
+    grpc_collector_input = TRUE;
+#endif
+  }
+
   if (config.telemetry_zmq_address) {
 #if defined WITH_ZMQ
     capture_methods++;
     zmq_input = TRUE;
-#else 
+#else
     Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon_zmq_* require --enable-zmq. Terminating.\n", config.name, t_data->log_str);
     exit_gracefully(1);
 #endif
@@ -170,15 +186,15 @@ int telemetry_daemon(void *t_data_void)
 
   if (capture_methods > 1) {
     Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon_ip, telemetry_daemon_zmq_* and telemetry_kafka_* are mutually exclusive. Exiting...\n",
-	config.name, t_data->log_str);
+        config.name, t_data->log_str);
     exit_gracefully(1);
   }
 
   memset(consumer_buf, 0, sizeof(consumer_buf));
 
-  if (!zmq_input && !kafka_input && !unyte_udp_notif_input) {
-    if (config.telemetry_port_tcp && config.telemetry_port_udp) {
-      Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon_port_tcp and telemetry_daemon_port_udp are mutually exclusive. Terminating.\n", config.name, t_data->log_str);
+  if (!zmq_input && !kafka_input && !unyte_udp_notif_input && !grpc_collector_input) {
+    if (config.telemetry_port_tcp && config.telemetry_port_udp && config.telemetry_grpc_collector_socket) {
+      Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon_port_tcp and telemetry_daemon_port_udp and telemetry_grpc_collector_socket are mutually exclusive. Terminating.\n", config.name, t_data->log_str);
       exit_gracefully(1);
     }
     else if (!config.telemetry_port_tcp && !config.telemetry_port_udp) {
@@ -189,15 +205,15 @@ int telemetry_daemon(void *t_data_void)
     }
     else {
       if (config.telemetry_port_tcp) {
-	port = config.telemetry_port_tcp;
-	srv_proto = malloc(strlen("tcp") + 1);
-	strcpy(srv_proto, "tcp");
+        port = config.telemetry_port_tcp;
+        srv_proto = malloc(strlen("tcp") + 1);
+        strcpy(srv_proto, "tcp");
       }
 
       if (config.telemetry_port_udp) {
-	port = config.telemetry_port_udp;
-	srv_proto = malloc(strlen("udp") + 1);
-	strcpy(srv_proto, "udp");
+        port = config.telemetry_port_udp;
+        srv_proto = malloc(strlen("udp") + 1);
+        strcpy(srv_proto, "udp");
       }
     }
 
@@ -213,8 +229,8 @@ int telemetry_daemon(void *t_data_void)
       trim_spaces(config.telemetry_ip);
       ret = str_to_addr(config.telemetry_ip, &addr);
       if (!ret) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon_ip value is not a valid IPv4/IPv6 address. Terminating.\n", config.name, t_data->log_str);
-	exit_gracefully(1);
+        Log(LOG_ERR, "ERROR ( %s/%s ): telemetry_daemon_ip value is not a valid IPv4/IPv6 address. Terminating.\n", config.name, t_data->log_str);
+        exit_gracefully(1);
       }
       slen = addr_to_sa((struct sockaddr *)&server, &addr, port);
     }
@@ -236,18 +252,23 @@ int telemetry_daemon(void *t_data_void)
 
     if (config.telemetry_decoder_id != TELEMETRY_DECODER_JSON) {
       if (zmq_input) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): ZeroMQ collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
-	exit_gracefully(1);
+        Log(LOG_ERR, "ERROR ( %s/%s ): ZeroMQ collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
+        exit_gracefully(1);
       }
 
       if (kafka_input) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): Kafka collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
-	exit_gracefully(1);
+        Log(LOG_ERR, "ERROR ( %s/%s ): Kafka collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
+        exit_gracefully(1);
       }
 
       if (unyte_udp_notif_input) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): Unyte UDP Notif collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
-	exit_gracefully(1);
+        Log(LOG_ERR, "ERROR ( %s/%s ): Unyte UDP Notif collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
+        exit_gracefully(1);
+      }
+
+      if (grpc_collector_input) {
+        Log(LOG_ERR, "ERROR ( %s/%s ): gRPC dial-out collection supports only 'json' decoder (telemetry_daemon_decoder). Terminating.\n", config.name, t_data->log_str);
+        exit_gracefully(1);
       }
     }
   }
@@ -255,7 +276,7 @@ int telemetry_daemon(void *t_data_void)
   if (!config.telemetry_max_peers) config.telemetry_max_peers = TELEMETRY_MAX_PEERS_DEFAULT;
   Log(LOG_INFO, "INFO ( %s/%s ): maximum telemetry peers allowed: %d\n", config.name, t_data->log_str, config.telemetry_max_peers);
 
-  if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input) {
+  if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
     if (!config.telemetry_peer_timeout) config.telemetry_peer_timeout = TELEMETRY_PEER_TIMEOUT_DEFAULT;
     Log(LOG_INFO, "INFO ( %s/%s ): telemetry peers timeout: %u\n", config.name, t_data->log_str, config.telemetry_peer_timeout);
   }
@@ -267,7 +288,7 @@ int telemetry_daemon(void *t_data_void)
   }
   memset(telemetry_peers, 0, config.telemetry_max_peers*sizeof(telemetry_peer));
 
-  if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input) {
+  if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
     telemetry_peers_timeout = malloc(config.telemetry_max_peers*sizeof(telemetry_peer_timeout));
     if (!telemetry_peers_timeout) {
       Log(LOG_ERR, "ERROR ( %s/%s ): Unable to malloc() telemetry_peers_timeout structure. Terminating.\n", config.name, t_data->log_str);
@@ -330,27 +351,27 @@ int telemetry_daemon(void *t_data_void)
     }
   }
 
-  if (!zmq_input && !kafka_input && !unyte_udp_notif_input) {
+  if (!zmq_input && !kafka_input && !unyte_udp_notif_input && !grpc_collector_input) {
     if (config.telemetry_port_tcp) config.telemetry_sock = socket(((struct sockaddr *)&server)->sa_family, SOCK_STREAM, 0);
     else if (config.telemetry_port_udp) config.telemetry_sock = socket(((struct sockaddr *)&server)->sa_family, SOCK_DGRAM, 0);
 
     if (config.telemetry_sock < 0) {
       /* retry with IPv4 */
       if (!config.telemetry_ip) {
-	struct sockaddr_in *sa4 = (struct sockaddr_in *)&server;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *)&server;
 
-	sa4->sin_family = AF_INET;
-	sa4->sin_addr.s_addr = htonl(0);
-	sa4->sin_port = htons(port);
-	slen = sizeof(struct sockaddr_in);
+        sa4->sin_family = AF_INET;
+        sa4->sin_addr.s_addr = htonl(0);
+        sa4->sin_port = htons(port);
+        slen = sizeof(struct sockaddr_in);
 
-	if (config.telemetry_port_tcp) config.telemetry_sock = socket(((struct sockaddr *)&server)->sa_family, SOCK_STREAM, 0);
-	else if (config.telemetry_port_udp) config.telemetry_sock = socket(((struct sockaddr *)&server)->sa_family, SOCK_DGRAM, 0);
+        if (config.telemetry_port_tcp) config.telemetry_sock = socket(((struct sockaddr *)&server)->sa_family, SOCK_STREAM, 0);
+        else if (config.telemetry_port_udp) config.telemetry_sock = socket(((struct sockaddr *)&server)->sa_family, SOCK_DGRAM, 0);
       }
 
       if (config.telemetry_sock < 0) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): socket() failed. Terminating.\n", config.name, t_data->log_str);
-	exit_gracefully(1);
+        Log(LOG_ERR, "ERROR ( %s/%s ): socket() failed. Terminating.\n", config.name, t_data->log_str);
+        exit_gracefully(1);
       }
 
       if (config.telemetry_port_tcp) setsockopt(config.telemetry_sock, SOL_SOCKET, SO_KEEPALIVE, (void *)&yes, sizeof(yes));
@@ -396,7 +417,7 @@ int telemetry_daemon(void *t_data_void)
       Setsocksize(config.telemetry_sock, SOL_SOCKET, SO_RCVBUF, &saved, l);
       getsockopt(config.telemetry_sock, SOL_SOCKET, SO_RCVBUF, &obtained, &l);
       Log(LOG_INFO, "INFO ( %s/%s ): telemetry_daemon_pipe_size: obtained=%d target=%d.\n",
-	  config.name, t_data->log_str, obtained, config.telemetry_pipe_size);
+          config.name, t_data->log_str, obtained, config.telemetry_pipe_size);
     }
 
     rc = bind(config.telemetry_sock, (struct sockaddr *) &server, slen);
@@ -406,20 +427,20 @@ int telemetry_daemon(void *t_data_void)
 
       ip_address = config.telemetry_ip ? config.telemetry_ip : null_ip_address;
       Log(LOG_ERR, "ERROR ( %s/%s ): bind() to ip=%s port=%u/%s failed (errno: %d).\n",
-	  config.name, t_data->log_str, ip_address, port, srv_proto, errno);
+          config.name, t_data->log_str, ip_address, port, srv_proto, errno);
       exit_gracefully(1);
     }
 
     if (config.telemetry_port_tcp) {
       rc = listen(config.telemetry_sock, 1);
       if (rc < 0) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): listen() failed (errno: %d).\n", config.name, t_data->log_str, errno);
-	exit_gracefully(1);
+        Log(LOG_ERR, "ERROR ( %s/%s ): listen() failed (errno: %d).\n", config.name, t_data->log_str, errno);
+        exit_gracefully(1);
       }
     }
   }
 
-  if (!zmq_input && !kafka_input && !unyte_udp_notif_input) {
+  if (!zmq_input && !kafka_input && !unyte_udp_notif_input && !grpc_collector_input) {
     char srv_string[INET6_ADDRSTRLEN];
     char *srv_interface = NULL, default_interface[] = "all";
     struct host_addr srv_addr;
@@ -436,7 +457,7 @@ int telemetry_daemon(void *t_data_void)
     addr_to_str(srv_string, &srv_addr);
 
     Log(LOG_INFO, "INFO ( %s/%s ): waiting for telemetry data on interface=%s ip=%s port=%u/%s\n",
-	config.name, t_data->log_str, srv_interface, srv_string, srv_port, srv_proto);
+        config.name, t_data->log_str, srv_interface, srv_string, srv_port, srv_proto);
   }
 #if defined WITH_ZMQ
   else if (zmq_input) {
@@ -448,7 +469,7 @@ int telemetry_daemon(void *t_data_void)
   else if (kafka_input) {
     telemetry_init_kafka_host(&telemetry_kafka_host);
     Log(LOG_INFO, "INFO ( %s/%s ): reading telemetry data from Kafka %s:%s\n", config.name, t_data->log_str,
-	p_kafka_get_broker(&telemetry_kafka_host), p_kafka_get_topic(&telemetry_kafka_host));
+        p_kafka_get_broker(&telemetry_kafka_host), p_kafka_get_topic(&telemetry_kafka_host));
   }
 #endif
 #if defined WITH_UNYTE_UDP_NOTIF
@@ -592,8 +613,8 @@ int telemetry_daemon(void *t_data_void)
     select_again:
 
     if (!t_data->is_thread) {
-      sigprocmask(SIG_UNBLOCK, &signal_set, NULL); 
-      sigprocmask(SIG_BLOCK, &signal_set, NULL); 
+      sigprocmask(SIG_UNBLOCK, &signal_set, NULL);
+      sigprocmask(SIG_BLOCK, &signal_set, NULL);
     }
 
     if (recalc_fds) {
@@ -601,11 +622,11 @@ int telemetry_daemon(void *t_data_void)
       max_peers_idx = -1; /* .. since valid indexes include 0 */
 
       for (peers_idx = 0, peers_num = 0; peers_idx < config.telemetry_max_peers; peers_idx++) {
-	if (select_fd < telemetry_peers[peers_idx].fd) select_fd = telemetry_peers[peers_idx].fd;
-	if (telemetry_peers[peers_idx].fd > 0) {
-	  max_peers_idx = peers_idx;
-	  peers_num++;
-	}
+        if (select_fd < telemetry_peers[peers_idx].fd) select_fd = telemetry_peers[peers_idx].fd;
+        if (telemetry_peers[peers_idx].fd > 0) {
+          max_peers_idx = peers_idx;
+          peers_num++;
+        }
       }
       select_fd++;
       max_peers_idx++;
@@ -627,7 +648,7 @@ int telemetry_daemon(void *t_data_void)
     }
     else drt_ptr = NULL;
 
-    if (!zmq_input && !kafka_input && !unyte_udp_notif_input) {
+    if (!zmq_input && !kafka_input && !unyte_udp_notif_input && !grpc_collector_input) {
       select_num = select(select_fd, &read_descs, NULL, NULL, drt_ptr);
       if (select_num < 0) goto select_again;
     }
@@ -644,13 +665,13 @@ int telemetry_daemon(void *t_data_void)
       select_num = p_kafka_consume_poller(&telemetry_kafka_host, &t_data->kafka_msg, drt_ptr ? (drt_ptr->tv_sec * 1000) : 1000);
 
       if (select_num < 0) {
-	/* Close */
-	p_kafka_manage_consumer(&nfacctd_kafka_host, FALSE);
+        /* Close */
+        p_kafka_manage_consumer(&nfacctd_kafka_host, FALSE);
 
-	/* Re-open */
-	telemetry_init_kafka_host(&telemetry_kafka_host);
+        /* Re-open */
+        telemetry_init_kafka_host(&telemetry_kafka_host);
 
-	goto select_again;
+        goto select_again;
       }
     }
 #endif
@@ -660,49 +681,55 @@ int telemetry_daemon(void *t_data_void)
       select_num = TRUE; /* anything but zero or negative */
     }
 #endif
+#if defined WITH_GRPC_COLLECTOR
+    else if (grpc_collector_input) {
+      zmq_recv(zmq_pull, &seg_ptr, sizeof(Payload), 0);
+      select_num = TRUE;
+    }
+#endif
 
     t_data->now = time(NULL);
 
     /* Logging stats */
     if (!t_data->global_stats.last_check || ((t_data->global_stats.last_check + TELEMETRY_LOG_STATS_INTERVAL) <= t_data->now)) {
       if (t_data->global_stats.last_check) {
-	telemetry_peer *stats_peer;
-	int peers_idx;
+        telemetry_peer *stats_peer;
+        int peers_idx;
 
-	for (stats_peer = NULL, peers_idx = 0; peers_idx < config.telemetry_max_peers; peers_idx++) {
-	  if (telemetry_peers[peers_idx].fd) {
-	    stats_peer = &telemetry_peers[peers_idx];
-	    telemetry_log_peer_stats(stats_peer, t_data);
-	    stats_peer->stats.last_check = t_data->now;
-	  }
-	}
+        for (stats_peer = NULL, peers_idx = 0; peers_idx < config.telemetry_max_peers; peers_idx++) {
+          if (telemetry_peers[peers_idx].fd) {
+            stats_peer = &telemetry_peers[peers_idx];
+            telemetry_log_peer_stats(stats_peer, t_data);
+            stats_peer->stats.last_check = t_data->now;
+          }
+        }
 
-	telemetry_log_global_stats(t_data);
+        telemetry_log_global_stats(t_data);
       }
 
       t_data->global_stats.last_check = t_data->now;
     }
 
     /* XXX: ZeroMQ / Kafka cases: timeout handling (to be tested) */
-    if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input) {
+    if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
       if (t_data->now > (last_peers_timeout_check + TELEMETRY_PEER_TIMEOUT_INTERVAL)) {
-	for (peers_idx = 0; peers_idx < config.telemetry_max_peers; peers_idx++) {
-	  telemetry_peer_timeout *peer_timeout;
+        for (peers_idx = 0; peers_idx < config.telemetry_max_peers; peers_idx++) {
+          telemetry_peer_timeout *peer_timeout;
 
-	  peer = &telemetry_peers[peers_idx];
-	  peer_timeout = &telemetry_peers_timeout[peers_idx];
+          peer = &telemetry_peers[peers_idx];
+          peer_timeout = &telemetry_peers_timeout[peers_idx];
 
-	  if (peer->fd) {
-	    if (t_data->now > (peer_timeout->last_msg + config.telemetry_peer_timeout)) {
-	      Log(LOG_INFO, "INFO ( %s/%s ): [%s] telemetry peer removed (timeout).\n", config.name, t_data->log_str, peer->addr_str);
-	      telemetry_peer_close(peer, FUNC_TYPE_TELEMETRY);
-	      peers_num--;
-	      recalc_fds = TRUE;
-	    }
-	  }
-	}
+          if (peer->fd) {
+            if (t_data->now > (peer_timeout->last_msg + config.telemetry_peer_timeout)) {
+              Log(LOG_INFO, "INFO ( %s/%s ): [%s] telemetry peer removed (timeout).\n", config.name, t_data->log_str, peer->addr_str);
+              telemetry_peer_close(peer, FUNC_TYPE_TELEMETRY);
+              peers_num--;
+              recalc_fds = TRUE;
+            }
+          }
+        }
 
-	last_peers_timeout_check = t_data->now;
+        last_peers_timeout_check = t_data->now;
       }
     }
 
@@ -710,8 +737,8 @@ int telemetry_daemon(void *t_data_void)
       if (config.telemetry_allow_file) load_allow_file(config.telemetry_allow_file, &allow);
 
       if (config.telemetry_tag_map) {
-	load_pre_tag_map(ACCT_PMTELE, config.telemetry_tag_map, &telemetry_logdump_tag_table, &req,
-			 &telemetry_logdump_tag_map_allocated, config.maps_entries, config.maps_row_len);
+        load_pre_tag_map(ACCT_PMTELE, config.telemetry_tag_map, &telemetry_logdump_tag_table, &req,
+                         &telemetry_logdump_tag_map_allocated, config.maps_entries, config.maps_row_len);
       }
 
       reload_map_telemetry_thread = FALSE;
@@ -738,11 +765,11 @@ int telemetry_daemon(void *t_data_void)
     if (telemetry_misc_db->msglog_backend_methods || telemetry_misc_db->dump_backend_methods) {
       gettimeofday(&telemetry_misc_db->log_tstamp, NULL);
       compose_timestamp(telemetry_misc_db->log_tstamp_str, SRVBUFLEN, &telemetry_misc_db->log_tstamp, TRUE,
-			config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
+                        config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
 
       /* let's reset log sequence here as we do not sequence dump_init/dump_close events */
       if (telemetry_log_seq_has_ro_bit(&telemetry_misc_db->log_seq))
-	telemetry_log_seq_init(&telemetry_misc_db->log_seq);
+        telemetry_log_seq_init(&telemetry_misc_db->log_seq);
 
       int refreshTimePerSlot = config.telemetry_dump_refresh_time / config.telemetry_dump_time_slots;
 
@@ -751,8 +778,8 @@ int telemetry_daemon(void *t_data_void)
           telemetry_misc_db->dump.tstamp.tv_sec = dump_refresh_deadline;
           telemetry_misc_db->dump.tstamp.tv_usec = 0;
           compose_timestamp(telemetry_misc_db->dump.tstamp_str, SRVBUFLEN, &telemetry_misc_db->dump.tstamp, FALSE,
-			    config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
-	  telemetry_misc_db->dump.period = refreshTimePerSlot;
+                            config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
+          telemetry_misc_db->dump.period = refreshTimePerSlot;
 
           telemetry_handle_dump_event(t_data, max_peers_idx);
 
@@ -789,59 +816,91 @@ int telemetry_daemon(void *t_data_void)
     if (!select_num) goto select_again;
 
     /* New connection is coming in */
-    if (FD_ISSET(config.telemetry_sock, &read_descs) || kafka_input || unyte_udp_notif_input) {
+    if (FD_ISSET(config.telemetry_sock, &read_descs) || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
       if (config.telemetry_port_tcp) {
         fd = accept(config.telemetry_sock, (struct sockaddr *) &client, &clen);
         if (fd == ERR) goto read_data;
       }
       else if (config.telemetry_port_udp) {
-	char dummy_local_buf[TRUE];
+        char dummy_local_buf[TRUE];
 
-	ret = recvfrom(config.telemetry_sock, dummy_local_buf, TRUE, MSG_PEEK, (struct sockaddr *) &client, &clen);
-	if (ret <= 0) goto select_again;
-	else fd = config.telemetry_sock;
+        ret = recvfrom(config.telemetry_sock, dummy_local_buf, TRUE, MSG_PEEK, (struct sockaddr *) &client, &clen);
+        if (ret <= 0) goto select_again;
+        else fd = config.telemetry_sock;
       }
 #if defined WITH_ZMQ
       else if (zmq_input) {
-	ret = telemetry_decode_producer_peer(t_data, &telemetry_zmq_host, consumer_buf, sizeof(consumer_buf), (struct sockaddr *) &client, &clen);
-	if (ret < 0) goto select_again; 
-	else fd = config.telemetry_sock;
+        ret = telemetry_decode_producer_peer(t_data, &telemetry_zmq_host, consumer_buf, sizeof(consumer_buf), (struct sockaddr *) &client, &clen);
+        if (ret < 0) goto select_again;
+        else fd = config.telemetry_sock;
       }
 #endif
 #if defined WITH_KAFKA
       else if (kafka_input) {
-	ret = telemetry_decode_producer_peer(t_data, &telemetry_kafka_host, consumer_buf, sizeof(consumer_buf), (struct sockaddr *) &client, &clen);
-	if (ret < 0) goto select_again;
+        ret = telemetry_decode_producer_peer(t_data, &telemetry_kafka_host, consumer_buf, sizeof(consumer_buf), (struct sockaddr *) &client, &clen);
+        if (ret < 0) goto select_again;
         else fd = TELEMETRY_KAFKA_FD;
       }
 #endif
 #if defined WITH_UNYTE_UDP_NOTIF
       else if (unyte_udp_notif_input) {
-	if (seg_ptr) {
-	  unyte_seg_met_t *seg = NULL;
+        if (seg_ptr) {
+          unyte_seg_met_t *seg = NULL;
           int payload_len = 0;
 
-	  seg = (unyte_seg_met_t *)seg_ptr;
+          seg = (unyte_seg_met_t *)seg_ptr;
 
-	  if (unyte_udp_get_media_type(seg) == UNYTE_MEDIATYPE_YANG_JSON && config.telemetry_decoder_id == TELEMETRY_DECODER_JSON) {
-	    struct sockaddr_storage *unsa = NULL;
+          if (unyte_udp_get_media_type(seg) == UNYTE_MEDIATYPE_YANG_JSON && config.telemetry_decoder_id == TELEMETRY_DECODER_JSON) {
+            struct sockaddr_storage *unsa = NULL;
 
-	    unsa = unyte_udp_get_src(seg);
-	    memcpy(&client, unsa, sizeof(struct sockaddr_storage));
+            unsa = unyte_udp_get_src(seg);
+            memcpy(&client, unsa, sizeof(struct sockaddr_storage));
 
-	    payload_len = strlen(seg->payload);
-	    if (payload_len < sizeof(consumer_buf)) {
-	      strlcpy((char *)consumer_buf, seg->payload, sizeof(consumer_buf));
-	      fd = TELEMETRY_UDP_NOTIF_FD;
-	    }
-	    else {
-	      goto select_again;
-	    }
-	  }
-	  else {
-	    goto select_again;
-	  }
-	}
+            payload_len = strlen(seg->payload);
+            if (payload_len < sizeof(consumer_buf)) {
+              strlcpy((char *)consumer_buf, seg->payload, sizeof(consumer_buf));
+              fd = TELEMETRY_UDP_NOTIF_FD;
+            }
+            else {
+              goto select_again;
+            }
+          }
+          else {
+            goto select_again;
+          }
+        }
+      }
+#endif
+#if defined WITH_GRPC_COLLECTOR
+      else if (grpc_collector_input) {
+        zmq_recv(zmq_pull, &seg_ptr, sizeof(Payload), 0);
+        if (seg_ptr) {
+          Payload *seg = NULL;
+          int payload_len = 0;
+
+          seg = (Payload *) seg_ptr;
+
+          if (config.telemetry_decoder_id == TELEMETRY_DECODER_JSON && strcmp(seg->telemetry_data, " ")) {
+            struct host_addr tmp;
+            str_to_addr(seg->telemetry_node, &tmp);
+            addr_to_sa(&client, &tmp, atoi(seg->telemetry_port));
+
+            payload_len = strlen(seg->telemetry_data);
+            if (payload_len < sizeof(consumer_buf)) {
+              /* printf("%s\n", seg->telemetry_data); */
+              strlcpy((char *)consumer_buf, seg->telemetry_data, sizeof(consumer_buf));
+              fd = TELEMETRY_GRPC_COLLECTOR_FD;
+              FreePayload(seg);
+            }
+            else {
+              FreePayload(seg);
+              goto select_again;
+            }
+          }
+          else {
+            goto select_again;
+          }
+        }
       }
 #endif
 
@@ -857,43 +916,43 @@ int telemetry_daemon(void *t_data_void)
       }
 
       /* XXX: UDP, ZeroMQ and Kafka cases may be optimized further */
-      if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input) {
-	telemetry_peer_cache *tpc_ret;
-	u_int16_t client_port;
+      if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
+        telemetry_peer_cache *tpc_ret;
+        u_int16_t client_port;
 
         sa_to_addr((struct sockaddr *)&client, &tpc.addr, &client_port);
-	tpc_ret = pm_tfind(&tpc, &telemetry_peers_cache, telemetry_tpc_addr_cmp);
+        tpc_ret = pm_tfind(&tpc, &telemetry_peers_cache, telemetry_tpc_addr_cmp);
 
-	if (tpc_ret) {
-	  telemetry_peer_cache *tpc_peer = (*(telemetry_peer_cache **) tpc_ret);
+        if (tpc_ret) {
+          telemetry_peer_cache *tpc_peer = (*(telemetry_peer_cache **) tpc_ret);
 
-	  peer = &telemetry_peers[tpc_peer->index];
-	  telemetry_peers_timeout[tpc_peer->index].last_msg = t_data->now;
+          peer = &telemetry_peers[tpc_peer->index];
+          telemetry_peers_timeout[tpc_peer->index].last_msg = t_data->now;
 
-	  goto read_data;
-	}
+          goto read_data;
+        }
       }
 
       for (peer = NULL, peers_idx = 0; peers_idx < config.telemetry_max_peers; peers_idx++) {
         if (!telemetry_peers[peers_idx].fd) {
-	  peer = &telemetry_peers[peers_idx];
+          peer = &telemetry_peers[peers_idx];
 
-	  if (telemetry_peer_init(peer, FUNC_TYPE_TELEMETRY)) peer = NULL;
+          if (telemetry_peer_init(peer, FUNC_TYPE_TELEMETRY)) peer = NULL;
 
-	  if (peer) {
-	    recalc_fds = TRUE; // XXX: do we need this for ZeroMQ / Kafka cases?
+          if (peer) {
+            recalc_fds = TRUE; // XXX: do we need this for ZeroMQ / Kafka cases?
 
-	    if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input) {
-	      tpc.index = peers_idx;
-	      telemetry_peers_timeout[peers_idx].last_msg = t_data->now;
+            if (config.telemetry_port_udp || zmq_input || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
+              tpc.index = peers_idx;
+              telemetry_peers_timeout[peers_idx].last_msg = t_data->now;
 
-	      if (!pm_tsearch(&tpc, &telemetry_peers_cache, telemetry_tpc_addr_cmp, sizeof(telemetry_peer_cache)))
-		Log(LOG_WARNING, "WARN ( %s/%s ): tsearch() unable to insert in peers cache.\n", config.name, t_data->log_str);
-	    }
-	  }
+              if (!pm_tsearch(&tpc, &telemetry_peers_cache, telemetry_tpc_addr_cmp, sizeof(telemetry_peer_cache)))
+                Log(LOG_WARNING, "WARN ( %s/%s ): tsearch() unable to insert in peers cache.\n", config.name, t_data->log_str);
+            }
+          }
 
-	  break;
-	}
+          break;
+        }
       }
 
       if (!peer) {
@@ -906,7 +965,7 @@ int telemetry_daemon(void *t_data_void)
 
 #if defined WITH_KAFKA
       if (kafka_input) {
-	peer->buf.kafka_msg = t_data->kafka_msg;
+        peer->buf.kafka_msg = t_data->kafka_msg;
         t_data->kafka_msg = NULL;
       }
 #endif
@@ -925,8 +984,8 @@ int telemetry_daemon(void *t_data_void)
       addr_to_str(peer->addr_str, &peer->addr);
 
       if (config.telemetry_tag_map) {
-	telemetry_tag_init_find(peer, (struct sockaddr *) &telemetry_logdump_tag_peer, &telemetry_logdump_tag);
-	telemetry_tag_find((struct id_table *)telemetry_logdump_tag.tag_table, &telemetry_logdump_tag, &telemetry_logdump_tag.tag, NULL);
+        telemetry_tag_init_find(peer, (struct sockaddr *) &telemetry_logdump_tag_peer, &telemetry_logdump_tag);
+        telemetry_tag_find((struct id_table *)telemetry_logdump_tag.tag_table, &telemetry_logdump_tag, &telemetry_logdump_tag.tag, NULL);
       }
 
       if (telemetry_misc_db->msglog_backend_methods)
@@ -937,7 +996,7 @@ int telemetry_daemon(void *t_data_void)
 
       peers_num++;
       Log(LOG_INFO, "INFO ( %s/%s ): [%s] telemetry peers usage: %u/%u\n",
-	  config.name, t_data->log_str, peer->addr_str, peers_num, config.telemetry_max_peers);
+          config.name, t_data->log_str, peer->addr_str, peers_num, config.telemetry_max_peers);
     }
 
     read_data:
@@ -965,21 +1024,24 @@ int telemetry_daemon(void *t_data_void)
 
     switch (config.telemetry_decoder_id) {
     case TELEMETRY_DECODER_JSON:
-      if (!zmq_input && !kafka_input && !unyte_udp_notif_input) {
-	ret = telemetry_recv_json(peer, 0, &recv_flags);
+      if (!zmq_input && !kafka_input && !unyte_udp_notif_input && !grpc_collector_input) {
+        ret = telemetry_recv_json(peer, 0, &recv_flags);
       }
       else {
-	ret = (strlen((char *) consumer_buf) + 1);
+        ret = (strlen((char *) consumer_buf) + 1);
 
-	if (ret > 0) {
-	  saved_peer_buf = peer->buf.base;
-	  peer->buf.base = (char *) consumer_buf;
-	  peer->msglen = peer->buf.tot_len = ret;
+        if (ret > 0) {
+          saved_peer_buf = peer->buf.base;
+          peer->buf.base = (char *) consumer_buf;
+          peer->msglen = peer->buf.tot_len = ret;
 
-	  if (unyte_udp_notif_input) {
-	    peer->stats.packet_bytes += ret;
-	  }
-	}
+          if (unyte_udp_notif_input) {
+            peer->stats.packet_bytes += ret;
+          }
+          if (grpc_collector_input) {
+            peer->stats.packet_bytes += ret;
+          }
+        }
       }
       data_decoder = TELEMETRY_DATA_DECODER_JSON;
       break;
@@ -1009,17 +1071,17 @@ int telemetry_daemon(void *t_data_void)
     else {
       peer->stats.packets++;
       if (recv_flags != ERR) {
-	if (config.telemetry_tag_map) {
-	  telemetry_tag_init_find(peer, (struct sockaddr *) &telemetry_logdump_tag_peer, &telemetry_logdump_tag);
-	  telemetry_tag_find((struct id_table *)telemetry_logdump_tag.tag_table, &telemetry_logdump_tag, &telemetry_logdump_tag.tag, NULL);
-	}
+        if (config.telemetry_tag_map) {
+          telemetry_tag_init_find(peer, (struct sockaddr *) &telemetry_logdump_tag_peer, &telemetry_logdump_tag);
+          telemetry_tag_find((struct id_table *)telemetry_logdump_tag.tag_table, &telemetry_logdump_tag, &telemetry_logdump_tag.tag, NULL);
+        }
 
         peer->stats.msg_bytes += ret;
         telemetry_process_data(peer, t_data, data_decoder);
       }
 
-      if (zmq_input || kafka_input || unyte_udp_notif_input) {
-	peer->buf.base = saved_peer_buf;
+      if (zmq_input || kafka_input || unyte_udp_notif_input || grpc_collector_input) {
+        peer->buf.base = saved_peer_buf;
       }
     }
   }


### PR DESCRIPTION
### Summary 

The main aim of this PR is to add gRPC data collection functionalities to pmtelemetryd. 
New [libraries](https://github.com/scuzzilla/mdt-dialout-collector) are linked with pmtelemetryd in order to be able to add the functions required to collect data via gRPC dialout.

The gRPC dialout should be enabled at compile time:
```SHELL
./configure --enable-kafka --enable-jansson --enable-grpc-collector
``` 
The pmtelemetryd's configuration should include the ZMQ socket option:
```SHELL
telemetry_daemon_grpc_collector_socket: ipc:///tmp/grpc.sock
```
The pmtelemetryd's configuration should specify "json" as decoder type:
```SHELL
telemetry_daemon_decoder:     json
```

The most important additions to the pmacct's existing code are:
- the autotools code in order to link the new "grpc_collector" libraries & to distribute a single header file including the used functions 
- the start_grpc_dialout_collector()  which is used to bind the gRPC deamons
- a minimal ZMQ puller in order to receive data from the gRPC deamons
- an ad-hoc configuration option to specify the pull/push ZMQ socket (telemetry_daemon_grpc_collector_socket) 

### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)
