### PR TITLE
nfacctd: handle layer 2 flow information without IP addresses

### DIFF
--- a/src/network.h
+++ b/src/network.h
@@ -626,6 +626,7 @@ struct cache_legacy_bgp_primitives {
 /* END: BGP section */
 
 struct packet_ptrs_vector {
+  struct packet_ptrs l2;
   struct packet_ptrs v4;
   struct packet_ptrs vlan4;
   struct packet_ptrs mpls4;

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -1216,6 +1216,17 @@ int main(int argc,char **argv, char **envp)
      main loop we maintain two packet_ptrs structures when IPv6 is enabled:
      we will sync here 'pptrs6' for common tables and pointers */
   memset(dummy_packet, 0, sizeof(dummy_packet));
+  pptrs.l2.f_agent = (u_char *) &client;
+  pptrs.l2.packet_ptr = dummy_packet;
+  pptrs.l2.pkthdr = &dummy_pkthdr;
+  Assign16(((struct eth_header *)pptrs.l2.packet_ptr)->ether_type, htons(ETHERTYPE_8021Q));
+  pptrs.l2.mac_ptr = (u_char *)((struct eth_header *)pptrs.l2.packet_ptr)->ether_dhost;
+  pptrs.l2.vlan_ptr = pptrs.l2.packet_ptr + ETHER_HDRLEN;
+  // pptrs.l2.pkthdr->caplen = 18; /* eth_header + vlan */
+  pptrs.l2.pkthdr->caplen = 35;
+  pptrs.l2.pkthdr->len = 100; /* fake len */
+
+  memset(dummy_packet, 0, sizeof(dummy_packet));
   pptrs.v4.f_agent = (u_char *) &client;
   pptrs.v4.packet_ptr = dummy_packet;
   pptrs.v4.pkthdr = &dummy_pkthdr;
@@ -2411,6 +2422,51 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
 
 	/* we need to understand the IP protocol version in order to build the fake packet */ 
 	switch (pptrs->flow_type.traffic_type) {
+        case PM_FTYPE_VLAN:
+          pptrsv->l2.f_header = pptrs->f_header;
+          pptrsv->l2.f_data = pptrs->f_data;
+          pptrsv->l2.f_tpl = pptrs->f_tpl;
+          memcpy(&pptrsv->l2.flow_type, &pptrs->flow_type, sizeof(struct flow_chars));
+
+          if (req->bpf_filter) {
+            reset_mac_vlan(&pptrsv->l2);
+            if (direction == DIRECTION_IN) {
+              memcpy(pptrsv->l2.mac_ptr+ETH_ADDR_LEN,
+                     pkt+tpl->fld[NF9_IN_SRC_MAC].off[0],
+                     tpl->fld[NF9_IN_SRC_MAC].len[0]);
+              memcpy(pptrsv->l2.mac_ptr,
+                     pkt+tpl->fld[NF9_IN_DST_MAC].off[0],
+                     tpl->fld[NF9_IN_DST_MAC].len[0]);
+              memcpy(pptrsv->l2.vlan_ptr,
+                     pkt+tpl->fld[NF9_IN_VLAN].off[0],
+                     tpl->fld[NF9_IN_VLAN].len[0]);
+            }
+            else if (direction == DIRECTION_OUT) {
+              memcpy(pptrsv->l2.mac_ptr+ETH_ADDR_LEN,
+                     pkt+tpl->fld[NF9_OUT_SRC_MAC].off[0],
+                     tpl->fld[NF9_OUT_SRC_MAC].len[0]);
+              memcpy(pptrsv->l2.mac_ptr,
+                     pkt+tpl->fld[NF9_OUT_DST_MAC].off[0],
+                     tpl->fld[NF9_OUT_DST_MAC].len[0]);
+              memcpy(pptrsv->l2.vlan_ptr,
+                     pkt+tpl->fld[NF9_OUT_VLAN].off[0],
+                     tpl->fld[NF9_OUT_VLAN].len[0]);
+            }
+          }
+
+          /* Let's copy some relevant fields */
+          pptrsv->l2.l4_proto = 0;
+          NF_process_classifiers(pptrs, &pptrsv->l2, pkt, tpl);
+          if (config.bgp_daemon_to_xflow_agent_map)
+            BTA_find_id((struct id_table *)pptrs->bta_table, &pptrsv->l2, &pptrsv->l2.bta, &pptrsv->l2.bta2);
+          if (config.nfacctd_flow_to_rd_map)
+            NF_find_id((struct id_table *)pptrs->bitr_table, &pptrsv->l2, &pptrsv->l2.bitr, NULL);
+          NF_mpls_vpn_rd_from_map(&pptrsv->l2);
+          NF_mpls_vpn_rd_from_ie90(&pptrsv->l2);
+          NF_mpls_vpn_rd_from_options(&pptrsv->l2);
+          exec_plugins(&pptrsv->l2, req);
+          break;
+
 	case PM_FTYPE_IPV4:
 	  if (req->bpf_filter) {
 	    reset_mac(pptrs);
@@ -2562,6 +2618,7 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
           if (config.bmp_daemon) bmp_srcdst_lookup(&pptrsv->v6, &bl_info);
           exec_plugins(&pptrsv->v6, req);
 	  break;
+
 	case PM_FTYPE_VLAN_IPV4:
 	  pptrsv->vlan4.f_header = pptrs->f_header;
 	  pptrsv->vlan4.f_data = pptrs->f_data;

--- a/src/xflow_status.c
+++ b/src/xflow_status.c
@@ -263,6 +263,7 @@ create_class_entry_status_table(xflow_status_table_t *table, struct xflow_status
 
 void set_vector_f_status(struct packet_ptrs_vector *pptrsv)
 {
+  pptrsv->l2.f_status = pptrsv->v4.f_status;
   pptrsv->vlan4.f_status = pptrsv->v4.f_status;
   pptrsv->mpls4.f_status = pptrsv->v4.f_status;
   pptrsv->vlanmpls4.f_status = pptrsv->v4.f_status;
@@ -275,6 +276,7 @@ void set_vector_f_status(struct packet_ptrs_vector *pptrsv)
 
 void set_vector_f_status_g(struct packet_ptrs_vector *pptrsv)
 {
+  pptrsv->l2.f_status_g = pptrsv->v4.f_status_g;
   pptrsv->vlan4.f_status_g = pptrsv->v4.f_status_g;
   pptrsv->mpls4.f_status_g = pptrsv->v4.f_status_g;
   pptrsv->vlanmpls4.f_status_g = pptrsv->v4.f_status_g;


### PR DESCRIPTION
This PR adds handling of layer 2 flow information without IP addresses to nfacctd which so far is ignored.
I've renamed the packet structure and removed the lookup functions according to your suggestions.