### PR TITLE
Remove config handler check preventing sub-minute historical time bins

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1348,11 +1348,9 @@ DESC:		Enables historical accounting by placing accounted data into configurable
 		which counters are accumulated. See also *_history_roundoff'. In nfacctd, where a flow
 		can span across multiple time-bins, flow counters can be pro-rated (seconds timestamp
 		resolution) over involved the time-bins by setting nfacctd_pro_rating to true. 
-		The end net effect of this directive is the same as time slots in a RRD file. When
-		expressing time in seconds, time must be minute-aligned (ie. 60 secs or multiples),
-		effectively making the currently supported minumum time-bin value 1 minute. Examples of
-		of values are: '300s' or '5m' - five minutes, '3600s' or '1h' - one hour, '14400s' or
-		'4h' - four hours, '86400s' or '1d' - one day, '1w' - one week, '1M' - one month).
+		The end net effect of this directive is the same as time slots in a RRD file. Examples of
+		valid values are: '15s' - 15 seconds, '300s' or '5m' - five minutes, '3600s' or '1h' - one hour,
+		'14400s' or '4h' - four hours, '86400s' or '1d' - one day, '1w' - one week, '1M' - one month).
 DEFAULT:	none
 
 KEY:            [ sql_history_offset | print_history_offset | amqp_history_offset | kafka_history_offset ]

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -6625,16 +6625,6 @@ void parse_time(char *filename, char *value, int *mu, int *howmany)
 
   k = atoi(value);
   if (k > 0) {
-    if (*mu == COUNT_SECONDLY) {
-      if (k % 60) {
-        Log(LOG_WARNING, "WARN: [%s] Ignoring invalid time value: %d (residual secs afters conversion in mins)\n", filename, k);
-        goto exit_lane;
-      }
-      else {
-        k = k / 60;
-        *mu = COUNT_MINUTELY;
-      }
-    }
     *howmany = k;
   }
   else {


### PR DESCRIPTION
### Short description
Per #661 I tested this patch and was able to confirm that sub 1 minute time bins are possible by removing the config handler conditional that checks that `_history` seconds passed must be multiples of 60 with no remainder.

This was validated using the print plugin to ease testing (docker environment) but should be applicable to other output plugins (kafka, etc.):

```
!
print_output_file[raw]: /tmp/sfacctd-%s.json
print_output[raw]: json
print_history[raw]: 15s
print_refresh_time[raw]: 15
!
```

Example output between two 15 second time bins and sending the same sflow sample a number of times between each window:

```
root@929c3e7fcf3b:/tmp# cat sfacctd-1675797120.json
{"event_type": "purge", "as_src": 0, "as_dst": 65000, "peer_ip_src": "203.0.113.0", "iface_in": 5, "iface_out": 33, "ip_src": "167.82.239.60", "net_src": "0.0.0.0", "ip_dst": "203.0.113.20", "net_dst": "203.0.113.0", "mask_src": 0, "mask_dst": 24, "port_src": 2515, "port_dst": 56560, "ip_proto": "tcp", "sampling_rate": 32768, "mpls_label_top": 0, "stamp_inserted": "2023-02-07 19:12:00", "stamp_updated": "2023-02-07 19:12:16", "packets": 7, "bytes": 490}
root@929c3e7fcf3b:/tmp#
root@929c3e7fcf3b:/tmp# cat sfacctd-1675797135.json
{"event_type": "purge", "as_src": 0, "as_dst": 65000, "peer_ip_src": "203.0.113.0", "iface_in": 5, "iface_out": 33, "ip_src": "167.82.239.60", "net_src": "0.0.0.0", "ip_dst": "203.0.113.20", "net_dst": "203.0.113.0", "mask_src": 0, "mask_dst": 24, "port_src": 2515, "port_dst": 56560, "ip_proto": "tcp", "sampling_rate": 32768, "mpls_label_top": 0, "stamp_inserted": "2023-02-07 19:12:15", "stamp_updated": "2023-02-07 19:12:31", "packets": 8, "bytes": 560}
```

We see two bins, `2023-02-07 19:12:00` and `2023-02-07 19:12:15` as expected with this configuration.


### Checklist

I have:
- [ x ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [ x ] compiled & tested this code
- [ x ] included documentation (including possible behaviour changes)
