### PR TITLE
BMP high availability for nfacctd (PR #630) - refactoring and adding BGP support

### DIFF
--- a/docs/README_BMP_HA.md
+++ b/docs/README_BMP_HA.md
@@ -1,113 +1,117 @@
 [![Build status](https://github.com/pmacct/pmacct/workflows/ci/badge.svg?branch=master)](https://github.com/pmacct/pmacct/actions)
 
-DOCUMENTATION
+BMP/BGP HIGH-AVAILABILITY FEATURE DOCUMENTATION 
 =============
-# Functionality
+## Important Information and Current Implementation Status
 
-  * Active/standby mode for the BMP collector (or thread) is enabled via the tmp_bmp_daemon_ha config knob (currently undocumented, until the feature is considered GA). The active/standby status is determined by the timestamp of the collector, which is set at startup of the process: a smaller timestamp means that a collector has worked fine for a longer time, and thus can be considered as a stable one, while the other(s), having a larger timestamp due to either just establishing BMP session a later, or crashing while running, will be considered as less stable one(s). (Please note that there can be multiple collectors where more than one collector can be standby but only one will be active)
-  The timestamp is written to Redis with key:
-  
+* This contribution doesn't change the behavior of the software when not enabled in the configuration file. The high-availability (HA) feature can be enabled via the following config knob (currently undocumented, until the feature is considered GA). 
   ```bash
-  [config.name]+[config.cluster_id]+[core_proc_name]+"attachment_time"ß
-  e.g. nfacctd-bmp-locB+0+locBbmp-locB01c+attachment_time
+  tmp_bmp_bgp_daemon_ha: true
   ```
- 
-  In redis_common.c, the function called p_redis_get_time() performs the following query:
+* Compilation with --enable-redis is required for this feature
+
+* The HA functionality supports both nfacctd+bmp and nfacctd+bgp.
+
+* Regarding exporting methods, it is currently only supporting kafka with avro.
+
+* Given vendor implementation it might be the case that the multiple BMP sessions established by a router with different collectors don't generate the exact same messages to both collectors. Thus the collector cache state might differ slightly.
+
+## Functionality
+
+  * While high-availability (HA) and load-balancing for IPFIX can be easily achieved at a network level by using IP anycast addresses, this is not the case for BMP, as state need to be maintained in pmacct for correlation to work properly. To achieve high-availability with BMP/BGP, all collectors need to receive the same BMP/BGP information from the router. The HA functionality was developed to reduce BMP/BGP duplicated messages arriving at the data collection, which would be the case in the described scenario otherwise.
+
+  * The HA feature integrates a mechanism that specifies whether an nfacctd daemon should be active (i.e. normally forwarding all received BMP/BGP messages) or stand-by (i.e. only enrich the local pmacct cache with information in the BMP/BGP packets but then dropping them instead of forwarding them).
+
+  * The active/standby status is determined by the startup timestamp of the collector: a smaller timestamp means that a collector has worked fine for a longer time, and thus can be considered as a stable one, while the other(s), having a larger timestamp due to either being started later, or crashing while running, will be considered as less stable one(s). Please note that there can be multiple collectors where more than one collector can be standby but only one will be active (unless you're manually triggering forced-active or forced-standby states for a daemon, see below).
+
+  * It is also possible to manually trigger forced active/standby states for maintenance purposes: a deamon can be triggered to be in active or standby state no matter its timestamp.
+
+### Redis
+  * Redis is used by each collector for broader cluster management, i.e. to exchange timestamp information. To quickly summarize the functionality: all daemons will periodically read the timestamp of all other daemons in the cluster and compare it with their local timestamp, to decide whether they need to be in active or stand-by state. A global variable (bmp_bgp_forwarding) is then set accordingly, to tell nfacctd if BMP/BGP packets need to be forwarded (active state) or need to be dropped (stand-by state).
+
+  * The timestamp is written to redis every 1s (PM_REDIS_DEFAULT_REFRESH_TIME) and has an expiration time of 3s (PM_REDIS_DEFAULT_EXP_TIME). If the timestamp expires, the other daemons cannot get it anymore and will assume that the daemon is offline.
+
+  * The timestamp is written to Redis with the following key:
+    ```bash
+    [config.cluster_name]+[config.cluster_id]+[core_proc_name]+"ha_daemon_startup_time"
+
+    e.g. nfacctd-bmp+0+locBbmp-locB01c+ha_daemon_startup_time
+    ```
+
+  * To gather the startup timestamps of all the daemons in the cluster, we use the p_redis_get_keys() function in redis_common.c and we query redis with the following regex:
+    ```bash
+    KEYS [config.cluster_name]+[config.cluster_id]+"*"+"ha_daemon_startup_time"
+    ```
+    The query above is replied with a two dimensional array containing all keys that fit the condition (i.e. all keys of all daemons in the cluster). In order to then get the actual timestamps, we use the p_redis_get_string() function in redis_common.c.
+
+### Queuing
   
+  * In order to ensure that no BMP/BGP messages are lost in case of a failover (e.g. daemon going from stand-by to active mode, because the current active daemon has crashed), the stand-by daemon is always queuing the messages for 10s before discarding them. The message expiry timeout of 10s accounts for:
+    * internal state-change delays (1s redis loop and 3s redis key expiration)
+    * router delay in sending the BMP/BGP messages to different collectors (unknown, estimate max couple of seconds)
+    * network and redis querying delays (minor)
+
+  * In case that the daemon should change to active state, all messages in the queue are immediately forwarded to kafka. This makes sure that no BMP messages are dropped during the failover period. Keep in mind however, that some duplicate packets might arrive at the data collection in these failover situations.
+
+  * A thread handles the discarding of messages from the queue after they've been there for more than the message expiry timeout (i.e. 10s), while another thread handles the forwarding of all the messages in the queue to the data collection as soon as the daemon becomes active.
+
+  * The execution of the periodic table dump mechanism for BMP/BGP (which can be enabled via the bmp_dump* or bgp_table_dump* config knobs) is prevented if the daemon is stand-by. In this case however, messages are not queued. Therefore it might sometime happen that this dump is not executed, and this risk was considered acceptable.
+
+
+## Sending Signals Commands
+UNIX signals were integrated to give the possibility to manually trigger daemon state changes:
+
+* **34 (SIGRTMIN)**: trigger reset of the local timestamp of the collector
+* **35 (SIGRTMIN + 1)**: set collector to forced active mode
+* **36 (SIGRTMIN + 2)**: set collector to forced stand-by mode
+* **37 (SIGRTMIN + 3)**: set collector back to timestamp-based (i.e. non-forced) mode
+
+### Example Scenarios:
+The following scenario assumes that daemon B is operating in automatic (timestamp-based) mode and has initially a bigger timestamp than A.
+
+| Scenario  | Daemon A's state  |  Daemon B's state  |
+|-----------|:-----------------:|:-----------------------:|
+|  Initial state     |  active     | stand-by |
+|  Send signal 35 to A | active   | stand-by |
+|  Send signal 36 to A   | stand-by  | stand-by |
+|  Send signal 37 to A   | active  | stand-by |
+|  Send signal 34 to A (B has smaller timestamp now)  |    stand-by       | active |
+|  Redis Unavailable |  active     | active |
+|  Only A's timestamp is in redis |    active       | ? |
+
+### Example Signals:
+* In order to send the signal, one has to seek for the PID of the targeted process. Let's assume that now A is active and B is passive. To search for the process ID, type:
   ```bash
-  KEYS *(cluster id)+attachment_time
+  sudo ps -ef | grep "nfacctd: Core Process"
   ```
 
-  The query is replied with information such as: a two dimensional array containing all keys that fit the condition(session_name), and the number of keys that fit the condition(session_num). In order to get timestamps, it does a GET with the key, see code below:
-  
+* If one now wants to set B as the active one, one needs to refresh A's timestamp. Simply type:
   ```bash
- for (int i = 0; i < session_num; i++) 
-  {
-    redis_host->reply = redisCommand(redis_host->ctx, "GET %s", session_name[i]);
-    session_value[i] = strtoll(redis_host->reply->str, &eptr, 0); //eptr is the endpointer, stands for NULL 
-    // If there is a timestamp larger than its timestamp, return 0
-    if (strtoll(timestamp, &eptr, 0) > session_value[i])
-    {
-      p_redis_process_reply(redis_host);
-      return false;
-    }
-    // Continue if it's its timestamp
-    else if (strtoll(timestamp, &eptr, 0) == session_value[i])
-    {
-      continue;
-    }
-  }
-```
-  
-  * Redis is used by each collector for broader cluster management, ie. to exchange timestamp information. Initially, the collector publishes to Redis once per minute. Then such interval decreases in order to exchange information faster. In addition, the collector does also consume timestamp information from Redis with the same rate of publishing. The active/standby status is calculated each time, written to the log and notified by a global variable "dump_flag" which will be used by the Kafka thread afterwards.
-  
-  * The collector calls the p_kafka_produce_data_to_part() function to dump messages to Kafka. Each time before dumping data, the dump_flag is checked and, if true, publish to the message bus will take place. If false, a data pointer, data length as well as a timestamp is saved in a structure and queued in a global linked list. See code below:
-  
-  ```bash
-struct QNode *newNode(void *k, size_t k_len)
-{
-  struct QNode *temp = (struct QNode *)malloc(sizeof(struct QNode));
-  temp->key = k;
-  temp->key_len = k_len;
-  struct timeval current_time;
-  gettimeofday(&current_time, NULL);                                      // Get time in micro second
-  temp->timestamp = current_time.tv_sec * 1000000 + current_time.tv_usec; // Setting the time when redis connects as timestamp for this bmp session
-  // temp->next = NULL;
-  return temp;
-}
+  sudo kill -34 collectorA-nfacctd-core-processID
   ```
 
-  A thread iteratively goes over the global linked list and removes entries whose timestamp is 2 secs earlier than current time. For dumping data in the linked list, another variable `queue_dump_flag` is used, which is set when there is a change in the value of `dump_flag` (and when it's not the first time getting the `dump_flag`). With the `queue_dump_flag` set, the thread goes through all the data in the list and dumps it before the next new BMP message will be dumped.
+* Now A is queuing messages while B is forwarding. If now one wants to force A to dump as well, type:
+  ```bash
+  sudo kill -35 collectorA-nfacctd-core-processID
+  ```
 
-# Possible daemon states
-(listed according to priority)
-Scenario			Daemon A's state    Other daemon's state
-Redis Unavailable               active              active
-Send signal 34 to A             active              standby
-Send signal 35 to A             active              - -
-Send signal 36 to A             standby             - -
-Only A's timestamp              active              standby
-A has smallest timestsmp        active              standby
-One tiemstamp smaller than A    standby             - -
+* Now both A & B are forwarding. If you now want B, which is initially forwarding, to stop and queue messages, simply type:
+  ```bash
+  sudo kill -36 collectorB-nfacctd-core-processID
+  ```
 
-# Sending Signals Commands
+* Now A is forwarding and B is queuing messages. However, A has a lower priority and B has a higher priority due to the timestamp. If one wants to set all them back to their normal status, simply type:
+  ```bash
+  sudo kill -37 collectorA-nfacctd-core-processID
+  sudo kill -37 collectorB-nfacctd-core-processID
+  ```
+  Then A will be queuing messaging while B will be forwarding, just like what is indicated by their timestamps.
 
-The main actions that may need to be triggered by commands are the likes of refreshing the timestamp and force to change collector status. To use them, firstly start the collector:
+### Logging:
 
-```bash
- ~# sudo systemctl nfacctd-bmp-locA01.service
- ~# sudo systemctl nfacctd-bmp-locB01.service
-```
+There are two levels of logging messages for the HA functionality: 
 
-In order to send the signal, one has to seek for the PID of the targeted process. Let's assume that now A is active and B is passive. To search for the process ID, type:
+* INFO logs: redis connectivity, daemon state changes and signal actions
+* DEBUG logs: enqueuing packets, dropping packets from the queue and dumping the queue
 
-```bash
- ~# sudo ps -ef | grep "nfacctd: Core Process"
-```
-
-If one now wants to set B as the active one, one needs to refresh A's timestamp. Simply type:
-
-```bash
- ~# sudo kill -34 collectorA-nfacctd-core-processID
-```
-
-Now A is queuing messages while B is dumping. If now one wants to force A to dump as well, type:
-
-```bash
- ~# sudo kill -35 collectorA-nfacctd-core-processID
-```
-
-Now both A & B are dumping. If you now want B, which is initially dumping, to stop and queue messages, simply type:
-
-```bash
- ~# sudo kill -36 collectorB-nfacctd-core-processID
-```
-
-Now A is dumping and B is queuing messages. However, A has a lower priority and B has a higher priority due to the timestamp. If one wants to set all them back to their normal status, simply type:
-
-```bash
- ~# sudo kill -37 collectorA-nfacctd-core-processID
- ~# sudo kill -37 collectorB-nfacctd-core-processID
-```
-
-Then A will be queuing messaging while B will be dumping, just like what is indicated by their timestamps.
+To filter logs just pipe the following string to grep: "BMP-BGP-HA".

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -656,7 +656,7 @@ static const struct _dictionary_line dictionary[] = {
   {"tmp_bgp_daemon_origin_type_int", cfg_key_tmp_bgp_daemon_origin_type_int},
   {"tmp_telemetry_daemon_udp_notif_legacy", cfg_key_tmp_telemetry_daemon_udp_notif_legacy},
   {"tmp_telemetry_decode_cisco_v1_json_string", cfg_key_tmp_telemetry_decode_cisco_v1_json_string},
-  {"tmp_bmp_daemon_ha", cfg_key_tmp_bmp_daemon_ha},
+  {"tmp_bmp_bgp_daemon_ha", cfg_key_tmp_bmp_bgp_daemon_ha},
   {"", NULL}
 };
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -628,7 +628,7 @@ struct configuration {
   int tmp_bgp_daemon_origin_type_int;
   int tmp_telemetry_udp_notif_legacy;
   int tmp_telemetry_decode_cisco_v1_json_string;
-  int tmp_bmp_daemon_ha;
+  int tmp_bmp_bgp_daemon_ha;
   size_t thread_stack;
   char *rpki_roas_file;
   char *rpki_rtr_cache;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -7821,7 +7821,7 @@ int cfg_key_tmp_telemetry_decode_cisco_v1_json_string(char *filename, char *name
   return changes;
 }
 
-int cfg_key_tmp_bmp_daemon_ha(char *filename, char *name, char *value_ptr)
+int cfg_key_tmp_bmp_bgp_daemon_ha(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;
   int value, changes = 0;
@@ -7829,8 +7829,8 @@ int cfg_key_tmp_bmp_daemon_ha(char *filename, char *name, char *value_ptr)
   value = parse_truefalse(value_ptr);
   if (value < 0) return ERR;
 
-  for (; list; list = list->next, changes++) list->cfg.tmp_bmp_daemon_ha = value;
-  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'tmp_bmp_daemon_ha'. Globalized.\n", filename);
+  for (; list; list = list->next, changes++) list->cfg.tmp_bmp_bgp_daemon_ha = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'tmp_bmp_bgp_daemon_ha'. Globalized.\n", filename);
 
   return changes;
 }

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -529,7 +529,7 @@ extern int cfg_key_tmp_bgp_daemon_route_refresh(char *, char *, char *);
 extern int cfg_key_tmp_bgp_daemon_origin_type_int(char *, char *, char *);
 extern int cfg_key_tmp_telemetry_daemon_udp_notif_legacy(char *, char *, char *);
 extern int cfg_key_tmp_telemetry_decode_cisco_v1_json_string(char *, char *, char *);
-extern int cfg_key_tmp_bmp_daemon_ha(char *, char *, char *);
+extern int cfg_key_tmp_bmp_bgp_daemon_ha(char *, char *, char *);
 
 extern void parse_time(char *, char *, int *, int *);
 extern void cfg_get_primitive_index_value(u_int64_t, u_int64_t *, u_int64_t *);

--- a/src/ha.c
+++ b/src/ha.c
@@ -22,75 +22,354 @@
 #include "pmacct.h"
 #include "pmacct-data.h"
 #include "thread_pool.h"
+#include <sys/time.h>
+#include "kafka_common.h"
+#include "ha.h"
 
-thread_pool_t *dq_pool;
-// A utility function to create a new linked list node.
-struct QNode *newNode(void *k, size_t k_len)
+/*Threads*/
+thread_pool_t *bmp_bgp_ha_queue_mgmt_pool;
+thread_pool_t *bmp_bgp_ha_queue_dump_pool;
+
+/*Variables*/
+int daemon_state = TRUE;                    // Local daemon state
+int old_bmp_bgp_forwarding = FALSE;         // Previous state of global bmp_bgp_forwarding flag
+int regenerate_timestamp = FALSE;           // Flag used to trigger refresh of daemon's local timestamp
+int forced_mode = FALSE;                    // Flag that specifies whether HA daemon is in forced mode or automatic (timestamp-based) mode
+
+struct p_redis_host *redis_host;
+int redis_loop_num = 1;                     // Redis loop counter used for identifying first loop
+char timestamp_local[SHORTBUFLEN];          // Local timestamp
+char redis_key_id_string[SHORTBUFLEN] = "ha_daemon_startup_time";
+char redis_local_key[SRVBUFLEN];
+
+cdada_queue_t *bmp_bgp_ha_data_queue;       // Queue used for storing BMP/BGP messages
+pthread_mutex_t mutex_queue;                // Mutex for locking the queue
+int queue_dumping = FALSE;                  // Flag to ensure queue popping stops & daemon stays active when queue is being dumped to kafka!
+
+struct p_kafka_host kafka_host;
+
+/*------------------------------------------------------*/
+/* Kafka Host initialization functions */
+/*------------------------------------------------------*/
+int bmp_ha_msglog_init_kafka_host(void)
+{
+  int ret;
+
+  p_kafka_init_host(&kafka_host, config.bmp_daemon_msglog_kafka_config_file);
+  ret = p_kafka_connect_to_produce(&kafka_host);
+
+  if (!config.bmp_daemon_msglog_kafka_broker_host) config.bmp_daemon_msglog_kafka_broker_host = default_kafka_broker_host;
+  if (!config.bmp_daemon_msglog_kafka_broker_port) config.bmp_daemon_msglog_kafka_broker_port = default_kafka_broker_port;
+  if (!config.bmp_daemon_msglog_kafka_retry) config.bmp_daemon_msglog_kafka_retry = PM_KAFKA_DEFAULT_RETRY;
+
+  p_kafka_set_broker(&kafka_host, config.bmp_daemon_msglog_kafka_broker_host, config.bmp_daemon_msglog_kafka_broker_port);
+  p_kafka_set_topic(&kafka_host, config.bmp_daemon_msglog_kafka_topic);
+  p_kafka_set_partition(&kafka_host, config.bmp_daemon_msglog_kafka_partition);
+  p_kafka_set_key(&kafka_host, config.bmp_daemon_msglog_kafka_partition_key, config.bmp_daemon_msglog_kafka_partition_keylen);
+  p_kafka_set_content_type(&kafka_host, PM_KAFKA_CNT_TYPE_STR);
+  P_broker_timers_set_retry_interval(&kafka_host.btimers, config.bmp_daemon_msglog_kafka_retry);
+#ifdef WITH_SERDES
+  P_broker_timers_set_retry_interval(&kafka_host.sd_schema_timers, config.bmp_daemon_msglog_kafka_retry);
+#endif
+
+  return ret;
+}
+
+int bgp_ha_msglog_init_kafka_host()
+{
+  int ret;
+
+  p_kafka_init_host(&kafka_host, config.bgp_daemon_msglog_kafka_config_file);
+  ret = p_kafka_connect_to_produce(&kafka_host);
+
+  if (!config.bgp_daemon_msglog_kafka_broker_host) config.bgp_daemon_msglog_kafka_broker_host = default_kafka_broker_host;
+  if (!config.bgp_daemon_msglog_kafka_broker_port) config.bgp_daemon_msglog_kafka_broker_port = default_kafka_broker_port;
+  if (!config.bgp_daemon_msglog_kafka_retry) config.bgp_daemon_msglog_kafka_retry = PM_KAFKA_DEFAULT_RETRY;
+
+  p_kafka_set_broker(&kafka_host, config.bgp_daemon_msglog_kafka_broker_host, config.bgp_daemon_msglog_kafka_broker_port);
+  p_kafka_set_topic(&kafka_host, config.bgp_daemon_msglog_kafka_topic);
+  p_kafka_set_partition(&kafka_host, config.bgp_daemon_msglog_kafka_partition);
+  p_kafka_set_key(&kafka_host, config.bgp_daemon_msglog_kafka_partition_key, config.bgp_daemon_msglog_kafka_partition_keylen);
+  p_kafka_set_content_type(&kafka_host, PM_KAFKA_CNT_TYPE_STR);
+  P_broker_timers_set_retry_interval(&kafka_host.btimers, config.bgp_daemon_msglog_kafka_retry);
+#ifdef WITH_SERDES
+  P_broker_timers_set_retry_interval(&kafka_host.sd_schema_timers, config.bgp_daemon_msglog_kafka_retry);
+#endif
+
+  return ret;
+}
+
+int bmp_bgp_ha_msglog_init_kafka_host(void)
+{
+  int ret;
+  if (config.bmp_daemon) ret = bmp_ha_msglog_init_kafka_host();
+  else if (config.bgp_daemon) ret = bgp_ha_msglog_init_kafka_host();
+  return ret;
+}
+
+/*------------------------------------------------------*/
+/* Cdada queuing Functions */
+/*------------------------------------------------------*/
+// A utility function to create a node
+struct QNode *newNode(void *buf, size_t buf_len)
 {
   struct QNode *temp = (struct QNode *)malloc(sizeof(struct QNode));
-  temp->key = k;
-  temp->key_len = k_len;
+  temp->buf = buf;
+  temp->buf_len = buf_len;
   struct timeval current_time;
-  gettimeofday(&current_time, NULL);                                      // Get time in micro second
-  temp->timestamp = current_time.tv_sec * 1000000 + current_time.tv_usec; // Setting the time when redis connects as timestamp for this bmp session
+  gettimeofday(&current_time, NULL);
+  temp->timestamp = current_time.tv_sec * 1000000 + current_time.tv_usec;
   return temp;
 }
 
-// The function to add a key k to q
-void enQueue(cdada_queue_t *ha_data_queue, void *k, size_t k_len)
+// Function to add a key k to a queue
+void enQueue(cdada_queue_t *ha_data_queue, void *buf, size_t buf_len)
 {
-  // Store key,key length and its timestamp in a struct
-  struct QNode *temp = newNode(k, k_len);
+  // Store key, key length and its timestamp in a struct
+  struct QNode *temp = newNode(buf, buf_len);
   cdada_queue_push(ha_data_queue, temp);
 }
 
-void pm_ha_queue_thread_wrapper()
+void bmp_bgp_ha_enqueue(void *avro_buf, size_t avro_buf_len)
 {
-  if (pthread_mutex_init(&bmp_ha_struct.mutex_thr, NULL) || pthread_cond_init(&bmp_ha_struct.sig, NULL)){
-    Log(LOG_ERR, "ERROR ( %s/%s ): mutex_init failed\n", config.name, config.type);
-    return;
-  }
-  pthread_mutex_lock(&bmp_ha_struct.mutex_thr);
-  bmp_ha_data_queue = cdada_queue_create(nodestruct);
-  pthread_mutex_unlock(&bmp_ha_struct.mutex_thr);
-  queue_thread_handler th_hdlr = &pm_ha_countdown_delete;
+  int queue_size;
 
-  dq_pool = allocate_thread_pool(1);
-  send_to_pool(dq_pool, pm_ha_queue_produce_thread, th_hdlr);
-  return;
+  // Prepare buffer void pointer for queuing
+  void *buf_cpy = malloc(avro_buf_len);
+  memcpy(buf_cpy, avro_buf, avro_buf_len);
+
+  // Enqueue the BMP message
+  pthread_mutex_lock(&mutex_queue);
+  enQueue(bmp_bgp_ha_data_queue, buf_cpy, avro_buf_len);
+  queue_size = cdada_queue_size(bmp_bgp_ha_data_queue);
+  pthread_mutex_unlock(&mutex_queue);
+
+  Log(LOG_DEBUG, "DEBUG ( %s/%s/ha ): BMP-BGP-HA - put data into queue. Queue size:%d.\n", config.name, config.type, queue_size);
 }
 
-int pm_ha_queue_produce_thread(void *qh)
+/*-------------------------------------------------------------------------------*/
+/* Thread 1: initialize queue and mutex + pop old messages */
+/*-------------------------------------------------------------------------------*/
+int bmp_bgp_ha_queue_pop(void *qh)
 {
   for (;;){
-    pm_ha_countdown_delete();
+    sleep(2);
+
+    long long timestamp;
+    struct timeval current_time;
+    nodestruct nodes;
+    gettimeofday(&current_time, NULL);                                
+    timestamp = current_time.tv_sec * 1000000 + current_time.tv_usec;
+  
+    pthread_mutex_lock(&mutex_queue);
+    cdada_queue_front(bmp_bgp_ha_data_queue, &nodes);
+
+    while (!cdada_queue_empty(bmp_bgp_ha_data_queue) && (timestamp - nodes.timestamp > QUEUE_POP_THRESHOLD) && !queue_dumping) {
+    
+      // Pop queue entries older than QUEUE_POP_THRESHOLD
+      cdada_queue_pop(bmp_bgp_ha_data_queue);
+
+      int check_flag = !cdada_queue_empty(bmp_bgp_ha_data_queue) & (timestamp - nodes.timestamp > QUEUE_POP_THRESHOLD);
+      Log(LOG_DEBUG, "DEBUG ( %s/%s/ha ): BMP-BGP-HA-MGMT-%d - delete one from queue (check=%d). Queue size: %d\n", 
+            config.name, config.type, bmp_bgp_forwarding, check_flag, cdada_queue_size(bmp_bgp_ha_data_queue));
+    
+      cdada_queue_front(bmp_bgp_ha_data_queue, &nodes);
+    }
+    pthread_mutex_unlock(&mutex_queue);
   }
   return SUCCESS;
 }
 
-void pm_ha_countdown_delete()
+void bmp_bgp_ha_queue_mgmt_thread_wrapper(void)
 {
-  sleep(2); // per two second
-  long long timestamp;
-  struct timeval current_time;
-  nodestruct nodes;
-  gettimeofday(&current_time, NULL);                                // Get time in micro second
-  timestamp = current_time.tv_sec * 1000000 + current_time.tv_usec; // Setting the time when redis connects as timestamp for this bmp session
-  pthread_mutex_lock(&bmp_ha_struct.mutex_thr);
-  int flag = cdada_queue_empty(bmp_ha_data_queue) ? 0 : 1;
-  pthread_mutex_unlock(&bmp_ha_struct.mutex_thr);
-  if (flag){
-    pthread_mutex_lock(&bmp_ha_struct.mutex_thr);
-    pthread_cond_wait(&bmp_ha_struct.sig, &bmp_ha_struct.mutex_thr);
-    cdada_queue_front(bmp_ha_data_queue, &nodes);
-    // while the data in the queue is expired by 2s
-    while (cdada_queue_size(bmp_ha_data_queue) && (timestamp - nodes.timestamp > 5000000) && !bmp_ha_struct.queue_dump_flag){
-      cdada_queue_pop(bmp_ha_data_queue);
-      Log(LOG_DEBUG, "DEBUG ( %s/%s ): Delete one from queue: %d %d %d %d \n", config.type, config.name, cdada_queue_size(bmp_ha_data_queue), !cdada_queue_empty(bmp_ha_data_queue), (timestamp - nodes.timestamp > 5000000), !bmp_ha_struct.queue_dump_flag);
-      cdada_queue_front(bmp_ha_data_queue, &nodes);
-    }
-    pthread_mutex_unlock(&bmp_ha_struct.mutex_thr);
+  // Initialize mutex (needed for accessing queue, as libcdada is not thread safe)
+  if (pthread_mutex_init(&mutex_queue, NULL)){
+    Log(LOG_ERR, "ERROR ( %s/%s/ha ): BMP-BGP-HA mutex_init failed\n", config.name, config.type);
+    return;
+  }
+  pthread_mutex_lock(&mutex_queue);
+  bmp_bgp_ha_data_queue = cdada_queue_create(nodestruct);
+  pthread_mutex_unlock(&mutex_queue);
+
+  bmp_bgp_ha_queue_mgmt_pool = allocate_thread_pool(1);
+  assert(bmp_bgp_ha_queue_mgmt_pool);
+  Log(LOG_DEBUG, "DEBUG ( %s/%s/ha ): BMP-BGP-HA - %d queue-mgmt thread initialized\n", config.name, config.type, 1);
+  send_to_pool(bmp_bgp_ha_queue_mgmt_pool, bmp_bgp_ha_queue_pop, NULL);
+}
+
+
+/*-------------------------------------------------------------------------------*/
+/* Thread 2: dump the queue to kafka if daemon goes from stand-by to active */
+/*-------------------------------------------------------------------------------*/
+void bmp_bgp_ha_queue_dump_thread_wrapper(void)
+{
+  // Initialize threads pool
+  bmp_bgp_ha_queue_dump_pool = allocate_thread_pool(1);
+  assert(bmp_bgp_ha_queue_dump_pool);
+  Log(LOG_DEBUG, "DEBUG ( %s/%s/ha ): BMP-BGP-HA -  %d queue-dump thread initialized\n", config.name, config.type, 1);
+}
+
+int bmp_bgp_ha_queue_dump(void)
+{
+  queue_dumping = TRUE;
+  nodestruct dequeued_node;
+
+  // Init Kafka host
+  bmp_bgp_ha_msglog_init_kafka_host();
+  int kafka_produce_ret;
+
+  pthread_mutex_lock(&mutex_queue);
+  cdada_queue_front(bmp_bgp_ha_data_queue, &dequeued_node);
+  uint32_t queue_size = cdada_queue_size(bmp_bgp_ha_data_queue);
+
+  while (queue_size)
+  {
+    kafka_produce_ret = write_binary_kafka(&kafka_host, dequeued_node.buf, dequeued_node.buf_len);
+    Log(LOG_DEBUG, "DEBUG ( %s/%s/ha ): BMP-BGP-HA-%d - Producing message #%d from the queue. Kafka ret (0=OK):%d\n", 
+                    config.name, config.type, bmp_bgp_forwarding, queue_size, kafka_produce_ret);
+
+    // Pop the produced node from the queue
+    cdada_queue_pop(bmp_bgp_ha_data_queue); 
+    if (!cdada_queue_empty(bmp_bgp_ha_data_queue))
+      cdada_queue_front(bmp_bgp_ha_data_queue, &dequeued_node);
+    queue_size = cdada_queue_size(bmp_bgp_ha_data_queue);
   }
 
-  return;
+  pthread_mutex_unlock(&mutex_queue);
+  Log(LOG_DEBUG, "DEBUG ( %s/%s/ha ): BMP-BGP-HA-%d - Finished producing messages - queue empty.\n", 
+            config.name, config.type, bmp_bgp_forwarding);
+
+  // Close kafka host
+  p_kafka_close(&kafka_host, FALSE);
+
+  queue_dumping = FALSE;
+  return SUCCESS;
+}
+
+void bmp_bgp_ha_queue_dump_start(void)
+{
+  send_to_pool(bmp_bgp_ha_queue_dump_pool, bmp_bgp_ha_queue_dump, NULL);
+}
+
+
+/*------------------------------------------------------*/
+/* Redis Handler and Functions */
+/*------------------------------------------------------*/
+/* Returns TRUE if active, FALSE if stand-by. */
+bool bmp_bgp_ha_redis_check_daemon_state(struct p_redis_host *redis_host)
+{ 
+  struct p_redis_keys bmp_bgp_ha_redis_keys = {.keys_amount = 0};
+  char timestamp_redis[SHORTBUFLEN];
+  
+  // Get all available keys storing bmp_bgp_ha timestamps from redis
+  char keys_regex[SRVBUFLEN];
+  snprintf(keys_regex, sizeof(keys_regex), "%s%s%d%s%s%s", config.cluster_name, PM_REDIS_DEFAULT_SEP, 
+            config.cluster_id, PM_REDIS_DEFAULT_SEP, "*", redis_key_id_string);
+  p_redis_get_keys(redis_host, keys_regex, &bmp_bgp_ha_redis_keys);
+  
+  // Get timestamps and compare to local
+  for (int i = 0; i < bmp_bgp_ha_redis_keys.keys_amount; i++)
+  {
+    p_redis_get_string(redis_host, bmp_bgp_ha_redis_keys.keys[i], timestamp_redis);
+    if ( (strtoll(timestamp_redis, NULL, 0)) < (strtoll(timestamp_local, NULL, 0)) ) return FALSE;    // return FALSE if there is a smaller timestamp
+    else if ( (strtoll(timestamp_redis, NULL, 0)) == (strtoll(timestamp_local, NULL, 0)) ) continue;  // current daemon's timestamp
+  }
+  
+  return TRUE;
+}
+
+/* Main loop */
+void p_redis_thread_bmp_bgp_ha_handler(void *rh)
+{
+  struct p_redis_host *redis_host = rh;
+
+  // Initialize the local timestamp (only at first loop/daemon startup)
+  if (redis_loop_num == 1) {
+    Log(LOG_INFO, "INFO ( %s/%s/ha/redis ): BMP-BGP-HA - Redis connection successful\n", config.name, config.type);
+    struct timeval current_time;
+    gettimeofday(&current_time, NULL);
+    snprintf(timestamp_local, sizeof(timestamp_local), "%ld", current_time.tv_sec * 1000000 + current_time.tv_usec);
+    Log(LOG_DEBUG, "DEBUG ( %s/%s/ha/redis ): BMP-BGP-HA - Daemon startup timestamp=%s\n", config.name, config.type, timestamp_local);
+  }
+
+  // Refresh the local timestamp if the regenerate_timestamp flag is set
+  if (regenerate_timestamp){
+    struct timeval current_time;
+    gettimeofday(&current_time, NULL);
+    snprintf(timestamp_local, sizeof(timestamp_local), "%ld", current_time.tv_sec * 1000000 + current_time.tv_usec);
+    regenerate_timestamp = FALSE;
+  }
+
+  // Write the local timestamp to redis
+  snprintf(redis_local_key, sizeof(redis_local_key), "%s%s%s", config.name, PM_REDIS_DEFAULT_SEP, redis_key_id_string);
+  p_redis_set_string(redis_host, redis_local_key, timestamp_local, PM_REDIS_DEFAULT_EXP_TIME);
+
+  // Refresh daemon state based on timestamp
+  if (!forced_mode) daemon_state = bmp_bgp_ha_redis_check_daemon_state(redis_host);
+
+  // Set global flag [pmacct-globals.c] according to current daemon state 
+  bmp_bgp_forwarding = daemon_state | queue_dumping;  // prevent going stand-by if dumping
+  if (queue_dumping && !daemon_state) { 
+    Log(LOG_INFO, "DEBUG ( %s/%s/ha/redis ): BMP-BGP-HA Thread is dumping the queue: waiting before going stand-by...\n", config.name, config.type);
+  }
+
+  // Dump the queue when daemon becomes active and this is not the first connection
+  if ( (bmp_bgp_forwarding && !old_bmp_bgp_forwarding) && redis_loop_num != 1 ){
+    bmp_bgp_ha_queue_dump_start();
+  }
+
+  // Write the current collector status to Log on state change
+  if ((bmp_bgp_forwarding != old_bmp_bgp_forwarding) || redis_loop_num == 1) {
+    Log(LOG_INFO, "INFO ( %s/%s/ha/redis ): BMP-BGP-HA Daemon state: %s\n", config.name, config.type, (bmp_bgp_forwarding ? "ACTIVE" : "STANDBY"));
+  }
+
+  // Update loop variables
+  old_bmp_bgp_forwarding = bmp_bgp_forwarding;
+  redis_loop_num++;
+  redis_loop_num = redis_loop_num % 62 + 2;           // result in range[2, 62]
+
+  // Redirect to redis common handler
+  p_redis_thread_produce_common_core_handler(redis_host);
+}
+
+
+/*-------------------------------------------------------------------------------*/
+/* Signal handlers */
+/*-------------------------------------------------------------------------------*/
+void bmp_bgp_ha_regenerate_timestamp(int signum){
+  regenerate_timestamp = TRUE;
+  Log(LOG_INFO, "INFO ( %s/%s/ha ) : BMP-BGP-HA: Local startup timestamp reset triggered.\n", config.name, config.type);
+  if (forced_mode) Log(LOG_INFO, "INFO ( %s/%s/ha/redis ): BMP-BGP-HA Daemon is in forced-mode (%s): startup timestamp has no influence on state!\n", 
+                        config.name, config.type, (bmp_bgp_forwarding ? "ACTIVE" : "STANDBY"));
+}
+
+void bmp_bgp_ha_set_to_active(int signum){
+  forced_mode = TRUE;
+  daemon_state = TRUE;
+  Log(LOG_INFO, "INFO ( %s/%s/ha ) : BMP-BGP-HA: Setting daemon to forced-active state.\n", config.name, config.type);
+}
+
+void bmp_bgp_ha_set_to_standby(int signum){
+  forced_mode = TRUE;
+  daemon_state = FALSE;
+  Log(LOG_INFO, "INFO ( %s/%s/ha ) : BMP-BGP-HA: Setting daemon to forced-standby state.\n", config.name, config.type);
+}
+
+void bmp_bgp_ha_set_to_normal(int signum){
+  if (forced_mode) Log(LOG_INFO, "INFO ( %s/%s/ha ) : BMP-BGP-HA: Setting daemon back to automatic timestamp-based mode.\n", config.name, config.type);
+  else Log(LOG_INFO, "INFO ( %s/%s/ha ) : BMP-BGP-HA: Daemon is already in automatic timestamp-based mode (%s).\n", 
+           config.name, config.type, (bmp_bgp_forwarding ? "ACTIVE" : "STANDBY"));
+  forced_mode = FALSE;
+}
+
+/*-------------------------------------------------------------------------------*/
+/* Main Function - called from core [nfacctd.c] */
+/*-------------------------------------------------------------------------------*/
+void bmp_bgp_ha_main(void){
+
+    // Thread 1: initialize the queue+mutex_queue and pops old messages
+    bmp_bgp_ha_queue_mgmt_thread_wrapper();
+      
+    // Thread 2: dump the queue if the daemon goes from stand-by to active
+    bmp_bgp_ha_queue_dump_thread_wrapper();
 }

--- a/src/ha.h
+++ b/src/ha.h
@@ -22,21 +22,25 @@
 #ifndef HA_H
 #define HA_H
 
-/*Global variables*/
-typedef void (*queue_thread_handler)();
+/* Defines [in microseconds] for how long messages will be kept in the queue*/
+#define QUEUE_POP_THRESHOLD 10000000LL  // 10s
 
-// A linked list (LL) node to store a queue entry
-typedef struct QNode
-{
-    void *key; //Data
-    size_t key_len; //Data length
+/*Linked list (LL) node to store a queue entry*/
+typedef struct QNode {
+    void *buf;
+    size_t buf_len;
     long long timestamp;
-}nodestruct;
+} nodestruct;
 
-/*Functions*/
-extern void pm_ha_countdown_delete();
-extern void pm_ha_queue_thread_wrapper();
-extern int pm_ha_queue_produce_thread(void *);
-extern void enQueue(cdada_queue_t*, void *, size_t);
+/*Global Functions*/
+extern void bmp_bgp_ha_enqueue(void *, size_t);
+extern void p_redis_thread_bmp_bgp_ha_handler(void *);
+extern void bmp_bgp_ha_main(void);
 
-#endif //HA_H
+/*Signal handlers*/
+extern void bmp_bgp_ha_regenerate_timestamp(int);
+extern void bmp_bgp_ha_set_to_active(int);
+extern void bmp_bgp_ha_set_to_standby(int);
+extern void bmp_bgp_ha_set_to_normal(int);
+
+#endif

--- a/src/pmacct-globals.c
+++ b/src/pmacct-globals.c
@@ -47,12 +47,9 @@ struct pm_pcap_devices devices, bkp_devices;
 struct pm_pcap_interfaces pm_pcap_if_map, pm_bkp_pcap_if_map;
 struct pcap_stat ps;
 struct sigaction sighandler_action;
+int bmp_bgp_forwarding = TRUE; /* flag used by BGP-BMP-HA feature if enabled */
 
 int protocols_number;
-
-/* XXX: to be moved away: tmp_bmp_daemon_ha stuff */
-struct bmp_ha bmp_ha_struct;
-cdada_queue_t *bmp_ha_data_queue;
 
 u_int32_t PdataSz, ChBufHdrSz, CharPtrSz, CounterSz, HostAddrSz;
 u_int32_t PpayloadSz, PextrasSz, PmsgSz, PvhdrSz, PtLabelTSz;

--- a/src/pmacct.h
+++ b/src/pmacct.h
@@ -233,7 +233,6 @@ typedef struct {
 #endif
 #endif
 
-#include "ha.h"
 #ifdef WITH_REDIS
 #include "redis_common.h"
 #endif
@@ -367,19 +366,6 @@ struct child_ctl2 {
   u_int32_t flags;
 };
 
-/* XXX: to be moved away: tmp_bmp_daemon_ha stuff: the group of
-   global variables used for BMP High Availability feature */
-struct bmp_ha {
-  int set_to_active_flag; //Send signal 35 to set this flag, force setting daemon state as active 
-  int set_to_standby_flag; //Send signal 36 to set this flag, force setting daemon state as standby
-  int regenerate_timestamp_flag; //Send signal 34 to set this flag, refresh daemon's timestamp
-  bool dump_flag; //Telling daemon whether to dump BMP message or not
-  bool queue_dump_flag;//If the message is not to be dumped, telling daemon whether the message needs to be put in the queue
-  pthread_mutex_t mutex_thr; //Mutex for locking the queue
-  pthread_cond_t sig; //cond variable to notify freeing mutex_thr
-  pthread_mutex_t mutex_rd; //Mutex for locking bmp_ha global variable
-};
-
 #define INIT_BUF(x) \
 	memset(x.base, 0, sizeof(x.base)); \
 	x.end = x.base+sizeof(x.base); \
@@ -433,13 +419,6 @@ extern void PM_evaluate_flow_type(struct packet_ptrs *);
 extern ssize_t recvfrom_savefile(struct pm_pcap_device *, void **, struct sockaddr *, struct timeval **, int *, struct packet_ptrs *);
 extern ssize_t recvfrom_rawip(unsigned char *, size_t, struct sockaddr *, struct packet_ptrs *);
 
-#ifdef WITH_REDIS
-void pm_ha_re_generate_timestamp(int);
-void pm_ha_set_to_active(int);
-void pm_ha_set_to_standby(int);
-void pm_ha_set_to_normal(int);
-#endif
-
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *, const char *, size_t);
 #endif
@@ -480,6 +459,7 @@ extern struct pm_pcap_devices devices, bkp_devices;
 extern struct pm_pcap_interfaces pm_pcap_if_map, pm_bkp_pcap_if_map;
 extern struct pcap_stat ps;
 extern struct sigaction sighandler_action;
+extern int bmp_bgp_forwarding;  /* flag used by BGP-BMP-HA feature if enabled */
 
 extern char pmacctd_globstr[];
 extern char nfacctd_globstr[];
@@ -488,8 +468,5 @@ extern char uacctd_globstr[];
 extern char pmtele_globstr[];
 extern char pmbgpd_globstr[];
 extern char pmbmpd_globstr[];
-
-extern struct bmp_ha bmp_ha_struct;
-extern cdada_queue_t *bmp_ha_data_queue;
 
 #endif /* _PMACCT_H_ */

--- a/src/redis_common.h
+++ b/src/redis_common.h
@@ -43,6 +43,11 @@ struct p_redis_host {
   redisReply *reply;
 };
 
+struct p_redis_keys {
+  char keys[SHORTBUFLEN][SHORTBUFLEN];
+  int keys_amount;
+};
+
 /* prototypes */
 extern void p_redis_thread_wrapper(struct p_redis_host *);
 extern int p_redis_master_produce_thread(void *);
@@ -58,11 +63,11 @@ extern void p_redis_set_exp_time(struct p_redis_host *, int);
 extern void p_redis_set_thread_handler(struct p_redis_host *, redis_thread_handler);
 
 extern void p_redis_set_string(struct p_redis_host *, char *, char *, int);
+extern void p_redis_get_string(struct p_redis_host *, char *, char *);
+extern void p_redis_get_keys(struct p_redis_host *, char *, struct p_redis_keys *);
 extern void p_redis_set_int(struct p_redis_host *, char *, int, int);
 extern void p_redis_ping(struct p_redis_host *);
 extern void p_redis_select_db(struct p_redis_host *);
 
 extern void p_redis_thread_produce_common_core_handler(void *);
 extern void p_redis_thread_produce_common_plugin_handler(void *);
-
-extern bool p_redis_get_time(struct p_redis_host *);

--- a/src/signals.c
+++ b/src/signals.c
@@ -241,35 +241,3 @@ void reload_maps(int signum)
     signal_kittens(signum, TRUE);
   }
 }
-
-#ifdef WITH_REDIS
-void pm_ha_re_generate_timestamp(int signum)
-{
-  if (config.redis_host)
-  {
-    bmp_ha_struct.regenerate_timestamp_flag = true;
-    Log(LOG_INFO, "INFO(%s/%s) : Timestamp reset\n", config.name, config.type);
-  }
-}
-
-void pm_ha_set_to_active(int signum)
-{
-  bmp_ha_struct.set_to_standby_flag = false;
-  bmp_ha_struct.set_to_active_flag = true;
-  Log(LOG_INFO, "INFO(%s/%s) : Setting %s as active\n", config.name, config.type, config.name);
-}
-
-void pm_ha_set_to_standby(int signum)
-{
-  bmp_ha_struct.set_to_standby_flag = true;
-  bmp_ha_struct.set_to_active_flag = false;
-  Log(LOG_INFO, "INFO(%s/%s) : Setting %s as standby\n", config.name, config.type, config.name);
-}
-
-void pm_ha_set_to_normal(int signum)
-{
-  bmp_ha_struct.set_to_standby_flag = false;
-  bmp_ha_struct.set_to_active_flag = false;
-  Log(LOG_INFO, "INFO(%s/%s) : Setting %s back to normal state\n", config.name, config.type, config.name);
-}
-#endif


### PR DESCRIPTION
### Summary
The aim of this PR is to review, refactor and better organize the BMP high-availability code added to nfacctd with PR #630. In the process, the feature was extended to support also BGP. Now high-availability is supported by both nfacctd+bmp and nfacctd+bgp.

### Changes
- code generalized, removed from kafka_common.[ch], redis_common.[ch] and centralized in ha.[ch]
- state switching and queue management logic revisited
- injection points for BMP/BGP message queuing moved to bmp_logdump.c/bgp_logdump.c and driven by global flag in pmacct-globals.c (bmp_bgp_forwarding)
- periodic BMP/BGP table dump is blocked if daemon is in stand-by mode (without queuing)
- documentation (docs/README_BMP_HA.md) updated and extended

### Checklist
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
