### PR TITLE
Adding a config knob to exclude BMP stats from regular dump

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -3045,6 +3045,12 @@ DESC:		Enables spreading the load deriving by BGP, BMP and Streaming Telemetry d
 		time.
 DEFAULT:	1
 
+KEY:		bmp_dump_exclude_stats [GLOBAL]
+VALUES:		[ true | false ]
+DESC:		When true, BMP Messages of Type 1 (Statistics Reports) are excluded from the dump
+                mechanism, i.e. they are only exported once in real-time but not cached.
+DEFAULT:	false
+
 KEY:            [ bgp_table_dump_latest_file | bmp_dump_latest_file | telemetry_dump_latest_file ]
 		[GLOBAL]
 DESC:           Defines the full pathname to pointer(s) to latest file(s). Dynamic names are supported

--- a/src/bmp/bmp_msg.c
+++ b/src/bmp/bmp_msg.c
@@ -1034,11 +1034,11 @@ void bmp_process_msg_stats(char **bmp_packet, u_int32_t *len, struct bmp_peer *b
           bmp_log_msg(peer, &bdata, tlvs, &bmp_logdump_tag, &blstats, bgp_peer_log_seq_get(&bms->log_seq), event_type, config.bmp_daemon_msglog_output, BMP_LOG_TYPE_STATS);
         } 
 
-        if (bms->dump_backend_methods) bmp_dump_se_ll_append(peer, &bdata, tlvs, &blstats, BMP_LOG_TYPE_STATS);
+        if (bms->dump_backend_methods && !config.bmp_dump_exclude_stats) bmp_dump_se_ll_append(peer, &bdata, tlvs, &blstats, BMP_LOG_TYPE_STATS);
 
         if (bms->msglog_backend_methods || bms->dump_backend_methods) bgp_peer_log_seq_increment(&bms->log_seq);
 
-	if (!pm_listcount(tlvs) || !bms->dump_backend_methods) bmp_tlv_list_destroy(tlvs);
+	if (!pm_listcount(tlvs) || !bms->dump_backend_methods || config.bmp_dump_exclude_stats) bmp_tlv_list_destroy(tlvs);
       }
     }
   }

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -611,6 +611,7 @@ static const struct _dictionary_line dictionary[] = {
   {"bmp_dump_avro_schema_file", cfg_key_bmp_daemon_dump_avro_schema_file},
   {"bmp_dump_refresh_time", cfg_key_bmp_daemon_dump_refresh_time},
   {"bmp_dump_time_slots", cfg_key_bmp_daemon_dump_time_slots},
+  {"bmp_dump_exclude_stats", cfg_key_bmp_daemon_dump_exclude_stats},
   {"bmp_dump_amqp_host", cfg_key_bmp_daemon_dump_amqp_host},
   {"bmp_dump_amqp_vhost", cfg_key_bmp_daemon_dump_amqp_vhost},
   {"bmp_dump_amqp_user", cfg_key_bmp_daemon_dump_amqp_user},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -478,6 +478,7 @@ struct configuration {
   char *bmp_dump_avro_schema_file;
   int bmp_dump_refresh_time;
   int bmp_dump_time_slots;
+  int bmp_dump_exclude_stats;
   char *bmp_dump_amqp_host;
   char *bmp_dump_amqp_vhost;
   char *bmp_dump_amqp_user;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -5085,6 +5085,20 @@ int cfg_key_bmp_daemon_dump_time_slots(char *filename, char *name, char *value_p
   return changes;
 }
 
+int cfg_key_bmp_daemon_dump_exclude_stats(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  for (; list; list = list->next, changes++) list->cfg.bmp_dump_exclude_stats = value;
+  if (name) Log(LOG_WARNING, "WARN: [%s] plugin name not supported for key 'bmp_dump_exclude_stats'. Globalized.\n", filename);
+
+  return changes;
+}
+
 int cfg_key_bmp_daemon_dump_amqp_host(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -482,6 +482,7 @@ extern int cfg_key_bmp_daemon_dump_avro_schema_file(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_latest_file(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_refresh_time(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_time_slots(char *, char *, char *);
+extern int cfg_key_bmp_daemon_dump_exclude_stats(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_amqp_host(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_amqp_vhost(char *, char *, char *);
 extern int cfg_key_bmp_daemon_dump_amqp_user(char *, char *, char *);


### PR DESCRIPTION
### Short description
This PR adds the bmp_dump_exclude_stats config knob (false by default), which if enabled causes the BMP stats messages to not being cached, and thus not being included in the regular dump. This does not change the normal behavior, i.e. BMP stats are still streamed out by the plugins in real-time when received. 

The main reason why someone would enable this feature is to limit memory usage for situations where routers send a lot of BMP stats messages.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
