### PR TITLE
BGP/BMP data structures, enriching the hash function with Route Distinguisher (RD)

### DIFF
--- a/src/bgp/bgp.c
+++ b/src/bgp/bgp.c
@@ -54,7 +54,7 @@ char *std_comm_patterns_to_asn[MAX_BGP_COMM_PATTERNS];
 char *lrg_comm_patterns_to_asn[MAX_BGP_COMM_PATTERNS];
 struct bgp_comm_range peer_src_as_ifrange; 
 struct bgp_comm_range peer_src_as_asrange; 
-u_int32_t (*bgp_route_info_modulo)(struct bgp_peer *, path_id_t *, int);
+u_int32_t (*bgp_route_info_modulo)(struct bgp_peer *, rd_t *, path_id_t *, int);
 struct bgp_rt_structs inter_domain_routing_dbs[FUNC_TYPE_MAX], *bgp_routing_db;
 struct bgp_misc_structs inter_domain_misc_dbs[FUNC_TYPE_MAX], *bgp_misc_db;
 bgp_tag_t bgp_logdump_tag;

--- a/src/bgp/bgp.h
+++ b/src/bgp/bgp.h
@@ -292,7 +292,7 @@ struct bgp_misc_structs {
   int table_per_peer_buckets;
   int table_attr_hash_buckets;
   int table_per_peer_hash;
-  u_int32_t (*route_info_modulo)(struct bgp_peer *, path_id_t *, int);
+  u_int32_t (*route_info_modulo)(struct bgp_peer *, rd_t *, path_id_t *, int);
   struct bgp_peer *(*bgp_lookup_find_peer)(struct sockaddr *, struct xflow_status_entry *, u_int16_t, int);
   int (*bgp_lookup_node_match_cmp)(struct bgp_info *, struct node_match_cmp_term2 *);
 
@@ -416,7 +416,7 @@ extern char *std_comm_patterns_to_asn[MAX_BGP_COMM_PATTERNS];
 extern char *lrg_comm_patterns_to_asn[MAX_BGP_COMM_PATTERNS];
 extern struct bgp_comm_range peer_src_as_ifrange; 
 extern struct bgp_comm_range peer_src_as_asrange; 
-extern u_int32_t (*bgp_route_info_modulo)(struct bgp_peer *, path_id_t *, int);
+extern u_int32_t (*bgp_route_info_modulo)(struct bgp_peer *, rd_t *, path_id_t *, int);
 
 extern struct bgp_rt_structs inter_domain_routing_dbs[FUNC_TYPE_MAX], *bgp_routing_db;
 extern struct bgp_misc_structs inter_domain_misc_dbs[FUNC_TYPE_MAX], *bgp_misc_db;

--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -2062,7 +2062,7 @@ int bgp_table_dump_event_runner(struct pm_dump_runner *pdr)
 	  node = bgp_table_top(peer, table);
 
 	  while (node) {
-	    u_int32_t modulo = bgp_route_info_modulo(peer, NULL, bms->table_per_peer_buckets);
+	    u_int32_t modulo = bgp_route_info_modulo(peer, NULL, NULL, bms->table_per_peer_buckets);
 	    u_int32_t peer_buckets;
 	    struct bgp_info *ri;
 

--- a/src/bgp/bgp_lookup.c
+++ b/src/bgp/bgp_lookup.c
@@ -377,7 +377,7 @@ void bgp_follow_nexthop_lookup(struct packet_ptrs *pptrs, int type)
   }
 
   if (nh_peer) {
-    modulo = bms->route_info_modulo(nh_peer, NULL, bms->table_per_peer_buckets);
+    modulo = bms->route_info_modulo(nh_peer, NULL, NULL, bms->table_per_peer_buckets);
 
     // XXX: to be optimized 
     if (bms->table_per_peer_hash == BGP_ASPATH_HASH_PATHID) modulo_max = bms->table_per_peer_buckets;
@@ -789,14 +789,16 @@ void free_cache_legacy_bgp_primitives(struct cache_legacy_bgp_primitives **c)
   }
 }
 
-u_int32_t bgp_route_info_modulo_pathid(struct bgp_peer *peer, path_id_t *path_id, int per_peer_buckets)
+u_int32_t bgp_route_info_modulo_pathid(struct bgp_peer *peer, rd_t *rd, path_id_t *path_id, int per_peer_buckets)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(peer->type);
   path_id_t local_path_id = 1;
+  u_int16_t local_rd = 0;
 
   if (path_id && *path_id) local_path_id = *path_id;
+  if (rd) local_rd = (rd->type + rd->as + rd->val);
 
-  return (((peer->fd * per_peer_buckets) +
+  return ((((peer->fd + local_rd) * per_peer_buckets) +
           ((local_path_id - 1) % per_peer_buckets)) %
           (bms->table_peer_buckets * per_peer_buckets));
 }

--- a/src/bgp/bgp_lookup.h
+++ b/src/bgp/bgp_lookup.h
@@ -26,7 +26,7 @@
 extern void bgp_srcdst_lookup(struct packet_ptrs *, int);
 extern void bgp_follow_nexthop_lookup(struct packet_ptrs *, int);
 extern struct bgp_peer *bgp_lookup_find_bgp_peer(struct sockaddr *, struct xflow_status_entry *, u_int16_t, int); 
-extern u_int32_t bgp_route_info_modulo_pathid(struct bgp_peer *, path_id_t *, int);
+extern u_int32_t bgp_route_info_modulo_pathid(struct bgp_peer *, rd_t *, path_id_t *, int);
 extern int bgp_lookup_node_match_cmp_bgp(struct bgp_info *, struct node_match_cmp_term2 *);
 extern int bgp_lookup_node_vector_unicast(struct prefix *, struct bgp_peer *, struct bgp_node_vector *);
 

--- a/src/bgp/bgp_msg.c
+++ b/src/bgp/bgp_msg.c
@@ -1369,7 +1369,7 @@ int bgp_process_update(struct bgp_msg_data *bmd, struct prefix *p, void *attr, s
   if (!inter_domain_routing_db || !bms) return ERR;
 
   if (!bms->skip_rib) { 
-    modulo = bms->route_info_modulo(peer, &attr_extra->path_id, bms->table_per_peer_buckets);
+    modulo = bms->route_info_modulo(peer, &attr_extra->rd, &attr_extra->path_id, bms->table_per_peer_buckets);
     route = bgp_node_get(peer, inter_domain_routing_db->rib[afi][safi], p);
 
     /* Check previously received route. */
@@ -1497,7 +1497,7 @@ int bgp_process_withdraw(struct bgp_msg_data *bmd, struct prefix *p, void *attr,
   if (!inter_domain_routing_db || !bms) return ERR;
 
   if (!bms->skip_rib) {
-    modulo = bms->route_info_modulo(peer, &attr_extra->path_id, bms->table_per_peer_buckets);
+    modulo = bms->route_info_modulo(peer, &attr_extra->rd, &attr_extra->path_id, bms->table_per_peer_buckets);
 
     /* Lookup node. */
     route = bgp_node_get(peer, inter_domain_routing_db->rib[afi][safi], p);

--- a/src/bgp/bgp_table.c
+++ b/src/bgp/bgp_table.c
@@ -245,7 +245,7 @@ void bgp_node_vector_debug(struct bgp_node_vector *bnv, struct prefix *p)
 /* Find matched prefix. */
 void
 bgp_node_match (const struct bgp_table *table, struct prefix *p, struct bgp_peer *peer,
-		u_int32_t (*modulo_func)(struct bgp_peer *, path_id_t *, int),
+		u_int32_t (*modulo_func)(struct bgp_peer *, rd_t *, path_id_t *, int),
 		int (*cmp_func)(struct bgp_info *, struct node_match_cmp_term2 *),
 		struct node_match_cmp_term2 *nmct2, struct bgp_node_vector *bnv,
 		struct bgp_node **result_node, struct bgp_info **result_info)
@@ -264,7 +264,7 @@ bgp_node_match (const struct bgp_table *table, struct prefix *p, struct bgp_peer
   if (bms->table_per_peer_hash == BGP_ASPATH_HASH_PATHID) modulo_max = bms->table_per_peer_buckets;
   else modulo_max = 1;
 
-  if (modulo_func) modulo = modulo_func(peer, NULL, modulo_max);
+  if (modulo_func) modulo = modulo_func(peer, nmct2->rd, NULL, modulo_max);
   else modulo = 0;
 
   matched_node = NULL;
@@ -309,7 +309,7 @@ bgp_node_match (const struct bgp_table *table, struct prefix *p, struct bgp_peer
 
 void
 bgp_node_match_ipv4 (const struct bgp_table *table, struct in_addr *addr, struct bgp_peer *peer,
-		     u_int32_t (*modulo_func)(struct bgp_peer *, path_id_t *, int),
+		     u_int32_t (*modulo_func)(struct bgp_peer *, rd_t *, path_id_t *, int),
 		     int (*cmp_func)(struct bgp_info *, struct node_match_cmp_term2 *),
 		     struct node_match_cmp_term2 *nmct2, struct bgp_node_vector *bnv,
 		     struct bgp_node **result_node, struct bgp_info **result_info)
@@ -326,7 +326,7 @@ bgp_node_match_ipv4 (const struct bgp_table *table, struct in_addr *addr, struct
 
 void
 bgp_node_match_ipv6 (const struct bgp_table *table, struct in6_addr *addr, struct bgp_peer *peer,
-		     u_int32_t (*modulo_func)(struct bgp_peer *, path_id_t *, int),
+		     u_int32_t (*modulo_func)(struct bgp_peer *, rd_t *, path_id_t *, int),
 		     int (*cmp_func)(struct bgp_info *, struct node_match_cmp_term2 *),
 		     struct node_match_cmp_term2 *nmct2, struct bgp_node_vector *bnv,
 		     struct bgp_node **result_node, struct bgp_info **result_info)

--- a/src/bgp/bgp_table.h
+++ b/src/bgp/bgp_table.h
@@ -117,17 +117,17 @@ extern struct bgp_node *bgp_node_get (struct bgp_peer *, struct bgp_table *const
 extern struct bgp_node *bgp_lock_node (struct bgp_peer *, struct bgp_node *node);
 extern void bgp_node_vector_debug(struct bgp_node_vector *, struct prefix *);
 extern void bgp_node_match (const struct bgp_table *, struct prefix *, struct bgp_peer *,
-			 u_int32_t (*modulo_func)(struct bgp_peer *, path_id_t *, int),
+			 u_int32_t (*modulo_func)(struct bgp_peer *, rd_t *, path_id_t *, int),
 			 int (*cmp_func)(struct bgp_info *, struct node_match_cmp_term2 *),
 			 struct node_match_cmp_term2 *, struct bgp_node_vector *,
 			 struct bgp_node **result_node, struct bgp_info **result_info);
 extern void bgp_node_match_ipv4 (const struct bgp_table *, struct in_addr *, struct bgp_peer *,
-			      u_int32_t (*modulo_func)(struct bgp_peer *, path_id_t *, int),
+			      u_int32_t (*modulo_func)(struct bgp_peer *, rd_t *,  path_id_t *, int),
 			      int (*cmp_func)(struct bgp_info *, struct node_match_cmp_term2 *),
 			      struct node_match_cmp_term2 *, struct bgp_node_vector *,
 			      struct bgp_node **result_node, struct bgp_info **result_info);
 extern void bgp_node_match_ipv6 (const struct bgp_table *, struct in6_addr *, struct bgp_peer *,
-			      u_int32_t (*modulo_func)(struct bgp_peer *, path_id_t *, int),
+			      u_int32_t (*modulo_func)(struct bgp_peer *, rd_t *, path_id_t *, int),
 			      int (*cmp_func)(struct bgp_info *, struct node_match_cmp_term2 *),
 			      struct node_match_cmp_term2 *, struct bgp_node_vector *,
 			      struct bgp_node **result_node, struct bgp_info **result_info);

--- a/src/bgp/bgp_util.c
+++ b/src/bgp/bgp_util.c
@@ -899,7 +899,7 @@ void bgp_table_info_delete(struct bgp_peer *peer, struct bgp_table *table, afi_t
     struct bgp_info *ri;
     struct bgp_info *ri_next;
 
-    if (bms->route_info_modulo) modulo = bms->route_info_modulo(peer, NULL, bms->table_per_peer_buckets);
+    if (bms->route_info_modulo) modulo = bms->route_info_modulo(peer, NULL, NULL, bms->table_per_peer_buckets);
     else modulo = 0;
 
     for (peer_buckets = 0; peer_buckets < bms->table_per_peer_buckets; peer_buckets++) {

--- a/src/bmp/bmp-globals.c
+++ b/src/bmp/bmp-globals.c
@@ -3,6 +3,6 @@
 #include "bmp.h"
 
 struct bmp_peer *bmp_peers = NULL;
-u_int32_t (*bmp_route_info_modulo)(struct bgp_peer *, path_id_t *, int) = NULL;
+u_int32_t (*bmp_route_info_modulo)(struct bgp_peer *, rd_t *, path_id_t *, int) = NULL;
 struct bgp_rt_structs *bmp_routing_db = NULL;
 struct bgp_misc_structs *bmp_misc_db = NULL;

--- a/src/bmp/bmp.h
+++ b/src/bmp/bmp.h
@@ -394,7 +394,7 @@ extern void bmp_daemon_msglog_prepare_sd_schemas();
 
 /* global variables */
 extern struct bmp_peer *bmp_peers;
-extern u_int32_t (*bmp_route_info_modulo)(struct bgp_peer *, path_id_t *, int);
+extern u_int32_t (*bmp_route_info_modulo)(struct bgp_peer *, rd_t *, path_id_t *, int);
 extern struct bgp_rt_structs *bmp_routing_db;
 extern struct bgp_misc_structs *bmp_misc_db;
 extern bgp_tag_t bmp_logdump_tag;

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -1858,7 +1858,7 @@ int bmp_dump_event_runner(struct pm_dump_runner *pdr)
           node = bgp_table_top(peer, table);
 
           while (node) {
-            u_int32_t modulo = bms->route_info_modulo(peer, NULL, bms->table_per_peer_buckets);
+            u_int32_t modulo = bms->route_info_modulo(peer, NULL, NULL, bms->table_per_peer_buckets);
             u_int32_t peer_buckets;
             struct bgp_info *ri;
 

--- a/src/bmp/bmp_lookup.c
+++ b/src/bmp/bmp_lookup.c
@@ -86,21 +86,23 @@ struct bgp_peer *bgp_lookup_find_bmp_peer(struct sockaddr *sa, struct xflow_stat
   return peer;
 }
 
-u_int32_t bmp_route_info_modulo_pathid(struct bgp_peer *peer, path_id_t *path_id, int per_peer_buckets)
+u_int32_t bmp_route_info_modulo_pathid(struct bgp_peer *peer, rd_t *rd, path_id_t *path_id, int per_peer_buckets)
 {
   struct bgp_misc_structs *bms = bgp_select_misc_db(peer->type);
   struct bmp_peer *bmpp = peer->bmp_se;
   path_id_t local_path_id = 1;
   int fd = 0;
+  u_int16_t local_rd = 0;
 
   if (path_id && *path_id) local_path_id = *path_id;
+  if (rd) local_rd = (rd->type + rd->as + rd->val);
 
   if (peer->fd) fd = peer->fd;
   else {
     if (bmpp && bmpp->self.fd) fd = bmpp->self.fd;
   }
 
-  return (((fd * per_peer_buckets) +
+  return ((((fd + local_rd) * per_peer_buckets) +
           ((local_path_id - 1) % per_peer_buckets)) %
           (bms->table_peer_buckets * per_peer_buckets));
 }

--- a/src/bmp/bmp_lookup.h
+++ b/src/bmp/bmp_lookup.h
@@ -29,7 +29,7 @@
 /* prototypes */
 extern void bmp_srcdst_lookup(struct packet_ptrs *);
 extern struct bgp_peer *bgp_lookup_find_bmp_peer(struct sockaddr *, struct xflow_status_entry *, u_int16_t, int);
-extern u_int32_t bmp_route_info_modulo_pathid(struct bgp_peer *, path_id_t *, int);
+extern u_int32_t bmp_route_info_modulo_pathid(struct bgp_peer *, rd_t *, path_id_t *, int);
 extern int bgp_lookup_node_match_cmp_bmp(struct bgp_info *, struct node_match_cmp_term2 *);
 
 #endif //BMP_LOOKUP_H


### PR DESCRIPTION
### Summary 

Within the context of BGP/BMP data structures,  the main aim of this PR is to enrich the hash function with a new hash parameter, the Route Distinguisher (RD), in order to minimize the number of collisions. It is crucial to have an efficient hash-table in order to perform data correlation between BGP/BMP & IPFIX(\*).

#### pmacct offers mainly two configuration options to pre-allocate the number of hash-table's buckets
```TEXT
1. bgp_table_per_peer_buckets | bmp_table_per_peer_buckets [1 - 128]  [DEFAULT: 1]
2. bgp_table_peer_buckets     | bmp_table_peer_buckets     [1 - 1000] [DEFAULT: 13]
```

- The buckets configured by the first parameter are hierarchically above the buckets defined by the second one. "useful when much BGP information per peer is received, ie. in case of BGP ADD-PATHs".
- The buckets configured by the second parameter are giving direct access to the RD information used to perform data correlation with IPFIX.

#### To optimize the hash table, load factor < 0.75
1. we can tune the amount of buckets defined by bgp_table_peer_buckets. 
```TEXT
[Load factor (λ) = Number of stored elements (n) / Number of available slots (N)]
```
2. Adding the RD to the hash function contributes to minimizing the amount of collisions (a better data distribution over the hash table is achieved).

By focusing on optimizing the load factor, we can ensure that the hash table operates efficiently, resulting in better overall performance.

#### During functional testing 
I experimented with various combinations of the above configuration parameters while monitoring the CPU level:

```TEXT
| bgp_table_peer_buckets | bgp_table_per_peer_buckets | %CPU    |
+------------------------+----------------------------+---------+
| DEFAULT                | DEFAULT                    | ~25-30% |
+------------------------+----------------------------+---------+
| DEFAULT                |  128                       | ~35-40% |
+------------------------+----------------------------+---------+
| 1000                   | DEFAULT                    | ~10-15% |
+------------------------+----------------------------+---------+
| 1000                   | 128                        | ~25-30% |
+------------------------+----------------------------+---------+
```

#### Additional considerations
1. Increasing the amount of bgp_table_per_peer_buckets is CPU inefficient most probably due to linear iteration over all buckets.
2. Increasing the amount of bgp_table_peer_buckets (keeping in mind the load factor formula) increases the hash table efficiency with the price of more memory consumption.

---

(*) BGP/BMP Data correlation:
```TEXT
                +------------------+ 
      IPFIX --->| pmacct & flow2rd |---> IPFIX + rd  (Example: peer_ip_src, src_ip, dst_ip, (rd))
                +------------------+   

                +----------------------------+
 IPFIX + rd --->|                            |
                | pmacct + correlation func .|---> IPFIX + rd + BGP communities (Example: peer_ip_src, src_ip, dst_ip, (rd), (comms, ecomms, ...))
    BGP/BMP --->|                            |
                +----------------------------+
```

#### Behavior:
1. per IPFIX record match peer_ip_src against flow2rd ---> retrieve the associated rd (if no match rd set-by-default to 0:0:0)
2. enrich the IPFIX record with the associated rd
3. per IPFIX+rd record match:
- peer_ip_src to identify the BGP-RIB belonging to a specific router
- rd against the BGP-RIB's RD field to select the right VRF
- src_ip/dst_ip against the BGP-RIB's Network field to finally retrieve the associated communities
4. enrich the IPFIX+rd record with the associated communities

### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)
