### PR TITLE
Pmtelemetryd[TCP/JSON] - Increasing the buffer size to be able to process messages above 100K bytes

### DIFF
--- a/src/bgp/bgp_packet.h
+++ b/src/bgp/bgp_packet.h
@@ -33,7 +33,7 @@
 #define _BGP_PACKET_H_
 
 /* some handy things to know */
-#define BGP_BUFFER_SIZE			100000
+#define BGP_BUFFER_SIZE			1000000
 #define BGP_MARKER_SIZE			16	/* size of BGP marker */
 #define BGP_HEADER_SIZE			19	/* size of BGP header, including marker */
 #define BGP_MIN_OPEN_MSG_SIZE		29

--- a/src/network.h
+++ b/src/network.h
@@ -487,7 +487,7 @@ struct pkt_extras {
   u_int8_t icmp_code;
 };
 
-#define PKT_MSG_SIZE 10000
+#define PKT_MSG_SIZE 1000000
 struct pkt_msg {
   struct sockaddr_storage agent;
   u_int32_t seqno;


### PR DESCRIPTION
### Summary

This pull request aims to address an issue with streaming telemetry from the Cisco NCS-5500 using TCP/JSON for a specific YANG resource.
The telemetry messages are exceeding the default buffer size of 100,000 bytes, leading to an enforced TCP/IP session teardown by pmtelemetryd.

- YANG resource:
```TEXT
[...]
!
telemetry model-driven sensor-group SENSOR sensor-path Cisco-IOS-XR-platforms-ofa-oper:ofa/stats/nodes/node/Cisco-IOS-XR-NCS-BDplatforms-npu-resources-oper:hw-resources-datas/hw-resources-data[resource='encap']
!
[...]
```

**In light of this issue, the proposed fix is to simply increase the default buffer size to 1,000,000 bytes.**
This change has been tested and found to be effective at preventing the forced teardown of the TCP/IP session due to exceeding the previous buffer size.


- Pmtelemetryd relevant configuration:
```TEXT
[...]
!
telemetry_daemon_ip:        XXX.XXX.XXX.XXX
telemetry_daemon_interface: YYYY
telemetry_daemon_port_tcp:  ZZZZ
telemetry_daemon_max_peers: 255 
!
telemetry_daemon_decoder: cisco_v1
tmp_telemetry_decode_cisco_v1_json_string: True
!
[...]
```


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)