### PR TITLE
Adding Encoding Options for BGP Communities & AS_PATH, JSON array for IPFIX

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1702,10 +1702,9 @@ DESC:           BGP communities are encoded by default as a string, including a 
                 of integers (community values). Setting this knob to true, makes it being encoded as an
 		array for Apache Avro encodings, i.e., for Standard Communities in Avro: "name": "comms",
 		"type": { "type": "array", "items": { "type": "string" }}.
-                As of now, this configuration is only applicable to IPFIX data streams and does not support
-		JSON encoding, but support for both JSON and additional data streams such as BMP and BGP is
-		planned for future releases. This knob has no effects for other encodings (i.e., CSV,
-		formatted) and backends not supporting complex types (i.e., SQL plugins).
+                As of now, this configuration is only applicable to IPFIX data streams for both AVRO and JSON encoding.
+                Additional data streams such as BMP and BGP is planned for future releases. This knob has no effects 
+                for other encodings (i.e., CSV, formatted) and backends not supporting complex types (i.e., SQL plugins).
 DEFAULT:        false
 
 KEY:            as_path_encode_as_array
@@ -1714,10 +1713,9 @@ DESC:           BGP AS_PATH is encoded by default as a string, including an unde
                 of integers (AS numbers). Setting this knob to true, makes it being encoded as an array
                 for Apache Avro encodings, i.e., in Avro "name": "as_path", "type": { "type": "array",
 		"items": { "type": "string" }}.
-                As of now, this configuration is only applicable to IPFIX data streams and does not support
-		JSON encoding, but support for both JSON and additional data streams such as BMP and BGP is
-		planned for future releases. This knob has no effects for other encodings (i.e., CSV,
-		formatted) and backends not supporting complex types (i.e., SQL plugins).
+                As of now, this configuration is only applicable to IPFIX data streams for both AVRO and JSON encoding.
+                Additional data streams such as BMP and BGP is planned for future releases. This knob has no effects 
+                for other encodings (i.e., CSV, formatted) and backends not supporting complex types (i.e., SQL plugins).
 DEFAULT:        false
 
 KEY:		tos_encode_as_dscp

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -139,22 +139,42 @@ void compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wtc_3)
   }
 
   if (wtc & COUNT_STD_COMM) {
-    cjhandler[idx] = compose_json_std_comm;
+    if (config.bgp_comms_encode_as_array) {
+      cjhandler[idx] = compose_json_array_std_comm;
+    }
+    else {
+      cjhandler[idx] = compose_json_std_comm;
+    }
     idx++;
   }
 
   if (wtc & COUNT_EXT_COMM) {
-    cjhandler[idx] = compose_json_ext_comm;
+    if (config.bgp_comms_encode_as_array) {
+      cjhandler[idx] = compose_json_array_ext_comm;
+    }
+    else {
+      cjhandler[idx] = compose_json_ext_comm;
+    }
     idx++;
   }
 
   if (wtc_2 & COUNT_LRG_COMM) {
-    cjhandler[idx] = compose_json_lrg_comm;
+    if (config.bgp_comms_encode_as_array) {
+      cjhandler[idx] = compose_json_array_lrg_comm;
+    }
+    else {
+      cjhandler[idx] = compose_json_lrg_comm;
+    }
     idx++;
   }
 
   if (wtc & COUNT_AS_PATH) {
-    cjhandler[idx] = compose_json_as_path;
+    if (config.as_path_encode_as_array) {
+      cjhandler[idx] = compose_json_array_as_path;
+    }
+    else {
+      cjhandler[idx] = compose_json_as_path;
+    }
     idx++;
   }
 
@@ -194,22 +214,42 @@ void compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wtc_3)
   }
 
   if (wtc & COUNT_SRC_STD_COMM) {
-    cjhandler[idx] = compose_json_src_std_comm;
+    if (config.bgp_comms_encode_as_array) {
+      cjhandler[idx] = compose_json_array_src_std_comm;
+    }
+    else {
+      cjhandler[idx] = compose_json_src_std_comm;
+    }
     idx++;
   }
 
   if (wtc & COUNT_SRC_EXT_COMM) {
-    cjhandler[idx] = compose_json_src_ext_comm;
+    if (config.bgp_comms_encode_as_array) {
+      cjhandler[idx] = compose_json_array_src_ext_comm;
+    }
+    else {
+      cjhandler[idx] = compose_json_src_ext_comm;
+    }
     idx++;
   }
 
   if (wtc_2 & COUNT_SRC_LRG_COMM) {
-    cjhandler[idx] = compose_json_src_lrg_comm;
+    if (config.bgp_comms_encode_as_array) {
+      cjhandler[idx] = compose_json_array_src_lrg_comm;
+    }
+    else {
+      cjhandler[idx] = compose_json_src_lrg_comm;
+    }
     idx++;
   }
 
   if (wtc & COUNT_SRC_AS_PATH) {
-    cjhandler[idx] = compose_json_src_as_path;
+    if (config.as_path_encode_as_array) {
+      cjhandler[idx] = compose_json_array_src_as_path;
+    }
+    else {
+      cjhandler[idx] = compose_json_src_as_path;
+    }
     idx++;
   }
 
@@ -330,7 +370,7 @@ void compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wtc_3)
     }
     idx++;
   }
-  
+
   if (wtc_2 & COUNT_FWD_STATUS) {
     if (config.fwd_status_encode_as_string) {
       cjhandler[idx] = compose_json_string_fwd_status;
@@ -459,8 +499,8 @@ void compose_json(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wtc_3)
   if (wtc_2 & COUNT_TUNNEL_IP_PROTO) {
     cjhandler[idx] = compose_json_tunnel_proto;
     idx++;
-  } 
-    
+  }
+
   if (wtc_2 & COUNT_TUNNEL_IP_TOS) {
     cjhandler[idx] = compose_json_tunnel_tos;
     idx++;
@@ -614,7 +654,7 @@ void compose_json_src_mac(json_t *obj, struct chained_cache *cc)
 void compose_json_dst_mac(json_t *obj, struct chained_cache *cc)
 {
   char mac[18];
-  
+
   etheraddr_string(cc->primitives.eth_dhost, mac);
   json_object_set_new_nocheck(obj, "mac_dst", json_string(mac));
 }
@@ -1376,7 +1416,7 @@ void compose_json_map_label(json_t *obj, struct chained_cache *cc)
   json_t *root_l1 = compose_label_json_data(ptm_ll, ll_size);
 
   json_object_set_new_nocheck(obj, "label", root_l1);
-  
+
   cdada_str_destroy(lbls_cdada);
   cdada_list_destroy(ptm_ll);
 }
@@ -1405,6 +1445,150 @@ void compose_json_string_fwd_status(json_t *obj, struct chained_cache *cc)
   json_object_set_new_nocheck(obj, "fwd_status", root_l1);
 
   cdada_list_destroy(fwd_status_ll);
+}
+
+void compose_json_array_std_comm(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_STD_COMM, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *std_comm_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(std_comm_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(std_comm_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "comms", root_l1);
+
+  cdada_list_destroy(std_comm_ll);
+}
+
+void compose_json_array_src_std_comm(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_SRC_STD_COMM, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *std_comm_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(std_comm_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(std_comm_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "comms_src", root_l1);
+
+  cdada_list_destroy(std_comm_ll);
+}
+
+void compose_json_array_ext_comm(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_EXT_COMM, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *ext_comm_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(ext_comm_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(ext_comm_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "ecomms", root_l1);
+
+  cdada_list_destroy(ext_comm_ll);
+}
+
+void compose_json_array_src_ext_comm(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_SRC_EXT_COMM, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *ext_comm_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(ext_comm_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(ext_comm_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "ecomms_src", root_l1);
+
+  cdada_list_destroy(ext_comm_ll);
+}
+
+void compose_json_array_lrg_comm(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_LRG_COMM, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *lrg_comm_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(lrg_comm_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(lrg_comm_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "lcomms", root_l1);
+
+  cdada_list_destroy(lrg_comm_ll);
+}
+
+void compose_json_array_src_lrg_comm(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_SRC_LRG_COMM, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *lrg_comm_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(lrg_comm_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(lrg_comm_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "lcomms_src", root_l1);
+
+  cdada_list_destroy(lrg_comm_ll);
+}
+
+void compose_json_array_as_path(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_AS_PATH, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *as_path_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(as_path_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(as_path_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "as_apth", root_l1);
+
+  cdada_list_destroy(as_path_ll);
+}
+
+void compose_json_array_src_as_path(json_t *obj, struct chained_cache *cc)
+{
+  char empty_string[] = "", *str_ptr;
+
+  vlen_prims_get(cc->pvlen, COUNT_INT_SRC_AS_PATH, &str_ptr);
+  if (!str_ptr) str_ptr = empty_string;
+
+  /* linked-list creation */
+  cdada_list_t *as_path_ll = generic_delim_str_to_linked_list(str_ptr, GENERIC_STR_DELIM);;
+  size_t ll_size = cdada_list_size(as_path_ll);
+
+  json_t *root_l1 = compose_str_linked_list_to_json_array_data(as_path_ll, ll_size);
+
+  json_object_set_new_nocheck(obj, "as_apth_src", root_l1);
+
+  cdada_list_destroy(as_path_ll);
 }
 
 void compose_json_array_mpls_label_stack(json_t *obj, struct chained_cache *cc)
@@ -1533,7 +1717,7 @@ json_t *compose_mpls_label_stack_json_data(u_int32_t *label_stack, int ls_len)
     strncat(label_idx_buf, label_buf, (MAX_MPLS_LABEL_IDX_LEN - max_mpls_label_idx_len_dec));
     max_mpls_label_idx_len_dec = (strlen(idx_buf) + strlen("-") + strlen(label_buf) + 3);
     j_str_tmp = json_string(label_idx_buf);
-    json_array_append(root, j_str_tmp); 
+    json_array_append(root, j_str_tmp);
   }
 
   return root;
@@ -1574,7 +1758,27 @@ json_t *compose_srv6_segment_ipv6_list_json_data(struct host_addr *ipv6_list, in
     strcat(idx_ipv6_str, ipv6_str);
 
     j_str_tmp = json_string(idx_ipv6_str);
-    json_array_append(root, j_str_tmp); 
+    json_array_append(root, j_str_tmp);
+  }
+
+  return root;
+}
+
+json_t *compose_str_linked_list_to_json_array_data(cdada_list_t *ll, int ll_size)
+{
+  generic_delim_string delim_s = {0};
+
+  json_t *root = json_array();
+  json_t *j_str_tmp = NULL;
+
+  size_t idx_0;
+  for (idx_0 = 0; idx_0 < ll_size; idx_0++) {
+    memset(&delim_s, 0, sizeof(delim_s));
+    cdada_list_get(ll, idx_0, &delim_s);
+    if (strncmp(delim_s.delim_str, "NULL", (strlen(delim_s.delim_str) - 1)) != 0) {
+      j_str_tmp = json_string(delim_s.delim_str);
+      json_array_append(root, j_str_tmp);
+    }
   }
 
   return root;

--- a/src/plugin_cmn_json.h
+++ b/src/plugin_cmn_json.h
@@ -23,6 +23,7 @@
 #define PLUGIN_CMN_JSON_H
 
 /* typedefs */
+#include "preprocess.h"
 #ifdef WITH_JANSSON
 typedef void (*compose_json_handler)(json_t *, struct chained_cache *);
 #endif
@@ -38,12 +39,21 @@ extern void compose_json_string_fwd_status(json_t *, struct chained_cache *);
 extern void compose_json_array_mpls_label_stack(json_t *, struct chained_cache *);
 extern void compose_json_array_srv6_segment_ipv6_list(json_t *, struct chained_cache *);
 extern void compose_json_array_tunnel_tcp_flags(json_t *, struct chained_cache *);
+extern void compose_json_array_std_comm(json_t *, struct chained_cache *);
+extern void compose_json_array_src_std_comm(json_t *, struct chained_cache *);
+extern void compose_json_array_ext_comm(json_t *, struct chained_cache *);
+extern void compose_json_array_src_ext_comm(json_t *, struct chained_cache *);
+extern void compose_json_array_lrg_comm(json_t *, struct chained_cache *);
+extern void compose_json_array_src_lrg_comm(json_t *, struct chained_cache *);
+extern void compose_json_array_as_path(json_t *, struct chained_cache *);
+extern void compose_json_array_src_as_path(json_t *, struct chained_cache *);
 
 extern json_t *compose_label_json_data(cdada_list_t *, int);
 extern json_t *compose_tcpflags_json_data(cdada_list_t *, int);
 extern json_t *compose_fwd_status_json_data(size_t, cdada_list_t *, int);
 extern json_t *compose_mpls_label_stack_json_data(u_int32_t *, int);
 extern json_t *compose_srv6_segment_ipv6_list_json_data(struct host_addr *, int);
+extern json_t *compose_str_linked_list_to_json_array_data(cdada_list_t *ll, int ll_size);
 
 extern void compose_json_event_type(json_t *, struct chained_cache *);
 extern void compose_json_tag(json_t *, struct chained_cache *);

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1132,7 +1132,7 @@ cdada_list_t *generic_delim_str_to_linked_list(const char *delimited_string, con
 
   cdada_list_t *delim_str_to_linked_list = cdada_list_create(generic_delim_string);
   if (!delim_str_to_linked_list) {
-    Log(LOG_ERR, "ERROR ( %s/%s ): delimited_string_to_linked_list() cannot instantiate delim_str_to_linked_list. Exiting ..\n", config.name, config.type);
+    Log(LOG_ERR, "ERROR ( %s/%s ): generic_delim_str_to_linked_list() cannot instantiate delim_str_to_linked_list. Exiting ..\n", config.name, config.type);
     exit_gracefully(1);
   }
 

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1121,6 +1121,8 @@ cdada_list_t *fwd_status_to_linked_list()
 
 cdada_list_t *generic_delim_str_to_linked_list(const char *generic_delim_str, const char *generic_str_delim)
 {
+  size_t max_generic_delim_str_len = strlen(generic_delim_str) + 1;
+
   generic_delim_string delim_s = {0};
 
   /* Setting the defualt delimiter */
@@ -1128,21 +1130,21 @@ cdada_list_t *generic_delim_str_to_linked_list(const char *generic_delim_str, co
     generic_str_delim = " ";
   }
 
-  cdada_list_t *delim_str_to_linked_list = cdada_list_create(generic_delim_str);
+  cdada_list_t *delim_str_to_linked_list = cdada_list_create(generic_delim_string);
   if (!delim_str_to_linked_list) {
       Log(LOG_ERR, "ERROR ( %s/%s ): generic_delim_str_to_linked_list() cannot instantiate delim_str_to_linked_list. Exiting ..\n", config.name, config.type);
       exit_gracefully(1);
   }
 
-  /* Safer to work on a copy of the original string*/
-  char generic_delim_str_cpy[MAX_GENERIC_DELIM_STR_LEN];
-  strncpy(generic_delim_str_cpy, generic_delim_str, MAX_GENERIC_DELIM_STR_LEN);
-  generic_delim_str_cpy[MAX_GENERIC_DELIM_STR_LEN - 1] = '\0';
+  /* Safer to work on a copy of the original string */
+  char generic_delim_str_cpy[max_generic_delim_str_len];
+  strncpy(generic_delim_str_cpy, generic_delim_str, max_generic_delim_str_len);
+  generic_delim_str_cpy[max_generic_delim_str_len - 1] = '\0';
 
   char *saveptr = NULL;
   for (char *token = strtok_r(generic_delim_str_cpy, generic_str_delim, &saveptr); token != NULL; token = strtok_r(NULL, generic_str_delim, &saveptr)) {
       memset(&delim_s, 0, sizeof(delim_s));
-      strncpy(delim_s.delim_str, token, MAX_GENERIC_DELIM_STR_LEN - 1);
+      strncpy(delim_s.delim_str, token, strlen(token) + 1);
       cdada_list_push_back(delim_str_to_linked_list, &delim_s);
   }
 

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -1119,33 +1119,34 @@ cdada_list_t *fwd_status_to_linked_list()
   return fwd_status_linked_list;
 }
 
-cdada_list_t *generic_delim_str_to_linked_list(const char *generic_delim_str, const char *generic_str_delim)
+cdada_list_t *generic_delim_str_to_linked_list(const char *delimited_string, const char *delimiter)
 {
-  size_t max_generic_delim_str_len = strlen(generic_delim_str) + 1;
+  size_t max_delimited_string_len = strlen(delimited_string) + 1;
 
   generic_delim_string delim_s = {0};
 
   /* Setting the defualt delimiter */
-  if (generic_str_delim == NULL) {
-    generic_str_delim = " ";
+  if (delimiter == NULL) {
+    delimiter = " ";
   }
 
   cdada_list_t *delim_str_to_linked_list = cdada_list_create(generic_delim_string);
   if (!delim_str_to_linked_list) {
-      Log(LOG_ERR, "ERROR ( %s/%s ): generic_delim_str_to_linked_list() cannot instantiate delim_str_to_linked_list. Exiting ..\n", config.name, config.type);
-      exit_gracefully(1);
+    Log(LOG_ERR, "ERROR ( %s/%s ): delimited_string_to_linked_list() cannot instantiate delim_str_to_linked_list. Exiting ..\n", config.name, config.type);
+    exit_gracefully(1);
   }
 
   /* Safer to work on a copy of the original string */
-  char generic_delim_str_cpy[max_generic_delim_str_len];
-  strncpy(generic_delim_str_cpy, generic_delim_str, max_generic_delim_str_len);
-  generic_delim_str_cpy[max_generic_delim_str_len - 1] = '\0';
+  char delimited_string_cpy[max_delimited_string_len];
+  strncpy(delimited_string_cpy, delimited_string, max_delimited_string_len - 1);
+  delimited_string_cpy[max_delimited_string_len - 1] = '\0';
 
   char *saveptr = NULL;
-  for (char *token = strtok_r(generic_delim_str_cpy, generic_str_delim, &saveptr); token != NULL; token = strtok_r(NULL, generic_str_delim, &saveptr)) {
-      memset(&delim_s, 0, sizeof(delim_s));
-      strncpy(delim_s.delim_str, token, strlen(token) + 1);
-      cdada_list_push_back(delim_str_to_linked_list, &delim_s);
+  for (char *token = strtok_r(delimited_string_cpy, delimiter, &saveptr); token != NULL; token = strtok_r(NULL, delimiter, &saveptr)) {
+    memset(&delim_s, 0, sizeof(delim_s));
+    strncpy(delim_s.delim_str, token, MAX_GENERIC_DELIM_STR_TOKEN_LEN - 1);
+    delim_s.delim_str[MAX_GENERIC_DELIM_STR_TOKEN_LEN - 1] = '\0';
+    cdada_list_push_back(delim_str_to_linked_list, &delim_s);
   }
 
   return delim_str_to_linked_list;

--- a/src/plugin_common.h
+++ b/src/plugin_common.h
@@ -37,7 +37,7 @@
 #define TCP_FLAG_LEN 6
 #define FWD_TYPES_STR_LEN 50
 #define MAX_MPLS_LABEL_STACK 128
-#define MAX_GENERIC_DELIM_STR_LEN 256
+#define MAX_GENERIC_DELIM_STR_TOKEN_LEN 128
 #define GENERIC_STR_DELIM " "
 
 #define PORTS_TABLE_ENTRIES  65536
@@ -140,7 +140,7 @@ struct protos_table {
 #ifndef STRUCT_DELIM_STR
 #define STRUCT_DELIM_STR
 typedef struct {
-  char delim_str[MAX_GENERIC_DELIM_STR_LEN];
+  char delim_str[MAX_GENERIC_DELIM_STR_TOKEN_LEN];
 } __attribute__((packed)) generic_delim_string;
 #endif
 


### PR DESCRIPTION
### Summary

This PR complements [PR#713](https://github.com/pmacct/pmacct/pull/713) and allows users to specify that BGP communities & the AS_PATH are encoded as a JSON array for IPFIX.


### Checklist

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behavior changes)