### PR TITLE
Collecting data via gRPC dialout with pmtelemetryd - flex config file option

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -296,6 +296,7 @@ static const struct _dictionary_line dictionary[] = {
   {"telemetry_daemon_udp_notif_nmsgs", cfg_key_telemetry_udp_notif_nmsgs},
   {"telemetry_daemon_udp_notif_rp_ebpf_prog", cfg_key_telemetry_udp_notif_rp_ebpf_prog},
   {"telemetry_daemon_grpc_collector_socket", cfg_key_telemetry_grpc_collector_socket},
+  {"telemetry_daemon_grpc_collector_conf", cfg_key_telemetry_grpc_collector_conf},
   {"telemetry_daemon_zmq_address", cfg_key_telemetry_zmq_address},
   {"telemetry_daemon_kafka_broker_host", cfg_key_telemetry_kafka_broker_host},
   {"telemetry_daemon_kafka_broker_port", cfg_key_telemetry_kafka_broker_port},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -262,6 +262,7 @@ struct configuration {
   int telemetry_udp_notif_nmsgs;
   char *telemetry_udp_notif_rp_ebpf_prog;
   char *telemetry_grpc_collector_socket;
+  char *telemetry_grpc_collector_conf;
   int telemetry_ipv6_only;
   char *telemetry_zmq_address;
   char *telemetry_kafka_broker_host;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -8010,6 +8010,17 @@ int cfg_key_telemetry_grpc_collector_socket(char *filename, char *name, char *va
   return changes;
 }
 
+int cfg_key_telemetry_grpc_collector_conf(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int changes = 0;
+
+  for (; list; list = list->next, changes++) list->cfg.telemetry_grpc_collector_conf = value_ptr;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'telemetry_daemon_collector_conf'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_telemetry_ipv6_only(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -223,6 +223,7 @@ extern int cfg_key_telemetry_udp_notif_ipv6_only(char *, char *, char *);
 extern int cfg_key_telemetry_udp_notif_nmsgs(char *, char *, char *);
 extern int cfg_key_telemetry_udp_notif_rp_ebpf_prog(char *, char *, char *);
 extern int cfg_key_telemetry_grpc_collector_socket(char *, char *, char *);
+extern int cfg_key_telemetry_grpc_collector_conf(char *, char *, char *);
 extern int cfg_key_telemetry_ipv6_only(char *, char *, char *);
 extern int cfg_key_telemetry_zmq_address(char *, char *, char *);
 extern int cfg_key_telemetry_kafka_broker_host(char *, char *, char *);

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -120,7 +120,7 @@ int telemetry_daemon(void *t_data_void)
   void *zmq_pull = zmq_socket(ctx, ZMQ_PULL);
   zmq_bind(zmq_pull, config.telemetry_grpc_collector_socket);
 
-  start_grpc_dialout_collector(config.telemetry_daemon_grpc_collector_conf);
+  start_grpc_dialout_collector(config.telemetry_grpc_collector_conf);
 #endif
 
   if (!t_data) {

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -120,7 +120,7 @@ int telemetry_daemon(void *t_data_void)
   void *zmq_pull = zmq_socket(ctx, ZMQ_PULL);
   zmq_bind(zmq_pull, config.telemetry_grpc_collector_socket);
 
-  start_grpc_dialout_collector();
+  start_grpc_dialout_collector(config.telemetry_daemon_grpc_collector_conf);
 #endif
 
   if (!t_data) {


### PR DESCRIPTION
### Summary 

this PR is closely related to [PR#653](https://github.com/pmacct/pmacct/pull/653) and it's adding the ability to specify the gRPC deamons configuration file directly from the pmtelemetryd's configuration options.  

The pmtelemetryd's configuration should include the gRPC deamons configuration file location:
```SHELL
telemetry_daemon_grpc_collector_conf: /etc/opt/mdt-dialout-collector/mdt_dialout_collector.conf
```

### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)
