### PR TITLE
Preload inner/customer layer ip_src/ip_dst for correlation with BGP/BMP [SRv6]

### DIFF
--- a/src/bgp/bgp_lookup.h
+++ b/src/bgp/bgp_lookup.h
@@ -19,11 +19,26 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
+/* defines */ 
 #ifndef _BGP_LOOKUP_H_
 #define _BGP_LOOKUP_H_
 
+
+/* Struct with additional information required to perform correlation of NFv9/IPFIX with BGP information */
+struct bgp_lookup_info {
+  
+  /* Inner/customer layer IPv4 source and destination addresses [e.g. for SRv6 tunnel]*/
+  struct in_addr inner_ip_src;	
+  struct in_addr inner_ip_dst; 
+
+  /* Inner/customer layer IPv6 source and destination addresses [e.g. for SRv6 tunnel] */
+  struct in6_addr inner_ipv6_src;	
+  struct in6_addr inner_ipv6_dst; 
+};
+extern struct bgp_lookup_info *bl_info;
+
 /* prototypes */
-extern void bgp_srcdst_lookup(struct packet_ptrs *, int);
+extern void bgp_srcdst_lookup(struct packet_ptrs *, int, struct bgp_lookup_info *);
 extern void bgp_follow_nexthop_lookup(struct packet_ptrs *, int);
 extern struct bgp_peer *bgp_lookup_find_bgp_peer(struct sockaddr *, struct xflow_status_entry *, u_int16_t, int); 
 extern u_int32_t bgp_route_info_modulo_pathid(struct bgp_peer *, rd_t *, path_id_t *, struct bgp_msg_extra_data *, int);

--- a/src/bmp/bmp_lookup.c
+++ b/src/bmp/bmp_lookup.c
@@ -24,9 +24,9 @@
 #include "bgp/bgp.h"
 #include "bmp.h"
 
-void bmp_srcdst_lookup(struct packet_ptrs *pptrs)
+void bmp_srcdst_lookup(struct packet_ptrs *pptrs, struct bgp_lookup_info *bl_info)
 {
-  bgp_srcdst_lookup(pptrs, FUNC_TYPE_BMP);
+  bgp_srcdst_lookup(pptrs, FUNC_TYPE_BMP, bl_info);
 }
 
 struct bgp_peer *bgp_lookup_find_bmp_peer(struct sockaddr *sa, struct xflow_status_entry *xs_entry, u_int16_t l3_proto, int compare_bgp_port)

--- a/src/bmp/bmp_lookup.h
+++ b/src/bmp/bmp_lookup.h
@@ -24,10 +24,10 @@
 
 /* includes */
 
-/* defines */
+/* defines */ 
 
 /* prototypes */
-extern void bmp_srcdst_lookup(struct packet_ptrs *);
+extern void bmp_srcdst_lookup(struct packet_ptrs *, struct bgp_lookup_info *);
 extern struct bgp_peer *bgp_lookup_find_bmp_peer(struct sockaddr *, struct xflow_status_entry *, u_int16_t, int);
 extern u_int32_t bmp_route_info_modulo_pathid(struct bgp_peer *, rd_t *, path_id_t *, struct bgp_msg_extra_data *, int);
 extern u_int32_t bmp_route_info_modulo_mplsvpnrd(struct bgp_peer *, rd_t *, path_id_t *, struct bgp_msg_extra_data *, int);

--- a/src/nfacctd.h
+++ b/src/nfacctd.h
@@ -144,5 +144,8 @@ extern void NF_mpls_vpn_rd_from_map(struct packet_ptrs *);
 extern void NF_mpls_vpn_rd_from_ie90(struct packet_ptrs *);
 extern void NF_mpls_vpn_rd_from_options(struct packet_ptrs *);
 
+extern struct bgp_lookup_info *bl_info;
+extern void NF_bgp_lookup_info_preload(struct packet_ptrs *, struct bgp_lookup_info *);
+
 extern struct utpl_field *(*get_ext_db_ie_by_type)(struct template_cache_entry *, u_int32_t, u_int16_t, u_int8_t);
 #endif //NFACCTD_H

--- a/src/nl.c
+++ b/src/nl.c
@@ -153,14 +153,14 @@ void pm_pcap_cb(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char *bu
         }
         if (config.bgp_daemon) {
           BTA_find_id((struct id_table *)pptrs.bta_table, &pptrs, &pptrs.bta, &pptrs.bta2);
-          bgp_srcdst_lookup(&pptrs, FUNC_TYPE_BGP);
+          bgp_srcdst_lookup(&pptrs, FUNC_TYPE_BGP, NULL);
         }
         if (config.bgp_daemon_peer_as_src_map) PM_find_id((struct id_table *)pptrs.bpas_table, &pptrs, &pptrs.bpas, NULL);
         if (config.bgp_daemon_src_local_pref_map) PM_find_id((struct id_table *)pptrs.blp_table, &pptrs, &pptrs.blp, NULL);
         if (config.bgp_daemon_src_med_map) PM_find_id((struct id_table *)pptrs.bmed_table, &pptrs, &pptrs.bmed, NULL);
         if (config.bmp_daemon) {
           BTA_find_id((struct id_table *)pptrs.bta_table, &pptrs, &pptrs.bta, &pptrs.bta2);
-	  bmp_srcdst_lookup(&pptrs);
+	  bmp_srcdst_lookup(&pptrs, NULL);
 	}
 
 	set_index_pkt_ptrs(&pptrs);

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -1826,11 +1826,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(pptrs);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, pptrs, &pptrs->bta, &pptrs->bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, pptrs, &pptrs->bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(pptrs, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(pptrs, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, pptrs, &pptrs->bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, pptrs, &pptrs->blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, pptrs, &pptrs->bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(pptrs);
+      if (config.bmp_daemon) bmp_srcdst_lookup(pptrs, NULL);
       exec_plugins(pptrs, req);
       break;
     case PM_FTYPE_IPV6:
@@ -1862,11 +1862,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->v6);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->v6, &pptrsv->v6.bta, &pptrsv->v6.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->v6, &pptrsv->v6.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->v6, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->v6, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->v6, &pptrsv->v6.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->v6, &pptrsv->v6.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->v6, &pptrsv->v6.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->v6);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->v6, NULL);
       exec_plugins(&pptrsv->v6, req);
       break;
     case PM_FTYPE_VLAN_IPV4:
@@ -1899,11 +1899,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlan4);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlan4, &pptrsv->vlan4.bta, &pptrsv->vlan4.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlan4, &pptrsv->vlan4.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlan4, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlan4, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlan4, &pptrsv->vlan4.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlan4, &pptrsv->vlan4.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->vlan4, &pptrsv->vlan4.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlan4);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlan4, NULL);
       exec_plugins(&pptrsv->vlan4, req);
       break;
     case PM_FTYPE_VLAN_IPV6:
@@ -1936,11 +1936,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlan6);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlan6, &pptrsv->vlan6.bta, &pptrsv->vlan6.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlan6, &pptrsv->vlan6.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlan6, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlan6, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlan6, &pptrsv->vlan6.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlan6, &pptrsv->vlan6.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->vlan6, &pptrsv->vlan6.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlan6);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlan6, NULL);
       exec_plugins(&pptrsv->vlan6, req);
       break;
     case PM_FTYPE_MPLS_IPV4:
@@ -1986,11 +1986,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->mpls4);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->mpls4, &pptrsv->mpls4.bta, &pptrsv->mpls4.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->mpls4, &pptrsv->mpls4.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->mpls4, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->mpls4, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->mpls4, &pptrsv->mpls4.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->mpls4, &pptrsv->mpls4.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->mpls4, &pptrsv->mpls4.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->mpls4);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->mpls4, NULL);
       exec_plugins(&pptrsv->mpls4, req);
       break;
     case PM_FTYPE_MPLS_IPV6:
@@ -2035,11 +2035,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->mpls6);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->mpls6, &pptrsv->mpls6.bta, &pptrsv->mpls6.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->mpls6, &pptrsv->mpls6.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->mpls6, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->mpls6, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->mpls6, &pptrsv->mpls6.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->mpls6, &pptrsv->mpls6.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->mpls6, &pptrsv->mpls6.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->mpls6);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->mpls6, NULL);
       exec_plugins(&pptrsv->mpls6, req);
       break;
     case PM_FTYPE_VLAN_MPLS_IPV4:
@@ -2085,11 +2085,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlanmpls4);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bta, &pptrsv->vlanmpls4.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlanmpls4, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlanmpls4, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->vlanmpls4, &pptrsv->vlanmpls4.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlanmpls4);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlanmpls4, NULL);
       exec_plugins(&pptrsv->vlanmpls4, req);
       break;
     case PM_FTYPE_VLAN_MPLS_IPV6:
@@ -2135,11 +2135,11 @@ void finalizeSample(SFSample *sample, struct packet_ptrs_vector *pptrsv, struct 
       if (config.nfacctd_isis) isis_srcdst_lookup(&pptrsv->vlanmpls6);
       if (config.bgp_daemon_to_xflow_agent_map) BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bta, &pptrsv->vlanmpls6.bta2);
       if (config.nfacctd_flow_to_rd_map) SF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bitr, NULL);
-      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlanmpls6, FUNC_TYPE_BGP);
+      if (config.bgp_daemon) bgp_srcdst_lookup(&pptrsv->vlanmpls6, FUNC_TYPE_BGP, NULL);
       if (config.bgp_daemon_peer_as_src_map) SF_find_id((struct id_table *)pptrs->bpas_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bpas, NULL);
       if (config.bgp_daemon_src_local_pref_map) SF_find_id((struct id_table *)pptrs->blp_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.blp, NULL);
       if (config.bgp_daemon_src_med_map) SF_find_id((struct id_table *)pptrs->bmed_table, &pptrsv->vlanmpls6, &pptrsv->vlanmpls6.bmed, NULL);
-      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlanmpls6);
+      if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->vlanmpls6, NULL);
       exec_plugins(&pptrsv->vlanmpls6, req);
       break;
     default:


### PR DESCRIPTION
### Short description
In order to perform correlation of IPFIX/NFv9 information with BGP/BMP we need RD + source and destination IP addresses. With an SRv6 underlay we need the inner/customer layer IP addresses, but at the moment when the correlation functions are called withing nfacctd.c these fields have not been yet decoded.

This PR adds a structs and functions to preload this information so that they are available when the correlation functions are called.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
