### PR TITLE
Fix rd selection precedence

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -2390,11 +2390,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, pptrs, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(pptrs);
-	  NF_mpls_vpn_rd_from_ie90(pptrs);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(pptrs);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, pptrs, &pptrs->bta, &pptrs->bta2);
-	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, pptrs, &pptrs->bitr, NULL);
+          if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, pptrs, &pptrs->bitr, NULL);
+          NF_mpls_vpn_rd_from_map(pptrs);
+          NF_mpls_vpn_rd_from_ie90(pptrs);
+          NF_mpls_vpn_rd_from_options(pptrs);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(pptrs, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, pptrs, &pptrs->bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, pptrs, &pptrs->blp, NULL);
@@ -2468,11 +2469,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->v6, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->v6);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->v6);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->v6);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->v6, &pptrsv->v6.bta, &pptrsv->v6.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->v6, &pptrsv->v6.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->v6);
+	  NF_mpls_vpn_rd_from_ie90(&pptrsv->v6);
+          NF_mpls_vpn_rd_from_options(&pptrsv->v6);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->v6, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->v6, &pptrsv->v6.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->v6, &pptrsv->v6.blp, NULL);
@@ -2552,11 +2554,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->vlan4, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->vlan4);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->vlan4);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlan4);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlan4, &pptrsv->vlan4.bta, &pptrsv->vlan4.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlan4, &pptrsv->vlan4.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->vlan4);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->vlan4);
+          NF_mpls_vpn_rd_from_options(&pptrsv->vlan4);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlan4, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlan4, &pptrsv->vlan4.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlan4, &pptrsv->vlan4.blp, NULL);
@@ -2633,11 +2636,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->vlan6, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->vlan6);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->vlan6);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlan6);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlan6, &pptrsv->vlan6.bta, &pptrsv->vlan6.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlan6, &pptrsv->vlan6.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->vlan6);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->vlan6);
+          NF_mpls_vpn_rd_from_options(&pptrsv->vlan6);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlan6, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlan6, &pptrsv->vlan6.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlan6, &pptrsv->vlan6.blp, NULL);
@@ -2720,11 +2724,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->mpls4, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->mpls4);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->mpls4);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->mpls4);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->mpls4, &pptrsv->mpls4.bta, &pptrsv->mpls4.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->mpls4, &pptrsv->mpls4.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->mpls4);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->mpls4);
+          NF_mpls_vpn_rd_from_options(&pptrsv->mpls4);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->mpls4, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->mpls4, &pptrsv->mpls4.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->mpls4, &pptrsv->mpls4.blp, NULL);
@@ -2804,11 +2809,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->mpls6, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->mpls6);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->mpls6);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->mpls6);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->mpls6, &pptrsv->mpls6.bta, &pptrsv->mpls6.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->mpls6, &pptrsv->mpls6.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->mpls6);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->mpls6);
+          NF_mpls_vpn_rd_from_options(&pptrsv->mpls6);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->mpls6, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->mpls6, &pptrsv->mpls6.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->mpls6, &pptrsv->mpls6.blp, NULL);
@@ -2900,11 +2906,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->vlanmpls4, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->vlanmpls4);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->vlanmpls4);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlanmpls4);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bta, &pptrsv->vlanmpls4.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->vlanmpls4);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->vlanmpls4);
+          NF_mpls_vpn_rd_from_options(&pptrsv->vlanmpls4);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlanmpls4, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.blp, NULL);
@@ -2993,11 +3000,12 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
                  tpl->fld[NF9_L4_PROTOCOL].len[0]);
 
 	  NF_process_classifiers(pptrs, &pptrsv->vlanmpls6, pkt, tpl);
-          NF_mpls_vpn_rd_from_options(&pptrsv->vlanmpls6);
-	  NF_mpls_vpn_rd_from_ie90(&pptrsv->vlanmpls6);
 	  if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlanmpls6);
 	  if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bta, &pptrsv->vlanmpls6.bta2);
 	  if (config.nfacctd_flow_to_rd_map) NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->vlanmpls6);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->vlanmpls6);
+          NF_mpls_vpn_rd_from_options(&pptrsv->vlanmpls6);
 	  if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlanmpls6, FUNC_TYPE_BGP);
 	  if (config.bgp_daemon_peer_as_src_map) NF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bpas, NULL);
 	  if (config.bgp_daemon_src_local_pref_map) NF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.blp, NULL);
@@ -3668,6 +3676,36 @@ void NF_init_zmq_host(void *zh, int *pipe_fd)
 }
 #endif
 
+/* Set RD_ORIGIN_MAP flag if RD was set with flow_to_rd_map */
+void NF_mpls_vpn_rd_from_map (struct packet_ptrs *pptrs)
+{
+  if (((rd_t *)&pptrs->bitr)->val) bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_MAP);
+}
+
+/* Get RD from IPFIX/NFv9 Data Packet for correlation with BGP/BMP */
+void NF_mpls_vpn_rd_from_ie90(struct packet_ptrs *pptrs)
+{
+  struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
+  struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
+
+  switch(hdr->version) {
+  case 10:
+  case 9:
+    if (tpl->fld[NF9_MPLS_VPN_RD].count) {
+      if (!((rd_t *)&pptrs->bitr)->val) { /* RD was not set with flow_to_rd_map */
+
+        memcpy(&pptrs->bitr, pptrs->f_data+tpl->fld[NF9_MPLS_VPN_RD].off[0],
+             MIN(tpl->fld[NF9_MPLS_VPN_RD].len[0], 8));
+        bgp_rd_ntoh((rd_t *)&pptrs->bitr);
+        bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_FLOW);
+      }
+    }
+    break;
+  default:
+    break;
+  }
+}
+
 /* Get RD from IPFIX/NFv9 Option Data for correlation with BGP/BMP */
 void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
 {
@@ -3687,16 +3725,20 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
       memcpy(&direction, pptrs->f_data+tpl->fld[NF9_DIRECTION].off[0], 
               MIN(tpl->fld[NF9_DIRECTION].len[0], 1));
     }
-    if (tpl->fld[NF9_INGRESS_VRFID].count) {
-      memcpy(&ingress_vrfid, pptrs->f_data+tpl->fld[NF9_INGRESS_VRFID].off[0], 
-              MIN(tpl->fld[NF9_INGRESS_VRFID].len[0], 4));
-      ingress_vrfid = ntohl(ingress_vrfid);
-    }
-    if (tpl->fld[NF9_EGRESS_VRFID].count) {
-      memcpy(&egress_vrfid, pptrs->f_data+tpl->fld[NF9_EGRESS_VRFID].off[0], 
-              MIN(tpl->fld[NF9_EGRESS_VRFID].len[0], 4));
-      egress_vrfid = ntohl(egress_vrfid);
-    }
+    
+    if (!((rd_t *)&pptrs->bitr)->val) { /* RD was not set with flow_to_rd_map or from IPFIX/NFv9 data */
+
+      if (tpl->fld[NF9_INGRESS_VRFID].count) {
+        memcpy(&ingress_vrfid, pptrs->f_data+tpl->fld[NF9_INGRESS_VRFID].off[0], 
+                MIN(tpl->fld[NF9_INGRESS_VRFID].len[0], 4));
+        ingress_vrfid = ntohl(ingress_vrfid);
+      }
+      if (tpl->fld[NF9_EGRESS_VRFID].count) {
+        memcpy(&egress_vrfid, pptrs->f_data+tpl->fld[NF9_EGRESS_VRFID].off[0], 
+                MIN(tpl->fld[NF9_EGRESS_VRFID].len[0], 4));
+        egress_vrfid = ntohl(egress_vrfid);
+      }
+  }
 
     if (ingress_vrfid && (!direction /* 0 = ingress */ || !egress_vrfid)) {
 
@@ -3764,27 +3806,6 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
           }
         }
       }
-    }
-    break;
-  default:
-    break;
-  }
-}
-
-/* Get RD from IPFIX/NFv9 Data Packet for correlation with BGP/BMP */
-void NF_mpls_vpn_rd_from_ie90(struct packet_ptrs *pptrs)
-{
-  struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
-  struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
-
-  switch(hdr->version) {
-  case 10:
-  case 9:
-    if (tpl->fld[NF9_MPLS_VPN_RD].count) {
-      memcpy(&pptrs->bitr, pptrs->f_data+tpl->fld[NF9_MPLS_VPN_RD].off[0],
-             MIN(tpl->fld[NF9_MPLS_VPN_RD].len[0], 8));
-      bgp_rd_ntoh((rd_t *)&pptrs->bitr);
-      bgp_rd_origin_set((rd_t *)&pptrs->bitr, RD_ORIGIN_FLOW);
     }
     break;
   default:

--- a/src/nfacctd.h
+++ b/src/nfacctd.h
@@ -140,8 +140,9 @@ extern void NF_init_kafka_host(void *);
 extern void NF_init_zmq_host(void *, int *);
 #endif
 
-extern void NF_mpls_vpn_rd_from_options(struct packet_ptrs *);
+extern void NF_mpls_vpn_rd_from_map(struct packet_ptrs *);
 extern void NF_mpls_vpn_rd_from_ie90(struct packet_ptrs *);
+extern void NF_mpls_vpn_rd_from_options(struct packet_ptrs *);
 
 extern struct utpl_field *(*get_ext_db_ie_by_type)(struct template_cache_entry *, u_int32_t, u_int16_t, u_int8_t);
 #endif //NFACCTD_H

--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -490,18 +490,17 @@ void evaluate_packet_handlers()
     }
 
     if (channels_list[index].aggregation & COUNT_MPLS_VPN_RD) {
-      if (config.nfacctd_flow_to_rd_map) {
-        channels_list[index].phandler[primitives] = mpls_vpn_rd_frommap_handler;
-        primitives++;
-      } 
 
       if (config.acct_type == ACCT_NF) {
         channels_list[index].phandler[primitives] = NF_mpls_vpn_rd_handler;
         primitives++;
+      }
 
-        channels_list[index].phandler[primitives] = NF_mpls_vpn_id_handler;
+      if (config.acct_type == ACCT_SF) {
+        channels_list[index].phandler[primitives] = SF_mpls_vpn_rd_handler;
         primitives++;
       }
+
     }
 
     if (channels_list[index].aggregation_2 & COUNT_MPLS_PW_ID) {
@@ -1986,13 +1985,23 @@ void sampling_direction_handler(struct channels_list_entry *chptr, struct packet
   pdata->primitives.sampling_direction = SAMPLING_DIRECTION_UNKNOWN;
 }
 
-void mpls_vpn_rd_frommap_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
+void SF_mpls_vpn_rd_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
   struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
 
   if (pbgp && pptrs->bitr) {
     memcpy(&pbgp->mpls_vpn_rd, &pptrs->bitr, sizeof(rd_t));
     bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_MAP);
+  }
+}
+
+void NF_mpls_vpn_rd_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
+{
+  struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
+
+  if (pbgp && pptrs->bitr) {
+    /* RD_ORIGIN is already set in nfacctd.c */
+    memcpy(&pbgp->mpls_vpn_rd, &pptrs->bitr, sizeof(rd_t)); 
   }
 }
 
@@ -4285,148 +4294,6 @@ void NF_srv6_segment_ipv6_list_handler(struct channels_list_entry *chptr, struct
   else {
     list_len = sizeof(struct host_addr) * list_elems;
     vlen_prims_insert(pvlen, COUNT_INT_SRV6_SEG_IPV6_SECTION, list_len, (u_char *) &srv6_segment_ipv6_list, PM_MSG_BIN_COPY);
-  }
-}
-
-void NF_mpls_vpn_id_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
-{
-  struct xflow_status_entry *entry = (struct xflow_status_entry *) pptrs->f_status;
-  struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
-  struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
-  struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives); 
-  u_int32_t ingress_vrfid = 0, egress_vrfid = 0;
-  u_int8_t direction = 0;
-  rd_t *rd = NULL;
-  rd_t rd_default = {0};
-  int ret;
-
-  switch(hdr->version) {
-  case 10:
-  case 9:
-    if (tpl->fld[NF9_DIRECTION].count) {
-      OTPL_CP_LAST_M(&direction, NF9_DIRECTION, 1);
-    }
-
-    if (!pbgp->mpls_vpn_rd.val) { /* RD was not set with flow_to_rd_map or from pkt_data */
-      if (tpl->fld[NF9_INGRESS_VRFID].count) {
-        OTPL_CP_LAST_M(&ingress_vrfid, NF9_INGRESS_VRFID, 4);
-	ingress_vrfid = ntohl(ingress_vrfid);
-      }
-
-      if (tpl->fld[NF9_EGRESS_VRFID].count) {
-        OTPL_CP_LAST_M(&egress_vrfid, NF9_EGRESS_VRFID, 4);
-	egress_vrfid = ntohl(egress_vrfid);
-      }
-    }
-
-    if (ingress_vrfid && (!direction /* 0 = ingress */ || !egress_vrfid)) {
-
-      if (entry->in_rd_map) { /* check obsID/srcID scoped xflow_status table */
-        ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
-	if (ret == CDADA_SUCCESS) {
-
-          /* If RD=0:0:0 [rd_default] --> check also egress VRF */
-          if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->out_rd_map) { 
-            cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
-          }
-
-	  memcpy(&pbgp->mpls_vpn_rd, rd, 8);
-	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-	}
-      }
-
-      if ( !entry->in_rd_map || ret != CDADA_SUCCESS ) { /* fallback to the global xflow_status table */
-        entry = (struct xflow_status_entry *) pptrs->f_status_g;
-        if (entry->in_rd_map) {
-          ret = cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
-          if (ret == CDADA_SUCCESS) {
-
-            /* If RD=0:0:0 [rd_default] --> check also egress VRF */
-            if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->out_rd_map) { 
-              cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
-            }
-
-	    memcpy(&pbgp->mpls_vpn_rd, rd, 8);
-	    bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-          }
-        }
-
-        if ( !entry->in_rd_map || ret != CDADA_SUCCESS ) { /* no RD found in option data --> fallback to vrfID:XXX */
-          pbgp->mpls_vpn_rd.val = ingress_vrfid;
-          if (pbgp->mpls_vpn_rd.val) {
-	    pbgp->mpls_vpn_rd.type = RD_TYPE_VRFID;
-	    bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-	  }
-        }
-      }
-    }
-
-    if (egress_vrfid && (direction /* 1 = egress */ || !ingress_vrfid)) {
-
-      if (entry->out_rd_map) { /* check obsID/srcID scoped xflow_status table */
-        ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
-	if (ret == CDADA_SUCCESS) {
-
-          /* If RD=0:0:0 [rd_default] --> check also ingress VRF */
-          if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->in_rd_map) { 
-            cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
-          }
-
-	  memcpy(&pbgp->mpls_vpn_rd, rd, 8);
-	  bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-	}
-      }
-
-      if ( !entry->out_rd_map || ret != CDADA_SUCCESS ) { /* fallback to the global xflow_status table */
-        entry = (struct xflow_status_entry *) pptrs->f_status_g;
-        if (entry->out_rd_map) { 
-          ret = cdada_map_find(entry->out_rd_map, &egress_vrfid, (void **) &rd);
-          if (ret == CDADA_SUCCESS) {
-
-            /* If RD=0:0:0 [rd_default] --> check also ingress VRF */
-            if (!memcmp(rd, &rd_default, sizeof(rd_t)) && entry->in_rd_map) { 
-              cdada_map_find(entry->in_rd_map, &ingress_vrfid, (void **) &rd);
-            }
-
-	    memcpy(&pbgp->mpls_vpn_rd, rd, 8);
-	    bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-          }
-        }
-
-        if ( !entry->out_rd_map || ret != CDADA_SUCCESS ) { /* no RD found in option data --> fallback to vrfID:XXX */
-          pbgp->mpls_vpn_rd.val = egress_vrfid;
-          if (pbgp->mpls_vpn_rd.val) {
-            pbgp->mpls_vpn_rd.type = RD_TYPE_VRFID;
-            bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-          }
-	}
-      }
-    }
-    break;
-  default:
-    break;
-  }
-}
-
-void NF_mpls_vpn_rd_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
-{
-  struct struct_header_v5 *hdr = (struct struct_header_v5 *) pptrs->f_header;
-  struct template_cache_entry *tpl = (struct template_cache_entry *) pptrs->f_tpl;
-  struct pkt_bgp_primitives *pbgp = (struct pkt_bgp_primitives *) ((*data) + chptr->extras.off_pkt_bgp_primitives);
-
-  switch(hdr->version) {
-  case 10:
-  case 9:
-    if (tpl->fld[NF9_MPLS_VPN_RD].count) {
-      if (!pbgp->mpls_vpn_rd.val) { /* RD was not set with flow_to_rd_map */
-        OTPL_CP_LAST_M(&pbgp->mpls_vpn_rd, NF9_MPLS_VPN_RD, 8);
-        bgp_rd_ntoh(&pbgp->mpls_vpn_rd);
-        bgp_rd_origin_set(&pbgp->mpls_vpn_rd, RD_ORIGIN_FLOW);
-      }
-    }
-    break;
-  default:
-    break;
   }
 }
 

--- a/src/pkt_handlers.h
+++ b/src/pkt_handlers.h
@@ -68,7 +68,6 @@ extern void timestamp_arrival_handler(struct channels_list_entry *, struct packe
 extern void custom_primitives_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void sfprobe_payload_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void nfprobe_extras_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
-extern void mpls_vpn_rd_frommap_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 
 extern void NF_src_mac_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void NF_dst_mac_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
@@ -114,7 +113,6 @@ extern void NF_mpls_label_stack_handler(struct channels_list_entry *, struct pac
 extern void NF_mpls_label_top_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void NF_mpls_label_bottom_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void NF_srv6_segment_ipv6_list_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
-extern void NF_mpls_vpn_id_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void NF_mpls_vpn_rd_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void NF_mpls_pw_id_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void NF_path_delay_avg_usec_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
@@ -216,6 +214,7 @@ extern void SF_mpls_label_bottom_handler(struct channels_list_entry *, struct pa
 extern void SF_mpls_label_stack_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void SF_mpls_pw_id_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void SF_custom_primitives_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
+extern void SF_mpls_vpn_rd_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 
 extern void pre_tag_handler(struct channels_list_entry *, struct packet_ptrs *, char **);
 extern void pre_tag2_handler(struct channels_list_entry *, struct packet_ptrs *, char **);


### PR DESCRIPTION
### Short description
This PR fixes an issue related to RD preloading that was preventing correlation from IPFIX options to succeed when flow_to_rd map is also enabled in the config.

I also did some cleanup: since we anyway need to preload the RD in nfacctd.c, I made sure that the RD is already loaded with the correct RD_ORIGIN and removed all the duplicated logic in pkt_handlers.c.

The RD precedence is still flow_to_rd.map > RD in IPFIX DATA message > RD in IPFIX OPTION DATA message

Have a look and tell me if it works for you or you want to do something differently :)

Ciao,
Leonardo

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
