### PR TITLE
small fix: uniform rd precedence on pkt_handlers

### DIFF
--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -496,10 +496,10 @@ void evaluate_packet_handlers()
       } 
 
       if (config.acct_type == ACCT_NF) {
-        channels_list[index].phandler[primitives] = NF_mpls_vpn_id_handler;
+        channels_list[index].phandler[primitives] = NF_mpls_vpn_rd_handler;
         primitives++;
 
-        channels_list[index].phandler[primitives] = NF_mpls_vpn_rd_handler;
+        channels_list[index].phandler[primitives] = NF_mpls_vpn_id_handler;
         primitives++;
       }
     }
@@ -4306,7 +4306,7 @@ void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptr
       OTPL_CP_LAST_M(&direction, NF9_DIRECTION, 1);
     }
 
-    if (!pbgp->mpls_vpn_rd.val) { /* RD was not set with flow2rdmap */
+    if (!pbgp->mpls_vpn_rd.val) { /* RD was not set with flow2rdmap or from pkt_data */
       if (tpl->fld[NF9_INGRESS_VRFID].count) {
         OTPL_CP_LAST_M(&ingress_vrfid, NF9_INGRESS_VRFID, 4);
 	ingress_vrfid = ntohl(ingress_vrfid);


### PR DESCRIPTION
### Short description
With this PR the precedence chain for RD enrichment is uniformed between the pre-loading process and pkt_handlers. This according to:

**RD in flow_to_rd.map > RD in IPFIX/NFv9 data packet > RD in IPFIX/NFv9 option packets**

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
