### PR TITLE
remove password from log output

### DIFF
--- a/src/pgsql_plugin.c
+++ b/src/pgsql_plugin.c
@@ -803,7 +803,7 @@ void PG_compose_conn_string(struct DBdesc *db, char *host, int port, char *ca_fi
     }
     string = db->conn_string;
 
-    snprintf(string, slen, "dbname=%s user=%s password=%s", config.sql_db, config.sql_user, config.sql_passwd);
+    snprintf(string, slen, "dbname=%s user=%s", config.sql_db, config.sql_user);
     slen -= strlen(string);
     string += strlen(string);
 


### PR DESCRIPTION
### Short description
It removes passwords from the log.

I mean, why should a password be in plain text in the log?
This is a disaster from a safety perspective.

### Checklist
I have:
- [x] compiled & tested this code