### PR TITLE
add support for NF9_EXPORTER_IPV[46]_ADDRESS field in the data packets

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -1821,9 +1821,9 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
   pptrs->f_header = pkt;
   pkt += HdrSz;
   off += HdrSz; 
-  pptrsv->v4.f_status = (u_char *) nfv9_check_status(pptrs, SourceId, 0, FlowSeq, TRUE);
+  pptrsv->v4.f_status = (u_char *) nfv9_check_status(pptrs, SourceId, 0, FlowSeq, TRUE);  /* SCOPE = SourceID / observation_ID */
   set_vector_f_status(pptrsv);
-  pptrsv->v4.f_status_g = (u_char *) nfv9_check_status(pptrs, 0, NF9_OPT_SCOPE_SYSTEM, 0, FALSE);
+  pptrsv->v4.f_status_g = (u_char *) nfv9_check_status(pptrs, 0, NF9_OPT_SCOPE_SYSTEM, 0, FALSE); /* SCOPE = SYSTEM (socket IP address) */
   set_vector_f_status_g(pptrsv);
 
   process_flowset:
@@ -2166,6 +2166,7 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
           }
 	}
 
+        /* XXX: this is dangerous, currently does not support multiple exporters behind the same proxy (same socket address). */
 	if (tpl->tpl[NF9_EXPORTER_IPV4_ADDRESS].len == 4 || tpl->tpl[NF9_EXPORTER_IPV6_ADDRESS].len == 16) {
           /* Handling the global option scoping case */
           if (!config.nfacctd_disable_opt_scope_check) {


### PR DESCRIPTION
### Short description
Currently the NF9_EXPORTER_IPV4_ADDRESS and NF9_EXPORTER_IPV6_ADDRESS fields are only supported by nfacctd when they are sent within the option packets. With this PR, support for these fields in the IPFIX data packets is added. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
