### PR TITLE
Changing srhSegmentIPv6ListSection to final IANA entityID

### DIFF
--- a/src/nfv9_template.h
+++ b/src/nfv9_template.h
@@ -181,7 +181,7 @@
 /* ... */
 #define NF9_DATALINK_FRAME_TYPE         408
 /* ... */
-#define NF9_srhSegmentIPv6ListSection   505
+#define NF9_srhSegmentIPv6ListSection   497
 /* ... */
 #define NF9_PathDelayMeanDeltaUsecs	600
 #define NF9_PathDelayMinDeltaUsecs	601

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -4263,7 +4263,7 @@ void NF_srv6_segment_ipv6_list_handler(struct channels_list_entry *chptr, struct
   case 10:
   case 9:
     if ((utpl = (*get_ext_db_ie_by_type)(tpl, 0, NF9_srhSegmentIPv6ListSection, FALSE)) ||
-	(utpl = (*get_ext_db_ie_by_type)(tpl, HUAWEI_PEN, NF9_srhSegmentIPv6ListSection, FALSE))) {
+	(utpl = (*get_ext_db_ie_by_type)(tpl, HUAWEI_PEN, 505, FALSE))) {
       list_len = utpl->len;
 
       if (list_len && !(list_len % 16 /* IPv6 Address length */)) {


### PR DESCRIPTION
### Short description
With this PR the srhSegmentIPv6ListSection entityID is adjusted to 497 according to https://www.iana.org/assignments/ipfix/ipfix.xhtml. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
