### PR TITLE
Add bgp_id to output of BMP stats messages

### DIFF
--- a/docs/BGP_BMP_METRICS.md
+++ b/docs/BGP_BMP_METRICS.md
@@ -197,6 +197,7 @@ Title | Description
 `peer_type` | Type of BGP peer (https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#peer-types)
 `rd` | BGP peer Route Distinguisher (https://tools.ietf.org/html/rfc7854#section-4.2)
 `rd_origin` | BGP peer Route Distinguisher origin. It will be set to "bmp".
+`bgp_id` | BGP router ID of remote peer
 `counter_type` | Statistics type field code (https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#statistics-types)
 `counter_type_str` | Statistics description
 `counter_value` | Statistics counter value
@@ -217,6 +218,7 @@ Title | Description
   "peer_type": 0,
   "rd": "0:64499:2",
   "rd_origin": "bmp",
+  "bgp_id": "192.0.2.2",
   "counter_type": 0,
   "counter_type_str": "Number of prefixes rejected by inbound policy",
   "counter_value": 0

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -410,6 +410,8 @@ int bmp_log_msg_stats(struct bgp_peer *peer, struct bmp_data *bdata, struct pm_l
       json_object_set_new_nocheck(obj, "rd_origin", json_string(bgp_rd_origin_print(bdata->chars.rd.type)));
     }
 
+    json_object_set_new_nocheck(obj, "bgp_id", json_string(inet_ntoa(bdata->bgp_id.address.ipv4)));
+
     json_object_set_new_nocheck(obj, "counter_type", json_integer((json_int_t)blstats->cnt_type));
 
     if (blstats->cnt_type <= BMP_STATS_MAX) {
@@ -540,6 +542,9 @@ int bmp_log_msg_stats(struct bgp_peer *peer, struct bmp_data *bdata, struct pm_l
       pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
     }
+
+    pm_avro_check(avro_value_get_by_name(obj, "bgp_id", &p_avro_field, NULL));
+    pm_avro_check(avro_value_set_string(&p_avro_field, inet_ntoa(bdata->bgp_id.address.ipv4)));
 
     pm_avro_check(avro_value_get_by_name(obj, "counter_type", &p_avro_field, NULL));
     pm_avro_check(avro_value_set_int(&p_avro_field, blstats->cnt_type));
@@ -2331,6 +2336,8 @@ avro_schema_t p_avro_schema_build_bmp_stats(char *schema_name)
 
   avro_schema_record_field_append(schema, "rd", optstr_s);
   avro_schema_record_field_append(schema, "rd_origin", optstr_s);
+
+  avro_schema_record_field_append(schema, "bgp_id", avro_schema_string());
 
   avro_schema_record_field_append(schema, "counter_type", avro_schema_int());
   avro_schema_record_field_append(schema, "counter_type_str", avro_schema_string());


### PR DESCRIPTION
### Short description

The changes in this pull request add the bgp_id field to the JSON and Avro output of BMP messages of type "stats". This field is included in the peer_up messages and policy messages already, this just includes it in the stats messages as well. The use case for adding it to the stats message is that in cases where we have multiple peerings, such as an IPv4 and an IPv6 peering, its useful to use the normalized bgp_id to filter/group the messages by router. We have this running against BMP data coming from our routers and seems to be working as advertised. This PR also updates the docs to reflect the change. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
