### PR TITLE
rename bgp_attr->flag to rpki_maxlen

### DIFF
--- a/src/bgp/bgp.h
+++ b/src/bgp/bgp.h
@@ -344,7 +344,7 @@ struct bgp_attr {
   struct ecommunity *ecommunity;
   struct lcommunity *lcommunity;
   unsigned long refcnt;
-  u_int8_t flag;
+  u_int8_t rpki_maxlen;
   struct in_addr nexthop;
   struct host_addr mp_nexthop;
   u_int32_t med;

--- a/src/bgp/bgp_util.c
+++ b/src/bgp/bgp_util.c
@@ -471,7 +471,7 @@ int attrhash_cmp(const void *p1, const void *p2)
   const struct bgp_attr *attr1 = (const struct bgp_attr *)p1;
   const struct bgp_attr *attr2 = (const struct bgp_attr *)p2;
 
-  if (attr1->flag == attr2->flag
+  if (attr1->rpki_maxlen == attr2->rpki_maxlen
       && attr1->bitmap == attr2->bitmap
       && attr1->origin == attr2->origin
       && attr1->nexthop.s_addr == attr2->nexthop.s_addr

--- a/src/rpki/rpki_lookup.c
+++ b/src/rpki/rpki_lookup.c
@@ -90,7 +90,7 @@ int rpki_prefix_lookup_node_match_cmp(struct bgp_info *info, struct node_match_c
 {
   if (!info || !info->attr || !info->attr->aspath || !nmct2) return TRUE;
 
-  if (info->attr->flag >= nmct2->p->prefixlen) {
+  if (info->attr->rpki_maxlen >= nmct2->p->prefixlen) {
     if (evaluate_last_asn(info->attr->aspath) == nmct2->last_as) {
       nmct2->ret_code = ROA_STATUS_VALID;
       return FALSE;

--- a/src/rpki/rpki_msg.c
+++ b/src/rpki/rpki_msg.c
@@ -155,7 +155,7 @@ int rpki_info_add(struct bgp_peer *peer, struct prefix *p, as_t asn, u_int8_t ma
   route = bgp_node_get(peer, rib, p);
 
   memset(&attr, 0, sizeof(attr));
-  attr.flag = maxlen; /* abusing flag for maxlen */
+  attr.rpki_maxlen = maxlen;
   attr.aspath = aspath_parse_ast(peer, asn);
   attr_new = bgp_attr_intern(peer, &attr);
   if (attr.aspath) aspath_unintern(peer, attr.aspath);


### PR DESCRIPTION
### Short description
`struct bgp_attr->flag` is only used in rpki for storing a prefix maximum length so let's rename the field to make this explicit :slightly_smiling_face: 
