### PR TITLE
adding support for sampling_rate calculation with IE309 and IE310

### DIFF
--- a/src/nfv9_template.h
+++ b/src/nfv9_template.h
@@ -196,6 +196,8 @@
 #define NF9_SELECTOR_ALGORITHM          304
 #define NF9_SAMPLING_PKT_INTERVAL       305
 #define NF9_SAMPLING_PKT_SPACE          306
+#define NF9_SAMPLING_SIZE               309
+#define NF9_SAMPLING_POPULATION         310
 
 /* Classification */
 #define NF9_APPLICATION_DESC            94

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -3217,7 +3217,7 @@ void NF_sampling_rate_handler(struct channels_list_entry *chptr, struct packet_p
     switch (hdr->version) {
     case 10:
     case 9:
-      if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len || tpl->tpl[NF9_SELECTOR_ID].len == 8) {
+      if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len || tpl->tpl[NF9_SELECTOR_ID].len) {
         if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len == 1) {
           memcpy(&t8, pptrs->f_data+tpl->tpl[NF9_FLOW_SAMPLER_ID].off, 1);
           sampler_id = t8;
@@ -3228,6 +3228,14 @@ void NF_sampling_rate_handler(struct channels_list_entry *chptr, struct packet_p
         }
         else if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len == 4) {
           memcpy(&t32, pptrs->f_data+tpl->tpl[NF9_FLOW_SAMPLER_ID].off, 4);
+          sampler_id = ntohl(t32);
+        }
+        else if (tpl->tpl[NF9_SELECTOR_ID].len == 2) {
+          memcpy(&t16, pptrs->f_data+tpl->tpl[NF9_SELECTOR_ID].off, 2);
+          sampler_id = ntohs(t16);
+        }
+        else if (tpl->tpl[NF9_SELECTOR_ID].len == 4) {
+          memcpy(&t32, pptrs->f_data+tpl->tpl[NF9_SELECTOR_ID].off, 4);
           sampler_id = ntohl(t32);
         }
         else if (tpl->tpl[NF9_SELECTOR_ID].len == 8) {
@@ -4228,7 +4236,7 @@ void NF_counters_renormalize_handler(struct channels_list_entry *chptr, struct p
   switch (hdr->version) {
   case 10:
   case 9:
-    if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len || tpl->tpl[NF9_SELECTOR_ID].len == 8) {
+    if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len || tpl->tpl[NF9_SELECTOR_ID].len) {
       if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len == 1) {
         memcpy(&t8, pptrs->f_data+tpl->tpl[NF9_FLOW_SAMPLER_ID].off, 1);
         sampler_id = t8;
@@ -4239,6 +4247,14 @@ void NF_counters_renormalize_handler(struct channels_list_entry *chptr, struct p
       }
       else if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len == 4) {
         memcpy(&t32, pptrs->f_data+tpl->tpl[NF9_FLOW_SAMPLER_ID].off, 4);
+        sampler_id = ntohl(t32);
+      }
+      else if (tpl->tpl[NF9_SELECTOR_ID].len == 2) {
+        memcpy(&t16, pptrs->f_data+tpl->tpl[NF9_SELECTOR_ID].off, 2);
+        sampler_id = ntohs(t16);
+      }
+      else if (tpl->tpl[NF9_SELECTOR_ID].len == 4) {
+        memcpy(&t32, pptrs->f_data+tpl->tpl[NF9_SELECTOR_ID].off, 4);
         sampler_id = ntohl(t32);
       }
       else if (tpl->tpl[NF9_SELECTOR_ID].len == 8) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR extends support for sampling rate calculation based on IANA entities IE309 (samplingSize) and IE310 (samplingPopulation), which are being exported in IPFIX sampling options for a random-n-out-of-N sampler.
This is aligned with: https://www.rfc-editor.org/rfc/rfc5477.html#section-8.2.1

Additionally, support for 16-bit and 32-bit selectorID is added as well. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
