### PR TITLE
add support for IPFIX v10 MPLS_RD options

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -1821,9 +1821,9 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
   pptrs->f_header = pkt;
   pkt += HdrSz;
   off += HdrSz; 
-  pptrsv->v4.f_status = (u_char *) nfv9_check_status(pptrs, SourceId, 0, FlowSeq, TRUE);
+  pptrsv->v4.f_status = (u_char *) nfv9_check_status(pptrs, SourceId, 0, FlowSeq, TRUE);  /* SCOPE = SourceID / observation_ID */
   set_vector_f_status(pptrsv);
-  pptrsv->v4.f_status_g = (u_char *) nfv9_check_status(pptrs, 0, NF9_OPT_SCOPE_SYSTEM, 0, FALSE);
+  pptrsv->v4.f_status_g = (u_char *) nfv9_check_status(pptrs, 0, NF9_OPT_SCOPE_SYSTEM, 0, FALSE); /* SCOPE = SYSTEM (socket IP address) */
   set_vector_f_status_g(pptrsv);
 
   process_flowset:
@@ -2023,7 +2023,7 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
 
 	/* Is this option about sampling? */
 	if (tpl->tpl[NF9_FLOW_SAMPLER_ID].len || tpl->tpl[NF9_SAMPLING_INTERVAL].len == 4 || 
-      tpl->tpl[NF9_SAMPLING_PKT_INTERVAL].len == 4 || tpl->tpl[NF9_SAMPLING_SIZE].len == 4) {
+            tpl->tpl[NF9_SAMPLING_PKT_INTERVAL].len == 4 || tpl->tpl[NF9_SAMPLING_SIZE].len == 4) {
 	  u_int8_t t8 = 0;
 	  u_int16_t t16 = 0;
 	  u_int32_t sampler_id = 0, t32 = 0, t32_2 = 0;

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -3987,7 +3987,7 @@ void NF_srv6_segment_ipv6_list(struct channels_list_entry *chptr, struct packet_
 
 void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
-  struct xflow_status_entry *entry = (struct xflow_status_entry *) pptrs->f_status_g;
+  struct xflow_status_entry *entry = (struct xflow_status_entry *) pptrs->f_status;
   struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
   struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives); 
@@ -4003,7 +4003,7 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
       memcpy(&direction, pptrs->f_data+tpl->tpl[NF9_DIRECTION].off, MIN(tpl->tpl[NF9_DIRECTION].len, 1));
     }
 
-    if (!pbgp->mpls_vpn_rd.val) {
+    if (!pbgp->mpls_vpn_rd.val) { /* RD was not set with flow2rdmap */
       if (tpl->tpl[NF9_INGRESS_VRFID].len) {
 	memcpy(&ingress_vrfid, pptrs->f_data+tpl->tpl[NF9_INGRESS_VRFID].off, MIN(tpl->tpl[NF9_INGRESS_VRFID].len, 4));
 	ingress_vrfid = ntohl(ingress_vrfid);
@@ -4016,35 +4016,59 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
     }
 
     if (ingress_vrfid && (!direction /* 0 = ingress */ || !egress_vrfid)) {
-      if (entry->in_rd_map) {
+
+      if (entry->in_rd_map) { /* check obsID/srcID scoped xflow_status table */
         ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
 	if (ret == CDADA_SUCCESS) {
 	  memcpy(&pbgp->mpls_vpn_rd, rd, 8);
 	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
 	}
       }
-      else {
-        pbgp->mpls_vpn_rd.val = ingress_vrfid;
-        if (pbgp->mpls_vpn_rd.val) {
-	  pbgp->mpls_vpn_rd.type = RD_TYPE_VRFID;
-	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-	}
+
+      if ( !entry->in_rd_map || ret != CDADA_SUCCESS ) { /* fallback to the global xflow_status table */
+        entry = (struct xflow_status_entry *) pptrs->f_status_g;
+        if (entry->in_rd_map) {
+          ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
+          if (ret == CDADA_SUCCESS) {
+            memcpy(&pbgp->mpls_vpn_rd, rd, 8);
+            bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
+          }
+        }
+        if ( !entry->in_rd_map || ret != CDADA_SUCCESS ) { /* no RD found in option data --> fallback to vrfID:XXX */
+          pbgp->mpls_vpn_rd.val = ingress_vrfid;
+          if (pbgp->mpls_vpn_rd.val) {
+	    pbgp->mpls_vpn_rd.type = RD_TYPE_VRFID;
+	    bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
+	  }
+        }
       }
     }
 
     if (egress_vrfid && (direction /* 1 = egress */ || !ingress_vrfid)) {
-      if (entry->out_rd_map) {
+
+      if (entry->out_rd_map) { /* check obsID/srcID scoped xflow_status table */
         ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
 	if (ret == CDADA_SUCCESS) {
 	  memcpy(&pbgp->mpls_vpn_rd, rd, 8);
 	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
 	}
       }
-      else {
-        pbgp->mpls_vpn_rd.val = egress_vrfid;
-        if (pbgp->mpls_vpn_rd.val) {
-	  pbgp->mpls_vpn_rd.type = RD_TYPE_VRFID;
-	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
+
+      if ( !entry->out_rd_map || ret != CDADA_SUCCESS ) { /* fallback to the global xflow_status table */
+        entry = (struct xflow_status_entry *) pptrs->f_status_g;
+        if (entry->out_rd_map) { 
+          ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
+          if (ret == CDADA_SUCCESS) {
+            memcpy(&pbgp->mpls_vpn_rd, rd, 8);
+            bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
+          }
+        }
+        if ( !entry->out_rd_map || ret != CDADA_SUCCESS ) { /* no RD found in option data --> fallback to vrfID:XXX */
+          pbgp->mpls_vpn_rd.val = egress_vrfid;
+          if (pbgp->mpls_vpn_rd.val) {
+            pbgp->mpls_vpn_rd.type = RD_TYPE_VRFID;
+            bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
+          }
 	}
       }
     }


### PR DESCRIPTION
### Short description
With IPFIX v10 the RD option packets are not SYSTEM-scoped anymore, but instead on ingress/egress_VRFID. This PR extends the option handlers to support those option packets by:

- setting srcID/observationDomainID scoped xflow table as default
- only fallback to the global xflow table if no mapping is found

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
