### PR TITLE
RD from options: check also other VRF when RD=0:0:0

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -3677,6 +3677,7 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
   u_int32_t ingress_vrfid = 0, egress_vrfid = 0;
   u_int8_t direction = 0;
   rd_t *rd = NULL;
+  rd_t rd_default = {0};
   int ret;
 
   switch(hdr->version) {
@@ -3702,6 +3703,12 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
       if (entry->in_rd_map) { /* check obsID/srcID scoped xflow_status table */
         ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
         if (ret == CDADA_SUCCESS) {
+
+          /* If RD=0:0:0 [rd_default] --> check also egress VRF */
+          if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->out_rd_map) { 
+            cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
+          }
+
           memcpy(&pptrs->bitr, rd, 8);
           bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_FLOW);
         }
@@ -3712,6 +3719,12 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
         if (entry->in_rd_map) {
           ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
           if (ret == CDADA_SUCCESS) {
+
+            /* If RD=0:0:0 [rd_default] --> check also egress VRF */
+            if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->out_rd_map) { 
+              cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
+            }
+
             memcpy(&pptrs->bitr, rd, 8);
             bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_FLOW);
           }
@@ -3724,6 +3737,12 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
       if (entry->out_rd_map) { /* check obsID/srcID scoped xflow_status table */
         ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
 	if (ret == CDADA_SUCCESS) {
+
+          /* If RD=0:0:0 [rd_default] --> check also ingress VRF */
+          if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->in_rd_map) { 
+            cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
+          }
+
 	  memcpy(&pptrs->bitr, rd, 8);
 	  bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_FLOW);
 	}
@@ -3734,6 +3753,12 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
         if (entry->out_rd_map) { 
           ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
           if (ret == CDADA_SUCCESS) {
+
+          /* If RD=0:0:0 [rd_default] --> check also ingress VRF */
+            if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->in_rd_map) { 
+              cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
+            }
+
 	    memcpy(&pptrs->bitr, rd, 8);
 	    bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_FLOW);
           }

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -4297,6 +4297,7 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
   u_int32_t ingress_vrfid = 0, egress_vrfid = 0;
   u_int8_t direction = 0;
   rd_t *rd = NULL;
+  rd_t rd_default = {0};
   int ret;
 
   switch(hdr->version) {
@@ -4323,6 +4324,12 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
       if (entry->in_rd_map) { /* check obsID/srcID scoped xflow_status table */
         ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
 	if (ret == CDADA_SUCCESS) {
+
+          /* If RD=0:0:0 [rd_default] --> check also egress VRF */
+          if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->out_rd_map) { 
+            cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
+          }
+
 	  memcpy(&pbgp->mpls_vpn_rd, rd, 8);
 	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
 	}
@@ -4333,6 +4340,12 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
         if (entry->in_rd_map) {
           ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
           if (ret == CDADA_SUCCESS) {
+
+            /* If RD=0:0:0 [rd_default] --> check also egress VRF */
+            if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->out_rd_map) { 
+              cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
+            }
+
 	    memcpy(&pbgp->mpls_vpn_rd, rd, 8);
 	    bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
           }
@@ -4352,6 +4365,12 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
       if (entry->out_rd_map) { /* check obsID/srcID scoped xflow_status table */
         ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
 	if (ret == CDADA_SUCCESS) {
+
+          /* If RD=0:0:0 [rd_default] --> check also ingress VRF */
+          if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->in_rd_map) { 
+            cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
+          }
+
 	  memcpy(&pbgp->mpls_vpn_rd, rd, 8);
 	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
 	}
@@ -4362,6 +4381,12 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
         if (entry->out_rd_map) { 
           ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
           if (ret == CDADA_SUCCESS) {
+
+            /* If RD=0:0:0 [rd_default] --> check also ingress VRF */
+            if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->in_rd_map) { 
+              cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
+            }
+
 	    memcpy(&pbgp->mpls_vpn_rd, rd, 8);
 	    bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
           }


### PR DESCRIPTION
### Short description
The current logic for gathering the RD from the option data relies on IE61 flowDirection field, which can be ingress or egress depending on the sampling configuration. With this logic, only one direction of vpnv4/6 flows (the flows coming from the customer facing interface of the PE node) is enriched with the relative RD, while the other direction (flows decapsulated from the MPLS or SR/SRv6 network) is enriched with RD=0:0:0.

This PR adds logic to check option data for the other VRF in cases where we obtain RD=0:0:0, and this makes sure that also the other flow direction is enriched with the actual vpnv4/6 RD.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
