### PR TITLE
Adding support for Extended Next Hop Encoding BGP capability

### DIFF
--- a/src/bgp/bgp_logdump.c
+++ b/src/bgp/bgp_logdump.c
@@ -160,7 +160,7 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, saf
 
     if (attr) {
       memset(nexthop_str, 0, INET6_ADDRSTRLEN);
-      if (attr->mp_nexthop.family) addr_to_str2(nexthop_str, &attr->mp_nexthop, bgp_afi2family(afi));
+      if (attr->mp_nexthop.family) addr_to_str2(nexthop_str, &attr->mp_nexthop, attr->mp_nexthop.family);
       else inet_ntop(AF_INET, &attr->nexthop, nexthop_str, INET6_ADDRSTRLEN);
       json_object_set_new_nocheck(obj, "bgp_nexthop", json_string(nexthop_str));
 
@@ -377,7 +377,7 @@ int bgp_peer_log_msg(struct bgp_node *route, struct bgp_info *ri, afi_t afi, saf
 
     if (attr) {
       memset(nexthop_str, 0, INET6_ADDRSTRLEN);
-      if (attr->mp_nexthop.family) addr_to_str2(nexthop_str, &attr->mp_nexthop, bgp_afi2family(afi));
+      if (attr->mp_nexthop.family) addr_to_str2(nexthop_str, &attr->mp_nexthop, attr->mp_nexthop.family);
       else inet_ntop(AF_INET, &attr->nexthop, nexthop_str, INET6_ADDRSTRLEN);
       pm_avro_check(avro_value_get_by_name(&p_avro_obj, "bgp_nexthop", &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));

--- a/src/bgp/bgp_packet.h
+++ b/src/bgp/bgp_packet.h
@@ -160,6 +160,14 @@ struct capability_mp_data
   u_char safi;
 };
 
+/* Fields are encoded with 2 octets according to RFC8950 */
+struct capability_ext_nh_enc_data
+{
+  u_int16_t afi;
+  u_int16_t safi;       
+  u_int16_t nh_afi;
+};
+
 struct capability_as4
 {
   uint32_t as4;
@@ -192,6 +200,7 @@ struct capability_add_paths
 #define BGP_CAPABILITY_RESERVED		           0   /* RFC2434 */
 #define BGP_CAPABILITY_MULTIPROTOCOL	           1   /* RFC2858 */
 #define BGP_CAPABILITY_ROUTE_REFRESH	           2   /* RFC2918 */
+#define BGP_CAPABILITY_EXTENDED_NEXT_HOP_ENCODING  5   /* RFC8950 */
 #define BGP_CAPABILITY_4_OCTET_AS_NUMBER	0x41   /* RFC4893 */
 #define BGP_CAPABILITY_ADD_PATHS		0x45   /* RFC7911 */
 


### PR DESCRIPTION
### Short description
As specified by RFC8950, routers cannot advertise IPv4 or VPNV4 routes with an IPv6 next hop without an extra capability advertisement (Extended Next Hop Encoding). This is relevant for example for VPNV4 routes in an SRv6 core. 

This PR adds support to nfacctd so that it can reply to the BGP OPEN message with this capability, and the router can advertise these routes. It also adds a small bugfix to allow the bgp_nexthop primitive to be populated correctly when AFI differs from next-hop AFI. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
