### PR TITLE
fix a crash for bgp and bmp when no dump method is configured, fix the dump interval for pmtelemetyd when using time slots

### DIFF
--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -740,22 +740,19 @@ void skinny_bgp_daemon_online()
 	  bgp_peer_log_seq_init(&bgp_misc_db->log_seq);
       }
 
-
-      int refreshTimePerSlot = config.bgp_table_dump_refresh_time / config.bgp_table_dump_time_slots;
       if (bgp_misc_db->dump_backend_methods) {
+        bgp_misc_db->dump.period = config.bgp_table_dump_refresh_time / config.bgp_table_dump_time_slots;
 	while (bgp_misc_db->log_tstamp.tv_sec > dump_refresh_deadline) {
 	  bgp_misc_db->dump.tstamp.tv_sec = dump_refresh_deadline;
 	  bgp_misc_db->dump.tstamp.tv_usec = 0;
 	  compose_timestamp(bgp_misc_db->dump.tstamp_str, SRVBUFLEN, &bgp_misc_db->dump.tstamp, FALSE,
 			    config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
-	  bgp_misc_db->dump.period = refreshTimePerSlot;
 
 	  if (bgp_peer_log_seq_has_ro_bit(&bgp_misc_db->log_seq))
 	    bgp_peer_log_seq_init(&bgp_misc_db->log_seq);
 
 	  bgp_handle_dump_event(max_peers_idx);
-
-	  dump_refresh_deadline += refreshTimePerSlot;
+          dump_refresh_deadline += bgp_misc_db->dump.period;
 	}
       }
 

--- a/src/bmp/bmp.c
+++ b/src/bmp/bmp.c
@@ -696,22 +696,19 @@ int skinny_bmp_daemon()
 	  bgp_peer_log_seq_init(&bmp_misc_db->log_seq);
       }
 
-
-      int refreshTimePerSlot = config.bmp_dump_refresh_time / config.bmp_dump_time_slots;
       if (bmp_misc_db->dump_backend_methods) {
+        bmp_misc_db->dump.period = config.bmp_dump_refresh_time / config.bmp_dump_time_slots;
         while (bmp_misc_db->log_tstamp.tv_sec > dump_refresh_deadline) {
           bmp_misc_db->dump.tstamp.tv_sec = dump_refresh_deadline;
           bmp_misc_db->dump.tstamp.tv_usec = 0;
           compose_timestamp(bmp_misc_db->dump.tstamp_str, SRVBUFLEN, &bmp_misc_db->dump.tstamp, FALSE,
 			    config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
-	  bmp_misc_db->dump.period = refreshTimePerSlot;
 
 	  if (bgp_peer_log_seq_has_ro_bit(&bmp_misc_db->log_seq))
 	    bgp_peer_log_seq_init(&bmp_misc_db->log_seq);
 
           bmp_handle_dump_event(max_peers_idx);
-
-          dump_refresh_deadline += refreshTimePerSlot;
+          dump_refresh_deadline += bmp_misc_db->dump.period;
         }
       }
 

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -720,16 +720,15 @@ int telemetry_daemon(void *t_data_void)
         telemetry_log_seq_init(&telemetry_misc_db->log_seq);
 
       if (telemetry_misc_db->dump_backend_methods) {
+        telemetry_misc_db->dump.period = config.telemetry_dump_refresh_time / config.telemetry_dump_time_slots;
         while (telemetry_misc_db->log_tstamp.tv_sec > dump_refresh_deadline) {
           telemetry_misc_db->dump.tstamp.tv_sec = dump_refresh_deadline;
           telemetry_misc_db->dump.tstamp.tv_usec = 0;
           compose_timestamp(telemetry_misc_db->dump.tstamp_str, SRVBUFLEN, &telemetry_misc_db->dump.tstamp, FALSE,
                             config.timestamps_since_epoch, config.timestamps_rfc3339, config.timestamps_utc);
-          telemetry_misc_db->dump.period = config.telemetry_dump_refresh_time / config.telemetry_dump_time_slots;
 
           telemetry_handle_dump_event(t_data, max_peers_idx);
-
-          dump_refresh_deadline += config.telemetry_dump_refresh_time;
+          dump_refresh_deadline += telemetry_misc_db->dump.period;
         }
       }
 


### PR DESCRIPTION
Avoid the division by zero also for bgp and bmp when no dump method is configured.
Fix the dump interval calculation for pmtelemetryd when time slots are used.
