### PR TITLE
Fix clang 15 build error: passing arguments to 'set_net_funcs' without a prototype is deprecated

### DIFF
--- a/src/net_aggr.h
+++ b/src/net_aggr.h
@@ -91,7 +91,7 @@ struct networks_file_data {
 typedef void (*net_func) (struct networks_table *, struct networks_cache *, struct pkt_primitives *, struct pkt_bgp_primitives *, struct networks_file_data *);
 
 /* prototypes */
-extern void set_net_funcs();
+extern void set_net_funcs(struct networks_table *);
 extern void init_net_funcs(struct networks_table *, struct networks_cache *, struct pkt_primitives *, struct pkt_bgp_primitives *, struct networks_file_data *); 
 extern void mask_src_ipaddr(struct networks_table *, struct networks_cache *, struct pkt_primitives *, struct pkt_bgp_primitives *, struct networks_file_data *); 
 extern void mask_dst_ipaddr(struct networks_table *, struct networks_cache *, struct pkt_primitives *, struct pkt_bgp_primitives *, struct networks_file_data *); 


### PR DESCRIPTION
nfprobe_plugin.c:1521:16: error: passing arguments to 'set_net_funcs' without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]

### Short description
Building with clang 15 generate error:

nfprobe_plugin.c:1521:16: error: passing arguments to 'set_net_funcs' without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
  set_net_funcs(&nt);

