### PR TITLE
Fixing the pmtelemetryd's pretag-map re-loading via SIGUSR2

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -230,6 +230,7 @@ void reload_maps(int signum)
   reload_map = FALSE;
   reload_map_bgp_thread = FALSE;
   reload_map_bmp_thread = FALSE;
+  reload_map_telemetry_thread = FALSE;
   reload_map_rpki_thread = FALSE;
   reload_map_exec_plugins = FALSE;
   reload_geoipv2_file = FALSE;
@@ -238,6 +239,7 @@ void reload_maps(int signum)
     reload_map = TRUE; 
     reload_map_bgp_thread = TRUE;
     reload_map_bmp_thread = TRUE;
+    reload_map_telemetry_thread = TRUE;
     reload_map_rpki_thread = TRUE;
     reload_map_exec_plugins = TRUE;
     reload_geoipv2_file = TRUE;


### PR DESCRIPTION
### Summary 

This PR is fixing the ability of re-loading pmtelemetryd's pretag-map via SIGUSR2 signal.


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)
