### PR TITLE
Adding Encoding Options for BGP Communities & AS_PATH, AVRO array for IPFIX

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1689,6 +1689,28 @@ DESC:		The 'mpls_label_stack' is encoded by default as a string, including a com
 		plugins).
 DEFAULT:	false
 
+KEY:            bgp_comms_encode_as_array
+VALUES:         [ true | false ]
+DESC:           The 'bgp_comms' (BGP communities) is encoded by default as a string, including a underscore-separated list
+                of integers (community values). Setting this knob to true, makes it being encoded as an array
+                for Apache Avro encodings, i.e., in Avro "name": "bgp_comms", "type": { "type": "array", "items": { "type": "string" }}.
+                As of now, this configuration is only applicable to IPFIX data streams and does not support JSON encoding,
+                but support for both JSON and additional data streams such as BMP and BGP is planned for future releases.
+                This knob has no effects for other encodings (i.e., CSV, formatted) and backends not supporting complex types
+                (i.e., SQL plugins).
+DEFAULT:        false
+
+KEY:            as_path_encode_as_array
+VALUES:         [ true | false ]
+DESC:           The 'as_path' (BGP AS_PATH) is encoded by default as a string, including an underscore-separated list
+                of integers (AS numbers). Setting this knob to true, makes it being encoded as an array
+                for Apache Avro encodings, i.e., in Avro "name": "as_path", "type": { "type": "array", "items": { "type": "string" }}.
+                As of now, this configuration is only applicable to IPFIX data streams and does not support JSON encoding,
+                but support for both JSON and additional data streams such as BMP and BGP is planned for future releases.
+                This knob has no effects for other encodings (i.e., CSV, formatted) and backends not supporting complex types
+                (i.e., SQL plugins).
+DEFAULT:        false
+
 KEY:		tos_encode_as_dscp
 VALUES:		[ true | false ]
 		The 'tos' field does honour the full 8 bits. This knob conveniently allows to honour only

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -92,6 +92,8 @@ static const struct _dictionary_line dictionary[] = {
   {"timestamps_secs", cfg_key_timestamps_secs},
   {"timestamps_since_epoch", cfg_key_timestamps_since_epoch},
   {"tcpflags_encode_as_array", cfg_key_tcpflags_encode_as_array},
+  {"bgp_comms_encode_as_array", cfg_key_bgp_comms_encode_as_array},
+  {"as_path_encode_as_array", cfg_key_as_path_encode_as_array},
   {"fwd_status_encode_as_string", cfg_key_fwd_status_encode_as_string},
   {"tos_encode_as_dscp", cfg_key_tos_encode_as_dscp},
   {"imt_path", cfg_key_imt_path},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -548,6 +548,8 @@ struct configuration {
   struct pretag_label_filter ptlf;
   int pretag_label_encode_as_map;
   int tcpflags_encode_as_array;
+  int bgp_comms_encode_as_array;
+  int as_path_encode_as_array;
   int mpls_label_stack_encode_as_array;
   int fwd_status_encode_as_string;
   int tos_encode_as_dscp;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -657,6 +657,50 @@ int cfg_key_tcpflags_encode_as_array(char *filename, char *name, char *value_ptr
   return changes;
 }
 
+int cfg_key_bgp_comms_encode_as_array(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.bgp_comms_encode_as_array = value;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.bgp_comms_encode_as_array = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
+int cfg_key_as_path_encode_as_array(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.as_path_encode_as_array = value;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.as_path_encode_as_array = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_fwd_status_encode_as_string(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -288,6 +288,8 @@ extern int cfg_key_pre_tag2_filter(char *, char *, char *);
 extern int cfg_key_pre_tag_label_filter(char *, char *, char *);
 extern int cfg_key_pre_tag_label_encode_as_map(char *, char *, char *);
 extern int cfg_key_tcpflags_encode_as_array(char *, char *, char *);
+extern int cfg_key_bgp_comms_encode_as_array(char *, char *, char *);
+extern int cfg_key_as_path_encode_as_array(char *, char *, char *);
 extern int cfg_key_fwd_status_encode_as_string(char *, char *, char *);
 extern int cfg_key_tos_encode_as_dscp(char *, char *, char *);
 extern int cfg_key_post_tag(char *, char *, char *);

--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -38,6 +38,11 @@
 avro_schema_t p_avro_acct_schema, p_avro_acct_init_schema, p_avro_acct_close_schema;
 avro_schema_t sc_type_array, sc_type_map, sc_type_string, sc_type_union;
 
+compose_bgp_comm_to_avro_array_schema_type compose_bgp_comm_to_avro_array_schema = compose_str_linked_list_to_avro_array_schema;
+compose_bgp_comm_to_avro_array_data_type compose_bgp_comm_to_avro_array_data = compose_str_linked_list_to_avro_array_data;
+compose_as_path_to_avro_array_schema_type compose_as_path_to_avro_array_schema = compose_str_linked_list_to_avro_array_schema;
+compose_as_path_to_avro_array_data_type compose_as_path_to_avro_array_data = compose_str_linked_list_to_avro_array_data;
+
 /* functions */
 avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wtc_3)
 {
@@ -105,17 +110,41 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_in
   if (wtc & COUNT_DST_AS)
     avro_schema_record_field_append(schema, "as_dst", avro_schema_long());
 
-  if (wtc & COUNT_STD_COMM)
-    avro_schema_record_field_append(schema, "comms", avro_schema_string());
+  if (wtc & COUNT_STD_COMM) {
+    if (config.bgp_comms_encode_as_array) {
+      compose_bgp_comm_to_avro_array_schema(schema, "comms");
+    }
+    else {
+      avro_schema_record_field_append(schema, "comms", avro_schema_string());
+    }
+  }
 
-  if (wtc & COUNT_EXT_COMM)
-    avro_schema_record_field_append(schema, "ecomms", avro_schema_string());
+  if (wtc & COUNT_EXT_COMM) {
+    if (config.bgp_comms_encode_as_array) {
+      compose_bgp_comm_to_avro_array_schema(schema, "ecomms");
+    }
+    else {
+      avro_schema_record_field_append(schema, "ecomms", avro_schema_string());
+    }
+  }
 
-  if (wtc_2 & COUNT_LRG_COMM)
-    avro_schema_record_field_append(schema, "lcomms", avro_schema_string());
+  if (wtc_2 & COUNT_LRG_COMM) {
+    if (config.bgp_comms_encode_as_array) {
+      compose_bgp_comm_to_avro_array_schema(schema, "lcomms");
+    }
+    else {
+      avro_schema_record_field_append(schema, "lcomms", avro_schema_string());
+    }
+  }
 
-  if (wtc & COUNT_AS_PATH)
-    avro_schema_record_field_append(schema, "as_path", avro_schema_string());
+  if (wtc & COUNT_AS_PATH) {
+    if (config.as_path_encode_as_array) {
+      compose_as_path_to_avro_array_schema(schema, "as_path");
+    }
+    else {
+      avro_schema_record_field_append(schema, "as_path", avro_schema_string());
+    }
+  }
 
   if (wtc & COUNT_LOCAL_PREF)
     avro_schema_record_field_append(schema, "local_pref", avro_schema_long());
@@ -138,17 +167,41 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_in
   if (wtc & COUNT_PEER_DST_IP)
     avro_schema_record_field_append(schema, "peer_ip_dst", avro_schema_string());
 
-  if (wtc & COUNT_SRC_STD_COMM)
-    avro_schema_record_field_append(schema, "comms_src", avro_schema_string());
+  if (wtc & COUNT_SRC_STD_COMM) {
+    if (config.bgp_comms_encode_as_array) {
+      compose_bgp_comm_to_avro_array_schema(schema, "comms_src");
+    }
+    else {
+      avro_schema_record_field_append(schema, "comms_src", avro_schema_string());
+    }
+  }
 
-  if (wtc & COUNT_SRC_EXT_COMM)
-    avro_schema_record_field_append(schema, "ecomms_src", avro_schema_string());
+  if (wtc & COUNT_SRC_EXT_COMM) {
+    if (config.bgp_comms_encode_as_array) {
+      compose_bgp_comm_to_avro_array_schema(schema, "ecomms_src");
+    }
+    else {
+      avro_schema_record_field_append(schema, "ecomms_src", avro_schema_string());
+    }
+  }
 
-  if (wtc_2 & COUNT_SRC_LRG_COMM)
-    avro_schema_record_field_append(schema, "lcomms_src", avro_schema_string());
+  if (wtc_2 & COUNT_SRC_LRG_COMM) {
+    if (config.bgp_comms_encode_as_array) {
+      compose_bgp_comm_to_avro_array_schema(schema, "lcomms_src");
+    }
+    else {
+      avro_schema_record_field_append(schema, "lcomms_src", avro_schema_string());
+    }
+  }
 
-  if (wtc & COUNT_SRC_AS_PATH)
-    avro_schema_record_field_append(schema, "as_path_src", avro_schema_string());
+  if (wtc & COUNT_SRC_AS_PATH) {
+    if (config.as_path_encode_as_array) {
+      compose_as_path_to_avro_array_schema(schema, "as_path_src");
+    }
+    else {
+      avro_schema_record_field_append(schema, "as_path_src", avro_schema_string());
+    }
+  }
 
   if (wtc & COUNT_SRC_LOCAL_PREF)
     avro_schema_record_field_append(schema, "local_pref_src", avro_schema_long());
@@ -219,7 +272,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_in
     avro_schema_record_field_append(schema, "lat_ip_dst", avro_schema_double());
     avro_schema_record_field_append(schema, "lon_ip_dst", avro_schema_double());
   }
-    
+
 #endif
 
   if (wtc & COUNT_TCPFLAGS) {
@@ -230,7 +283,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_in
       avro_schema_record_field_append(schema, "tcp_flags", avro_schema_string());
     }
   }
-  
+
   if (wtc_2 & COUNT_FWD_STATUS) {
     if (config.fwd_status_encode_as_string) {
       compose_fwd_status_avro_schema(schema);
@@ -513,8 +566,8 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
     char ndpi_class[SUPERSHORTBUFLEN];
 
     snprintf(ndpi_class, SUPERSHORTBUFLEN, "%s/%s",
-	ndpi_get_proto_name(pm_ndpi_wfl->ndpi_struct, pbase->ndpi_class.master_protocol),
-	ndpi_get_proto_name(pm_ndpi_wfl->ndpi_struct, pbase->ndpi_class.app_protocol));
+        ndpi_get_proto_name(pm_ndpi_wfl->ndpi_struct, pbase->ndpi_class.master_protocol),
+        ndpi_get_proto_name(pm_ndpi_wfl->ndpi_struct, pbase->ndpi_class.app_protocol));
 
     pm_avro_check(avro_value_get_by_name(&value, "class", &field, NULL));
     pm_avro_check(avro_value_set_string(&field, ndpi_class));
@@ -573,62 +626,94 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
 
   if (wtc & COUNT_STD_COMM) {
     vlen_prims_get(pvlen, COUNT_INT_STD_COMM, &str_ptr);
-    if (str_ptr) {
-      bgp_comm = str_ptr;
-      while (bgp_comm) {
-        bgp_comm = strchr(str_ptr, ' ');
-        if (bgp_comm) *bgp_comm = '_';
+    if (config.bgp_comms_encode_as_array) {
+      if (str_ptr) {
+        compose_bgp_comm_to_avro_array_data(str_ptr, "comms", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        bgp_comm = str_ptr;
+        while (bgp_comm) {
+          bgp_comm = strchr(str_ptr, ' ');
+          if (bgp_comm) *bgp_comm = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "comms", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "comms", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc & COUNT_EXT_COMM) {
     vlen_prims_get(pvlen, COUNT_INT_EXT_COMM, &str_ptr);
-    if (str_ptr) {
-      bgp_comm = str_ptr;
-      while (bgp_comm) {
-        bgp_comm = strchr(str_ptr, ' ');
-        if (bgp_comm) *bgp_comm = '_';
+    if (config.bgp_comms_encode_as_array) {
+      if (str_ptr) {
+        compose_bgp_comm_to_avro_array_data(str_ptr, "ecomms", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        bgp_comm = str_ptr;
+        while (bgp_comm) {
+          bgp_comm = strchr(str_ptr, ' ');
+          if (bgp_comm) *bgp_comm = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "ecomms", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "ecomms", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc_2 & COUNT_LRG_COMM) {
     vlen_prims_get(pvlen, COUNT_INT_LRG_COMM, &str_ptr);
-    if (str_ptr) {
-      bgp_comm = str_ptr;
-      while (bgp_comm) {
-        bgp_comm = strchr(str_ptr, ' ');
-        if (bgp_comm) *bgp_comm = '_';
+    if (config.bgp_comms_encode_as_array) {
+      if (str_ptr) {
+        compose_bgp_comm_to_avro_array_data(str_ptr, "lcomms", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        bgp_comm = str_ptr;
+        while (bgp_comm) {
+          bgp_comm = strchr(str_ptr, ' ');
+          if (bgp_comm) *bgp_comm = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "lcomms", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "lcomms", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc & COUNT_AS_PATH) {
     vlen_prims_get(pvlen, COUNT_INT_AS_PATH, &str_ptr);
-    if (str_ptr) {
-      as_path = str_ptr;
-      while (as_path) {
-	as_path = strchr(str_ptr, ' ');
-	if (as_path) *as_path = '_';
+    if (config.as_path_encode_as_array) {
+      if (str_ptr) {
+        compose_as_path_to_avro_array_data(str_ptr, "as_path", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        as_path = str_ptr;
+        while (as_path) {
+          as_path = strchr(str_ptr, ' ');
+          if (as_path) *as_path = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "as_path", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "as_path", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc & COUNT_LOCAL_PREF) {
@@ -668,64 +753,96 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
     pm_avro_check(avro_value_set_string(&field, ip_address));
   }
 
-  if (wtc & COUNT_STD_COMM) {
+  if (wtc & COUNT_SRC_STD_COMM) {
     vlen_prims_get(pvlen, COUNT_INT_SRC_STD_COMM, &str_ptr);
-    if (str_ptr) {
-      bgp_comm = str_ptr;
-      while (bgp_comm) {
-        bgp_comm = strchr(str_ptr, ' ');
-        if (bgp_comm) *bgp_comm = '_';
+    if (config.bgp_comms_encode_as_array) {
+      if (str_ptr) {
+        compose_bgp_comm_to_avro_array_data(str_ptr, "comms_src", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        bgp_comm = str_ptr;
+        while (bgp_comm) {
+          bgp_comm = strchr(str_ptr, ' ');
+          if (bgp_comm) *bgp_comm = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "comms_src", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "comms_src", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc & COUNT_SRC_EXT_COMM) {
     vlen_prims_get(pvlen, COUNT_INT_SRC_EXT_COMM, &str_ptr);
-    if (str_ptr) {
-      bgp_comm = str_ptr;
-      while (bgp_comm) {
-        bgp_comm = strchr(str_ptr, ' ');
-        if (bgp_comm) *bgp_comm = '_';
+    if (config.bgp_comms_encode_as_array) {
+      if (str_ptr) {
+        compose_bgp_comm_to_avro_array_data(str_ptr, "ecomms_src", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        bgp_comm = str_ptr;
+        while (bgp_comm) {
+          bgp_comm = strchr(str_ptr, ' ');
+          if (bgp_comm) *bgp_comm = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "ecomms_src", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "ecomms_src", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc_2 & COUNT_SRC_LRG_COMM) {
     vlen_prims_get(pvlen, COUNT_INT_SRC_LRG_COMM, &str_ptr);
-    if (str_ptr) {
-      bgp_comm = str_ptr;
-      while (bgp_comm) {
-        bgp_comm = strchr(str_ptr, ' ');
-        if (bgp_comm) *bgp_comm = '_';
+    if (config.bgp_comms_encode_as_array) {
+      if (str_ptr) {
+        compose_bgp_comm_to_avro_array_data(str_ptr, "lcomms_src", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        bgp_comm = str_ptr;
+        while (bgp_comm) {
+          bgp_comm = strchr(str_ptr, ' ');
+          if (bgp_comm) *bgp_comm = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "lcomms_src", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "lcomms_src", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc & COUNT_SRC_AS_PATH) {
     vlen_prims_get(pvlen, COUNT_INT_SRC_AS_PATH, &str_ptr);
-    if (str_ptr) {
-      as_path = str_ptr;
-      while (as_path) {
-        as_path = strchr(str_ptr, ' ');
-        if (as_path) *as_path = '_';
+    if (config.as_path_encode_as_array) {
+      if (str_ptr) {
+        compose_as_path_to_avro_array_data(str_ptr, "as_path_src", value);
       }
+      else str_ptr = empty_string;
     }
-    else str_ptr = empty_string;
+    else {
+      if (str_ptr) {
+        as_path = str_ptr;
+        while (as_path) {
+          as_path = strchr(str_ptr, ' ');
+          if (as_path) *as_path = '_';
+        }
+      }
+      else str_ptr = empty_string;
 
-    pm_avro_check(avro_value_get_by_name(&value, "as_path_src", &field, NULL));
-    pm_avro_check(avro_value_set_string(&field, str_ptr));
+      pm_avro_check(avro_value_get_by_name(&value, "as_path_src", &field, NULL));
+      pm_avro_check(avro_value_set_string(&field, str_ptr));
+    }
   }
 
   if (wtc & COUNT_SRC_LOCAL_PREF) {
@@ -867,14 +984,14 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
       pm_avro_check(avro_value_set_string(&field, misc_str));
     }
   }
-  
+
   if (wtc_2 & COUNT_FWD_STATUS) {
     sprintf(misc_str, "%u", pnat->fwd_status);
 
     if (config.fwd_status_encode_as_string) {
       compose_fwd_status_avro_data(pnat->fwd_status, value);
     }
-    else { 
+    else {
       pm_avro_check(avro_value_get_by_name(&value, "fwd_status", &field, NULL));
       pm_avro_check(avro_value_set_string(&field, misc_str));
     }
@@ -890,12 +1007,12 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
     label_stack_len = vlen_prims_get(pvlen, COUNT_INT_MPLS_LABEL_STACK, &label_stack_ptr);
     if (label_stack_ptr) {
       if (config.mpls_label_stack_encode_as_array) {
-	compose_mpls_label_stack_data((u_int32_t *)label_stack_ptr, label_stack_len, value);
-      } 
+        compose_mpls_label_stack_data((u_int32_t *)label_stack_ptr, label_stack_len, value);
+      }
       else {
-	mpls_label_stack_to_str(label_stack, sizeof(label_stack), (u_int32_t *)label_stack_ptr, label_stack_len);
-	pm_avro_check(avro_value_get_by_name(&value, "mpls_label_stack", &field, NULL));
-	pm_avro_check(avro_value_set_string(&field, label_stack));
+        mpls_label_stack_to_str(label_stack, sizeof(label_stack), (u_int32_t *)label_stack_ptr, label_stack_len);
+        pm_avro_check(avro_value_get_by_name(&value, "mpls_label_stack", &field, NULL));
+        pm_avro_check(avro_value_set_string(&field, label_stack));
       }
     }
   }
@@ -1064,24 +1181,24 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
 
   if (wtc_2 & COUNT_TIMESTAMP_START) {
     compose_timestamp(tstamp_str, SRVBUFLEN, &pnat->timestamp_start, TRUE,
-		      config.timestamps_since_epoch, config.timestamps_rfc3339,
-		      config.timestamps_utc);
+                      config.timestamps_since_epoch, config.timestamps_rfc3339,
+                      config.timestamps_utc);
     pm_avro_check(avro_value_get_by_name(&value, "timestamp_start", &field, NULL));
     pm_avro_check(avro_value_set_string(&field, tstamp_str));
   }
 
   if (wtc_2 & COUNT_TIMESTAMP_END) {
     compose_timestamp(tstamp_str, SRVBUFLEN, &pnat->timestamp_end, TRUE,
-		      config.timestamps_since_epoch, config.timestamps_rfc3339,
-		      config.timestamps_utc);
+                      config.timestamps_since_epoch, config.timestamps_rfc3339,
+                      config.timestamps_utc);
     pm_avro_check(avro_value_get_by_name(&value, "timestamp_end", &field, NULL));
     pm_avro_check(avro_value_set_string(&field, tstamp_str));
   }
 
   if (wtc_2 & COUNT_TIMESTAMP_ARRIVAL) {
     compose_timestamp(tstamp_str, SRVBUFLEN, &pnat->timestamp_arrival, TRUE,
-		      config.timestamps_since_epoch, config.timestamps_rfc3339,
-		      config.timestamps_utc);
+                      config.timestamps_since_epoch, config.timestamps_rfc3339,
+                      config.timestamps_utc);
     pm_avro_check(avro_value_get_by_name(&value, "timestamp_arrival", &field, NULL));
     pm_avro_check(avro_value_set_string(&field, tstamp_str));
   }
@@ -1089,15 +1206,15 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
   if (config.nfacctd_stitching) {
     if (stitch) {
       compose_timestamp(tstamp_str, SRVBUFLEN, &stitch->timestamp_min, TRUE,
-			config.timestamps_since_epoch, config.timestamps_rfc3339,
-			config.timestamps_utc);
+                        config.timestamps_since_epoch, config.timestamps_rfc3339,
+                        config.timestamps_utc);
       pm_avro_check(avro_value_get_by_name(&value, "timestamp_min", &field, NULL));
       pm_avro_check(avro_value_set_branch(&field, 1, &branch));
       pm_avro_check(avro_value_set_string(&branch, tstamp_str));
 
       compose_timestamp(tstamp_str, SRVBUFLEN, &stitch->timestamp_max, TRUE,
-			config.timestamps_since_epoch, config.timestamps_rfc3339,
-			config.timestamps_utc);
+                        config.timestamps_since_epoch, config.timestamps_rfc3339,
+                        config.timestamps_utc);
       pm_avro_check(avro_value_get_by_name(&value, "timestamp_max", &field, NULL));
       pm_avro_check(avro_value_set_branch(&field, 1, &branch));
       pm_avro_check(avro_value_set_string(&branch, tstamp_str));
@@ -1127,8 +1244,8 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
 
   if (wtc_2 & COUNT_EXPORT_PROTO_TIME) {
     compose_timestamp(tstamp_str, SRVBUFLEN, &pnat->timestamp_export, TRUE,
-		      config.timestamps_since_epoch, config.timestamps_rfc3339,
-		      config.timestamps_utc);
+                      config.timestamps_since_epoch, config.timestamps_rfc3339,
+                      config.timestamps_utc);
     pm_avro_check(avro_value_get_by_name(&value, "timestamp_export", &field, NULL));
     pm_avro_check(avro_value_set_string(&field, tstamp_str));
   }
@@ -1163,8 +1280,8 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
       tv.tv_sec = basetime->tv_sec;
       tv.tv_usec = 0;
       compose_timestamp(tstamp_str, SRVBUFLEN, &tv, FALSE,
-			config.timestamps_since_epoch, config.timestamps_rfc3339,
-			config.timestamps_utc);
+                        config.timestamps_since_epoch, config.timestamps_rfc3339,
+                        config.timestamps_utc);
       pm_avro_check(avro_value_get_by_name(&value, "stamp_inserted", &field, NULL));
       pm_avro_check(avro_value_set_branch(&field, 1, &branch));
       pm_avro_check(avro_value_set_string(&branch, tstamp_str));
@@ -1172,8 +1289,8 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
       tv.tv_sec = time(NULL);
       tv.tv_usec = 0;
       compose_timestamp(tstamp_str, SRVBUFLEN, &tv, FALSE,
-			config.timestamps_since_epoch, config.timestamps_rfc3339,
-			config.timestamps_utc);
+                        config.timestamps_since_epoch, config.timestamps_rfc3339,
+                        config.timestamps_utc);
       pm_avro_check(avro_value_get_by_name(&value, "stamp_updated", &field, NULL));
       pm_avro_check(avro_value_set_branch(&field, 1, &branch));
       pm_avro_check(avro_value_set_string(&branch, tstamp_str));
@@ -1248,7 +1365,7 @@ void write_avro_schema_to_file(char *filename, avro_schema_t schema)
 
     if (p_avro_schema_writer) {
       if (avro_schema_to_json(schema, p_avro_schema_writer)) {
-	goto exit_lane;
+        goto exit_lane;
       }
     }
     else goto exit_lane;
@@ -1336,7 +1453,7 @@ char *compose_avro_purge_schema(avro_schema_t avro_schema, char *writer_name)
 
 char *compose_avro_schema_name(char *extra1, char *extra2)
 {
-  int len_base = 0, len_extra1 = 0, len_extra2 = 0, len_total = 0; 
+  int len_base = 0, len_extra1 = 0, len_extra2 = 0, len_total = 0;
   char *schema_name = NULL;
 
   if (extra1) len_extra1 = strlen(extra1);
@@ -1344,13 +1461,13 @@ char *compose_avro_schema_name(char *extra1, char *extra2)
     if (len_extra1) len_extra1++;
     len_extra2 = strlen(extra2);
   }
-  
+
   if (len_extra1 || len_extra2) len_base = strlen("pmacct_");
   else len_base = strlen("pmacct");
 
   len_total = len_base + len_extra1 + len_extra2 + 1;
 
-  schema_name = malloc(len_total);  
+  schema_name = malloc(len_total);
   if (!schema_name) {
     Log(LOG_ERR, "ERROR ( %s/%s ): compose_avro_schema_name(): malloc() failed. Exiting.\n", config.name, config.type);
     pm_avro_exit_gracefully(1);
@@ -1381,7 +1498,7 @@ void p_avro_serdes_logger(serdes_t *sd_desc, int level, const char *fac, const c
 }
 
 serdes_schema_t *compose_avro_schema_registry_name_2(char *topic, int is_topic_dyn,
-		avro_schema_t avro_schema, char *type, char *name, char *schema_registry)
+                avro_schema_t avro_schema, char *type, char *name, char *schema_registry)
 {
   serdes_schema_t *loc_schema = NULL;
   char *loc_schema_name = NULL;
@@ -1399,14 +1516,14 @@ serdes_schema_t *compose_avro_schema_registry_name_2(char *topic, int is_topic_d
   strcat(loc_schema_name, "_");
   strcat(loc_schema_name, name);
 
-  loc_schema = compose_avro_schema_registry_name(loc_schema_name, FALSE, avro_schema, NULL, NULL, schema_registry); 
+  loc_schema = compose_avro_schema_registry_name(loc_schema_name, FALSE, avro_schema, NULL, NULL, schema_registry);
   free(loc_schema_name);
 
-  return loc_schema; 
+  return loc_schema;
 }
 
 serdes_schema_t *compose_avro_schema_registry_name(char *topic, int is_topic_dyn,
-		avro_schema_t avro_schema, char *type, char *name, char *schema_registry)
+                avro_schema_t avro_schema, char *type, char *name, char *schema_registry)
 {
   serdes_conf_t *sd_conf;
   serdes_t *sd_desc;
@@ -1445,11 +1562,11 @@ serdes_schema_t *compose_avro_schema_registry_name(char *topic, int is_topic_dyn
   else {
     if (!config.debug) {
       Log(LOG_INFO, "INFO ( %s/%s ): serdes_schema_add(): name=%s id=%d\n", config.name, config.type,
-	  serdes_schema_name(loc_schema), serdes_schema_id(loc_schema));
+          serdes_schema_name(loc_schema), serdes_schema_id(loc_schema));
     }
     else {
       Log(LOG_DEBUG, "DEBUG ( %s/%s ): serdes_schema_add(): name=%s id=%d definition=%s\n", config.name, config.type,
-	  serdes_schema_name(loc_schema), serdes_schema_id(loc_schema), serdes_schema_definition(loc_schema));
+          serdes_schema_name(loc_schema), serdes_schema_id(loc_schema), serdes_schema_definition(loc_schema));
     }
   }
 
@@ -1514,7 +1631,7 @@ void compose_label_avro_schema_nonopt(avro_schema_t sc_type_record)
 {
   sc_type_string = avro_schema_string();
   sc_type_map = avro_schema_map(sc_type_string);
-    
+
   avro_schema_record_field_append(sc_type_record, "label", sc_type_map);
 
   /* free-up memory - avro map only*/
@@ -1569,6 +1686,17 @@ void compose_srv6_segment_ipv6_list_schema(avro_schema_t sc_type_record)
   sc_type_string = avro_schema_string();
   sc_type_array = avro_schema_array(sc_type_string);
   avro_schema_record_field_append(sc_type_record, "srv6_seg_ipv6_list", sc_type_array);
+
+  /* free-up memory */
+  avro_schema_decref(sc_type_array);
+  avro_schema_decref(sc_type_string);
+}
+
+void compose_str_linked_list_to_avro_array_schema(avro_schema_t sc_type_record, const char *comm_type)
+{
+  sc_type_string = avro_schema_string();
+  sc_type_array = avro_schema_array(sc_type_string);
+  avro_schema_record_field_append(sc_type_record, comm_type, sc_type_array);
 
   /* free-up memory */
   avro_schema_decref(sc_type_array);
@@ -1720,7 +1848,7 @@ int compose_fwd_status_avro_data(size_t fwdstatus_decimal, avro_value_t v_type_r
   size_t ll_size = cdada_list_size(ll);
 
   avro_value_t v_type_string;
-  
+
   /* default fwdstatus */
   if ((fwdstatus_decimal >= 0) && (fwdstatus_decimal <= 63)) {
     if (avro_value_get_by_name(&v_type_record, "fwd_status", &v_type_string, NULL) == 0) {
@@ -1758,7 +1886,7 @@ int compose_fwd_status_avro_data(size_t fwdstatus_decimal, avro_value_t v_type_r
       }
     }
   }
-  
+
   /* free-up memory */
   cdada_list_destroy(ll);
 
@@ -1847,3 +1975,31 @@ int compose_srv6_segment_ipv6_list_data(struct host_addr *ipv6_list, int list_le
 
   return FALSE;
 }
+
+int compose_str_linked_list_to_avro_array_data(const char *delim_str, const char *delim_str_type, avro_value_t v_type_record)
+{
+  generic_delim_string delim_s = {0};
+
+  /* linked-list creation */
+  cdada_list_t *ll = generic_delim_str_to_linked_list(delim_str, GENERIC_STR_DELIM);
+  size_t ll_size = cdada_list_size(ll);
+
+  avro_value_t v_type_array, v_type_string;
+
+  size_t idx_0;
+  for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&delim_s, 0, sizeof(delim_s));
+    cdada_list_get(ll, idx_0, &delim_s);
+    if (avro_value_get_by_name(&v_type_record, delim_str_type, &v_type_array, NULL) == 0) {
+      if (avro_value_append(&v_type_array, &v_type_string, NULL) == 0) {
+        avro_value_set_string(&v_type_string, delim_s.delim_str);
+      }
+    }
+  }
+
+  /* free-up memory */
+  cdada_list_destroy(ll);
+
+  return 0;
+}
+

--- a/src/plugin_cmn_avro.h
+++ b/src/plugin_cmn_avro.h
@@ -53,6 +53,7 @@ extern void compose_tunnel_tcpflags_avro_schema(avro_schema_t);
 extern void compose_fwd_status_avro_schema(avro_schema_t);
 extern void compose_mpls_label_stack_schema(avro_schema_t);
 extern void compose_srv6_segment_ipv6_list_schema(avro_schema_t);
+extern void compose_str_linked_list_to_avro_array_schema(avro_schema_t, const char *);
 extern int compose_label_avro_data_opt(char *, avro_value_t);
 extern int compose_label_avro_data_nonopt(char *, avro_value_t);
 extern int compose_tcpflags_avro_data(size_t, avro_value_t);
@@ -60,6 +61,7 @@ extern int compose_tunnel_tcpflags_avro_data(size_t, avro_value_t);
 extern int compose_mpls_label_stack_data(u_int32_t *, int, avro_value_t);
 extern int compose_srv6_segment_ipv6_list_data(struct host_addr *, int, avro_value_t);
 extern int compose_fwd_status_avro_data(size_t, avro_value_t);
+extern int compose_str_linked_list_to_avro_array_data(const char *, const char *, avro_value_t);
 
 extern void pm_avro_exit_gracefully(int);
 
@@ -95,6 +97,14 @@ extern serdes_schema_t *compose_avro_schema_registry_name_2(char *, int, avro_sc
 
 /* global variables */
 extern avro_schema_t p_avro_acct_schema, p_avro_acct_init_schema, p_avro_acct_close_schema;
+typedef void (*compose_bgp_comm_to_avro_array_schema_type)(avro_schema_t, const char *);
+typedef int (*compose_bgp_comm_to_avro_array_data_type)(const char *, const char *, avro_value_t);
+typedef void (*compose_as_path_to_avro_array_schema_type)(avro_schema_t, const char *);
+typedef int (*compose_as_path_to_avro_array_data_type)(const char *, const char *, avro_value_t);
+extern compose_bgp_comm_to_avro_array_schema_type compose_bgp_comm_to_avro_array_schema;
+extern compose_bgp_comm_to_avro_array_data_type compose_bgp_comm_to_avro_array_data;
+extern compose_as_path_to_avro_array_schema_type compose_as_path_to_avro_array_schema;
+extern compose_as_path_to_avro_array_data_type compose_as_apth_to_avro_array_data;
 #endif
 
 #endif //PLUGIN_CMN_AVRO_H

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1,6 +1,6 @@
 /*
     pmacct (Promiscuous mode IP Accounting package)
-    pmacct is Copyright (C) 2003-2023 by Paolo Lucente
+    pmacct is Copyright (C) 2003-2022 by Paolo Lucente
 */
 
 /*
@@ -31,13 +31,13 @@
 
 /* Global variables */
 void (*insert_func)(struct primitives_ptrs *, struct insert_data *); /* pointer to INSERT function */
-void (*purge_func)(struct chained_cache *[], int, int); /* pointer to purge function */ 
+void (*purge_func)(struct chained_cache *[], int, int); /* pointer to purge function */
 struct scratch_area sa;
 struct chained_cache *cache;
 struct chained_cache **queries_queue, **pending_queries_queue, *pqq_container;
 struct timeval flushtime;
 int qq_ptr, pqq_ptr, pp_size, pb_size, pn_size, pm_size, pt_size, pc_size;
-int dbc_size, quit; 
+int dbc_size, quit;
 time_t refresh_deadline;
 
 void (*basetime_init)(time_t);
@@ -57,7 +57,7 @@ void P_set_signals()
   signal(SIGPIPE, SIG_IGN);
   signal(SIGCHLD, SIG_IGN);
 }
- 
+
 void P_init_default_values()
 {
   if (config.pidfile) write_pid_file_plugin(config.pidfile, config.type, config.name);
@@ -103,8 +103,8 @@ void P_init_default_values()
   sa.size = sa.num*dbc_size;
 
   Log(LOG_INFO, "INFO ( %s/%s ): cache entries=%d base cache memory=%" PRIu64 " bytes\n", config.name, config.type,
-	config.print_cache_entries, ((config.print_cache_entries * dbc_size) + (2 * ((sa.num +
-	config.print_cache_entries) * sizeof(struct chained_cache *))) + sa.size));
+        config.print_cache_entries, ((config.print_cache_entries * dbc_size) + (2 * ((sa.num +
+        config.print_cache_entries) * sizeof(struct chained_cache *))) + sa.size));
 
   cache = (struct chained_cache *) pm_malloc(config.print_cache_entries*dbc_size);
   queries_queue = (struct chained_cache **) pm_malloc((sa.num+config.print_cache_entries)*sizeof(struct chained_cache *));
@@ -221,7 +221,7 @@ struct chained_cache *P_cache_search(struct primitives_ptrs *prim_ptrs)
       }
     }
   }
-  else return cache_ptr; 
+  else return cache_ptr;
 
   return NULL;
 }
@@ -273,7 +273,7 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
   start:
   res_data = res_bgp = res_nat = res_mpls = res_tun = res_time = res_cust = res_vlen = TRUE;
 
-  res_data = memcmp(&cache_ptr->primitives, srcdst, sizeof(struct pkt_primitives)); 
+  res_data = memcmp(&cache_ptr->primitives, srcdst, sizeof(struct pkt_primitives));
 
   if (basetime_cmp) {
     res_time = (*basetime_cmp)(&cache_ptr->basetime, &ibasetime);
@@ -301,7 +301,7 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
   else res_tun = FALSE;
 
   if (pcust) {
-    if (cache_ptr->pcust) res_cust = memcmp(cache_ptr->pcust, pcust, config.cpptrs.len); 
+    if (cache_ptr->pcust) res_cust = memcmp(cache_ptr->pcust, pcust, config.cpptrs.len);
   }
   else res_cust = FALSE;
 
@@ -312,18 +312,18 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
 
   if (res_data || res_bgp || res_nat || res_mpls || res_tun || res_time || res_cust || res_vlen) {
     /* aliasing of entries */
-    if (cache_ptr->valid == PRINT_CACHE_INUSE) { 
+    if (cache_ptr->valid == PRINT_CACHE_INUSE) {
       if (cache_ptr->next) {
-	cache_ptr = cache_ptr->next;
-	goto start;
+        cache_ptr = cache_ptr->next;
+        goto start;
       }
       else {
-	cache_ptr = P_cache_attach_new_node(cache_ptr); 
-	if (!cache_ptr) goto safe_action;
-	else {
-	  queries_queue[qq_ptr] = cache_ptr;
-	  qq_ptr++;
-	}
+        cache_ptr = P_cache_attach_new_node(cache_ptr);
+        if (!cache_ptr) goto safe_action;
+        else {
+          queries_queue[qq_ptr] = cache_ptr;
+          qq_ptr++;
+        }
       }
     }
     else {
@@ -404,11 +404,11 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
 
     if (config.nfacctd_stitching) {
       if (!cache_ptr->stitch) {
-	cache_ptr->stitch = (struct pkt_stitching *) malloc(sizeof(struct pkt_stitching));
+        cache_ptr->stitch = (struct pkt_stitching *) malloc(sizeof(struct pkt_stitching));
       }
 
       if (cache_ptr->stitch) {
-	P_set_stitch(cache_ptr, data, idata);
+        P_set_stitch(cache_ptr, data, idata);
       }
       else Log(LOG_WARNING, "WARN ( %s/%s ): Finished memory for flow stitching.\n", config.name, config.type);
     }
@@ -429,9 +429,9 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
       cache_ptr->tunnel_tcp_flags |= data->tunnel_tcp_flags;
 
       if (config.nfacctd_stitching) {
-	if (cache_ptr->stitch) {
-	  P_update_stitch(cache_ptr, data, idata);
-	}
+        if (cache_ptr->stitch) {
+          P_update_stitch(cache_ptr, data, idata);
+        }
       }
     }
     else {
@@ -444,7 +444,7 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
       cache_ptr->tunnel_tcp_flags = data->tunnel_tcp_flags;
 
       if (config.nfacctd_stitching) {
-	P_set_stitch(cache_ptr, data, idata);
+        P_set_stitch(cache_ptr, data, idata);
       }
 
       cache_ptr->valid = PRINT_CACHE_INUSE;
@@ -481,8 +481,8 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
     if (dump_writers_get_flags() != CHLD_ALERT) {
       switch (ret = fork()) {
       case 0: /* Child */
-	pm_setproctitle("%s %s [%s]", config.type, "Plugin -- Writer (urgent)", config.name);
-	config.is_forked = TRUE;
+        pm_setproctitle("%s %s [%s]", config.type, "Plugin -- Writer (urgent)", config.name);
+        config.is_forked = TRUE;
 
         (*purge_func)(queries_queue, qq_ptr, TRUE);
 
@@ -491,7 +491,7 @@ void P_cache_insert(struct primitives_ptrs *prim_ptrs, struct insert_data *idata
         if (ret == -1) Log(LOG_WARNING, "WARN ( %s/%s ): Unable to fork writer: %s\n", config.name, config.type, strerror(errno));
         else dump_writers_add(ret);
 
-	break;
+        break;
       }
     }
     else Log(LOG_WARNING, "WARN ( %s/%s ): Maximum number of writer processes reached (%d).\n", config.name, config.type, dump_writers_get_active());
@@ -557,7 +557,7 @@ void P_cache_insert_pending(struct chained_cache *queue[], int index, struct cha
     if (cache_ptr->pvlen) free(cache_ptr->pvlen);
     if (cache_ptr->stitch) free(cache_ptr->stitch);
 
-    memcpy(cache_ptr, &container[j], dbc_size); 
+    memcpy(cache_ptr, &container[j], dbc_size);
 
     container[j].pbgp = NULL;
     container[j].pnat = NULL;
@@ -635,7 +635,7 @@ void P_cache_mark_flush(struct chained_cache *queue[], int index, int exiting)
 
   /* check-pointing */
   if (new_basetime.tv_sec) commit_basetime.tv_sec = new_basetime.tv_sec;
-  else commit_basetime.tv_sec = basetime.tv_sec; 
+  else commit_basetime.tv_sec = basetime.tv_sec;
 
   /* evaluating any delay we may have to introduce */
   if (config.sql_startup_delay) {
@@ -654,13 +654,13 @@ void P_cache_mark_flush(struct chained_cache *queue[], int index, int exiting)
     }
 
     if (pqq_ptr) {
-      pqq_container = (struct chained_cache *) malloc(pqq_ptr*dbc_size); 
+      pqq_container = (struct chained_cache *) malloc(pqq_ptr*dbc_size);
       if (!pqq_container) {
-	Log(LOG_ERR, "ERROR ( %s/%s ): P_cache_mark_flush() cannot allocate pqq_container. Exiting ..\n", config.name, config.type);
-	exit_gracefully(1); 
+        Log(LOG_ERR, "ERROR ( %s/%s ): P_cache_mark_flush() cannot allocate pqq_container. Exiting ..\n", config.name, config.type);
+        exit_gracefully(1);
       }
     }
-    
+
     /* we copy un-committed elements to a container structure for re-insertion
        in cache. As we copy elements out of the cache we mark entries as free */
     for (j = 0; j < pqq_ptr; j++) {
@@ -932,7 +932,7 @@ void P_update_time_reference(struct insert_data *idata)
       new_basetime.tv_sec = basetime.tv_sec;
       basetime.tv_sec += timeslot;
       if (config.sql_history == COUNT_MONTHLY)
-	timeslot = calc_monthly_timeslot(basetime.tv_sec, config.sql_history_howmany, ADD);
+        timeslot = calc_monthly_timeslot(basetime.tv_sec, config.sql_history_howmany, ADD);
     }
   }
 }
@@ -994,18 +994,16 @@ cdada_list_t *ptm_labels_to_linked_list(const char *ptm_labels)
   }
 
   size_t tokens_counter = 0;
-  char *saveptr = NULL;
-
-  for (token = strtok_r(ptm_array_labels, DEFAULT_SEP, &saveptr); token != NULL; token = strtok_r(NULL, DEFAULT_SEP, &saveptr)) {
+  for (token = strtok(ptm_array_labels, DEFAULT_SEP); token != NULL; token = strtok(NULL, DEFAULT_SEP)) {
     tokens[tokens_counter] = token;
     tokens_counter++;
   }
 
   size_t list_counter;
   for (list_counter = 0;
-	(list_counter < tokens_counter) && (tokens[list_counter] != NULL) &&
-	((list_counter + 1) < tokens_counter) && (tokens[list_counter + 1] != NULL);
-	list_counter += 2) {
+        (list_counter < tokens_counter) && (tokens[list_counter] != NULL) &&
+        ((list_counter + 1) < tokens_counter) && (tokens[list_counter + 1] != NULL);
+        list_counter += 2) {
     memset(&lbl, 0, sizeof(lbl));
 
     if (strlen(tokens[list_counter]) > (MAX_PTM_LABEL_TOKEN_LEN - 1)) {
@@ -1121,6 +1119,36 @@ cdada_list_t *fwd_status_to_linked_list()
   return fwd_status_linked_list;
 }
 
+cdada_list_t *generic_delim_str_to_linked_list(const char *generic_delim_str, const char *generic_str_delim)
+{
+  generic_delim_string delim_s = {0};
+
+  /* Setting the defualt delimiter */
+  if (generic_str_delim == NULL) {
+    generic_str_delim = " ";
+  }
+
+  cdada_list_t *delim_str_to_linked_list = cdada_list_create(generic_delim_str);
+  if (!delim_str_to_linked_list) {
+      Log(LOG_ERR, "ERROR ( %s/%s ): generic_delim_str_to_linked_list() cannot instantiate delim_str_to_linked_list. Exiting ..\n", config.name, config.type);
+      exit_gracefully(1);
+  }
+
+  /* Safer to work on a copy of the original string*/
+  char generic_delim_str_cpy[MAX_GENERIC_DELIM_STR_LEN];
+  strncpy(generic_delim_str_cpy, generic_delim_str, MAX_GENERIC_DELIM_STR_LEN);
+  generic_delim_str_cpy[MAX_GENERIC_DELIM_STR_LEN - 1] = '\0';
+
+  char *saveptr = NULL;
+  for (char *token = strtok_r(generic_delim_str_cpy, generic_str_delim, &saveptr); token != NULL; token = strtok_r(NULL, generic_str_delim, &saveptr)) {
+      memset(&delim_s, 0, sizeof(delim_s));
+      strncpy(delim_s.delim_str, token, MAX_GENERIC_DELIM_STR_LEN - 1);
+      cdada_list_push_back(delim_str_to_linked_list, &delim_s);
+  }
+
+  return delim_str_to_linked_list;
+}
+
 void mpls_label_stack_to_str(char *str_label_stack, int sls_len, u_int32_t *label_stack, int ls_len)
 {
   int max_mpls_label_stack_dec = 0, idx_0;
@@ -1172,52 +1200,52 @@ void load_protos(char *filename, struct protos_table *pt)
       memset(pt, 0, sizeof(struct protos_table));
 
       while (!feof(file)) {
-        if (fgets(buf, sizeof(buf), file)) { 
-	  if (strchr(buf, '\n')) { 
+        if (fgets(buf, sizeof(buf), file)) {
+          if (strchr(buf, '\n')) {
             if (!newline) {
-	      newline = TRUE; 
-	      continue;
-	    }
-	  }
-	  else {
+              newline = TRUE;
+              continue;
+            }
+          }
+          else {
             if (!newline) continue;
-	    newline = FALSE;
-	  }
-	  trim_spaces(buf);
-	  buf_eff_len = strlen(buf);
-	  if (!buf_eff_len || (buf[0] == '!')) {
-	    continue;
-	  }
+            newline = FALSE;
+          }
+          trim_spaces(buf);
+          buf_eff_len = strlen(buf);
+          if (!buf_eff_len || (buf[0] == '!')) {
+            continue;
+          }
 
-	  for (idx = 0, ret = 0; idx < buf_eff_len; idx++) {
-	    ret = isdigit(buf[idx]);
-	    if (!ret) {
-	      break;
-	    }
-	  }
+          for (idx = 0, ret = 0; idx < buf_eff_len; idx++) {
+            ret = isdigit(buf[idx]);
+            if (!ret) {
+              break;
+            }
+          }
 
-	  if (!ret) {
-	    for (idx = 0; _protocols[idx].number != -1; idx++) {
-	      if (!strcmp(buf, _protocols[idx].name)) {
-		ret = _protocols[idx].number;
-		break;
-	      }
-	    }
-	  }
-	  else {
-	    ret = atoi(buf); 
-	  }
+          if (!ret) {
+            for (idx = 0; _protocols[idx].number != -1; idx++) {
+              if (!strcmp(buf, _protocols[idx].name)) {
+                ret = _protocols[idx].number;
+                break;
+              }
+            }
+          }
+          else {
+            ret = atoi(buf);
+          }
 
-	  /* 255 / 'others' excluded from valid IP protocols */
-	  if ((ret >= 0) && (ret < (PROTOS_TABLE_ENTRIES - 1))) {
-	    pt->table[ret] = TRUE;
-	  }
-	  else {
-	    Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] invalid protocol specified.\n", config.name, config.type, filename, rows); 
-	  }
+          /* 255 / 'others' excluded from valid IP protocols */
+          if ((ret >= 0) && (ret < (PROTOS_TABLE_ENTRIES - 1))) {
+            pt->table[ret] = TRUE;
+          }
+          else {
+            Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] invalid protocol specified.\n", config.name, config.type, filename, rows);
+          }
 
-	  rows++;
-	}
+          rows++;
+        }
       }
       fclose(file);
 
@@ -1227,7 +1255,7 @@ void load_protos(char *filename, struct protos_table *pt)
   }
 
   /* filename check to not print nulls as load_networks()
-     may not be secured inside an if statement */ 
+     may not be secured inside an if statement */
   if (filename) {
     Log(LOG_INFO, "INFO ( %s/%s ): [%s] map successfully (re)loaded.\n", config.name, config.type, filename);
   }
@@ -1263,23 +1291,23 @@ void load_ports(char *filename, struct ports_table *pt)
       memset(pt, 0, sizeof(struct ports_table));
 
       while (!feof(file)) {
-        if (fgets(buf, 8, file)) { 
-	  if (strchr(buf, '\n')) { 
+        if (fgets(buf, 8, file)) {
+          if (strchr(buf, '\n')) {
             if (!newline) {
-	      newline = TRUE; 
-	      continue;
-	    }
-	  }
-	  else {
+              newline = TRUE;
+              continue;
+            }
+          }
+          else {
             if (!newline) continue;
-	    newline = FALSE;
-	  }
-	  trim_spaces(buf);
-	  if (!strlen(buf) || (buf[0] == '!')) continue;
-	  ret = atoi(buf); 
-	  if ((ret > 0) && (ret < PORTS_TABLE_ENTRIES)) pt->table[ret] = TRUE;
-	  else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] invalid port specified.\n", config.name, config.type, filename, rows); 
-	}
+            newline = FALSE;
+          }
+          trim_spaces(buf);
+          if (!strlen(buf) || (buf[0] == '!')) continue;
+          ret = atoi(buf);
+          if ((ret > 0) && (ret < PORTS_TABLE_ENTRIES)) pt->table[ret] = TRUE;
+          else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] invalid port specified.\n", config.name, config.type, filename, rows);
+        }
       }
       fclose(file);
 
@@ -1289,7 +1317,7 @@ void load_ports(char *filename, struct ports_table *pt)
   }
 
   /* filename check to not print nulls as load_networks()
-     may not be secured inside an if statement */ 
+     may not be secured inside an if statement */
   if (filename) {
     Log(LOG_INFO, "INFO ( %s/%s ): [%s] map successfully (re)loaded.\n", config.name, config.type, filename);
   }
@@ -1311,3 +1339,4 @@ void load_tos(char *filename, struct protos_table *tost)
 {
   load_protos(filename, tost);
 }
+

--- a/src/plugin_common.h
+++ b/src/plugin_common.h
@@ -27,16 +27,18 @@
 #include "preprocess.h"
 
 /* defines */
-#define DEFAULT_PLUGIN_COMMON_REFRESH_TIME 60 
+#define DEFAULT_PLUGIN_COMMON_REFRESH_TIME 60
 #define DEFAULT_PLUGIN_COMMON_WRITERS_NO 10
 #define DEFAULT_PLUGIN_COMMON_RECV_BUDGET 100
 
 #define AVERAGE_CHAIN_LEN 10
 #define PRINT_CACHE_ENTRIES 16411
-#define MAX_PTM_LABEL_TOKEN_LEN	128
+#define MAX_PTM_LABEL_TOKEN_LEN 128
 #define TCP_FLAG_LEN 6
 #define FWD_TYPES_STR_LEN 50
 #define MAX_MPLS_LABEL_STACK 128
+#define MAX_GENERIC_DELIM_STR_LEN 256
+#define GENERIC_STR_DELIM " "
 
 #define PORTS_TABLE_ENTRIES  65536
 #define PROTOS_TABLE_ENTRIES 256
@@ -45,11 +47,11 @@
 #define PM_IP_TOS_OTHERS 255
 
 /* cache element states */
-#define PRINT_CACHE_FREE	0
-#define PRINT_CACHE_COMMITTED	1
-#define PRINT_CACHE_INUSE	2 
-#define PRINT_CACHE_INVALID	3 
-#define PRINT_CACHE_ERROR	255
+#define PRINT_CACHE_FREE        0
+#define PRINT_CACHE_COMMITTED   1
+#define PRINT_CACHE_INUSE       2
+#define PRINT_CACHE_INVALID     3
+#define PRINT_CACHE_ERROR       255
 
 /* structures */
 #ifndef STRUCT_SCRATCH_AREA
@@ -120,7 +122,7 @@ typedef struct {
 #endif
 
 #ifndef STRUCT_PORTS_TABLE
-#define STRUCT_PORTS_TABLE 
+#define STRUCT_PORTS_TABLE
 struct ports_table {
   u_int8_t table[PORTS_TABLE_ENTRIES];
   time_t timestamp;
@@ -128,11 +130,18 @@ struct ports_table {
 #endif
 
 #ifndef STRUCT_PROTOS_TABLE
-#define STRUCT_PROTOS_TABLE 
+#define STRUCT_PROTOS_TABLE
 struct protos_table {
   u_int8_t table[PROTOS_TABLE_ENTRIES];
   time_t timestamp;
 };
+#endif
+
+#ifndef STRUCT_DELIM_STR
+#define STRUCT_DELIM_STR
+typedef struct {
+  char delim_str[MAX_GENERIC_DELIM_STR_LEN];
+} __attribute__((packed)) generic_delim_string;
 #endif
 
 #include "sql_common.h"
@@ -171,6 +180,7 @@ extern void P_update_stitch(struct chained_cache *, struct pkt_data *, struct in
 extern cdada_list_t *ptm_labels_to_linked_list(const char *);
 extern cdada_list_t *tcpflags_to_linked_list(size_t);
 extern cdada_list_t *fwd_status_to_linked_list();
+extern cdada_list_t *generic_delim_str_to_linked_list(const char *, const char *);
 
 extern void mpls_label_stack_to_str(char *, int, u_int32_t *, int);
 
@@ -180,13 +190,13 @@ extern void load_tos(char *, struct protos_table *);
 
 /* global vars */
 extern void (*insert_func)(struct primitives_ptrs *, struct insert_data *); /* pointer to INSERT function */
-extern void (*purge_func)(struct chained_cache *[], int, int); /* pointer to purge function */ 
+extern void (*purge_func)(struct chained_cache *[], int, int); /* pointer to purge function */
 extern struct scratch_area sa;
 extern struct chained_cache *cache;
 extern struct chained_cache **queries_queue, **pending_queries_queue, *pqq_container;
 extern struct timeval flushtime;
 extern int qq_ptr, pqq_ptr, pp_size, pb_size, pn_size, pm_size, pt_size, pc_size;
-extern int dbc_size, quit; 
+extern int dbc_size, quit;
 extern time_t refresh_deadline;
 
 extern void (*basetime_init)(time_t);


### PR DESCRIPTION
### Summary

This PR introduces two new configuration keys, `bgp_comms_encode_as_array` and `as_path_encode_as_array`, that allow users to specify that BGP communities & the AS_PATH are encoded as an AVRO array.

#### BGP Communities Encoding

- Added the `bgp_comms_encode_as_array` key to control the encoding of BGP communities.
- By default, communities are encoded as a string with underscore-separated integers.
- If set to true, communities are encoded as an array in Apache Avro.
- Currently applicable only to IPFIX data streams with planned support for JSON, BMP, and BGP.

#### AS_PATH Encoding

- Added the `as_path_encode_as_array` key to control the encoding of the AS_PATH.
- By default, AS_PATH is encoded as a string with underscore-separated integers.
- If set to true, AS_PATH is encoded as an array in Apache Avro.
- Currently applicable only to IPFIX data streams with planned support for JSON, BMP, and BGP.

#### Example

```json
{
  "label": {
    "nkey": "CGN813-1",
    "pkey": "CGN"
  },
  "comms": [
    "60633:20",
    "60633:20",
    "60633:22",
    "60633:23",
    "60633:10",
    "60633:10",
    "64497:27",
    "64499:12"
  ],
  "ecomms": [
    "RT:60633"
  ],
  "lcomms": [],
  "as_path": [
    "42598438",
    "42000733",
    "60633",
    "42000723",
    "65536"
  ],
  "comms_src": [],
  "ecomms_src": [],
  "lcomms_src": [],
  "as_path_src": [
    "42598438",
    "42000733",
    "42598508"
  ],
...
```
### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)