### PR TITLE
Implement flowset pre-processing checks (on end-of-flowset-padding)

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -2105,6 +2105,19 @@ DESC:		This knob is to use the socket address instead of the one passed as part 
 		send Agent Address and that is used by default.
 DEFAULT:	false
 
+KEY:		[ nfacctd_pre_processing_checks ] [GLOBAL, ONLY_NFACCTD]
+VALUES:         [ true | false ]
+DESC:		This knob is to enable some pre-processing checks on the IPFIX/NFv9 Data Records in order 
+                to ensure these would not contain incorrect information (e.g. due to buggy router sending 
+                garbage or a wrong template). If enabled, flowsets that are considered malformed according 
+                to the currently implemented checks (see NOTES below) will be discarded and not processed 
+                by nfacctd. Additional checks might be implemented in the future.
+DEFAULT:	false
+NOTES:          * Currently implemented pre-processing checks:
+                  - end-of-flowset padding: malformed if contains non-zero bytes (before enabling these 
+                    checks consider that RFC7011[IPFIX] mandates zero-octets padding whereas RFC3954[NFv9]
+                    only recommends it).
+
 KEY:		pre_tag_map [MAP]
 DESC:		Full pathname to a file containing specific tags for data. For all daemons, tags (be that
 		numerical 'tag' or stringy 'label') can be exposed in output data; traffic daemons (ie.

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -258,6 +258,7 @@ static const struct _dictionary_line dictionary[] = {
   {"nfacctd_kafka_config_file", cfg_key_nfacctd_kafka_config_file},
   {"nfacctd_zmq_address", cfg_key_nfacctd_zmq_address},
   {"nfacctd_dtls_port", cfg_key_nfacctd_dtls_port},
+  {"nfacctd_pre_processing_checks", cfg_key_nfacctd_pre_processing_checks},
   {"mpls_label_stack_encode_as_array", cfg_key_mpls_label_stack_encode_as_array},
   {"pmacctd_proc_name", cfg_key_proc_name},
   {"pmacctd_force_frag_handling", cfg_key_pmacctd_force_frag_handling},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -250,6 +250,7 @@ struct configuration {
   int nfacctd_disable_checks;
   int nfacctd_disable_opt_scope_check;
   int nfacctd_ignore_exporter_address;
+  int nfacctd_pre_processing_checks;
   int telemetry_daemon;
   int telemetry_sock;
   int telemetry_port_tcp;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -8942,3 +8942,17 @@ int cfg_key_nfacctd_bmp_daemon_parse_proxy_header(char *filename, char *name, ch
 
   return changes;
 }
+
+int cfg_key_nfacctd_pre_processing_checks(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  for (; list; list = list->next, changes++) list->cfg.nfacctd_pre_processing_checks = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'nfacctd_pre_processing_checks'. Globalized.\n", filename);
+
+  return changes;
+}

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -531,6 +531,7 @@ extern int cfg_key_tmp_bgp_daemon_origin_type_int(char *, char *, char *);
 extern int cfg_key_tmp_telemetry_daemon_udp_notif_legacy(char *, char *, char *);
 extern int cfg_key_tmp_telemetry_decode_cisco_v1_json_string(char *, char *, char *);
 extern int cfg_key_bgp_bmp_daemon_ha(char *, char *, char *);
+extern int cfg_key_nfacctd_pre_processing_checks(char *, char *, char *);
 
 extern void parse_time(char *, char *, int *, int *);
 extern void cfg_get_primitive_index_value(u_int64_t, u_int64_t *, u_int64_t *);


### PR DESCRIPTION
### Short description
This PR introduces pre-processing checks on IPFIX Data records in nfacctd that can be enabled via a new config knob (nfacctd_pre_processing_checks). Currently the only check implemented is on the end-of-flowset padding, which is considered malformed if it is not composed of 0 bytes. In the future we might add other checks (e.g. on invalid timestamp formats or other fields).

The main purpose of this feature is to discard packets being decoded with a wrong template, which can happen if a router starts sending flow data encoded with a new template reusing older template IDs. This was sometimes observed on some buggy routers upon reboots/upgrades, where we received some data packets before receiving the updated templates. The result of this can be detrimental even with few packets, as all fields are wrongly decoded, delivering crazy numbers for e.g. packet and byte counts.

In general, according to RFCs 3954&7011, template ID reuse should be avoided. At least in any case it should be made sure that no data is being sent before sending out the respective template.

This feature gives us partial protection against some of these scenarios. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
