### PR TITLE
network.h: adds ifndefs to MAX_BGP_*_COMMS macros

### DIFF
--- a/src/network.h
+++ b/src/network.h
@@ -505,9 +505,15 @@ struct pkt_stitching {
 };
 
 /* START: BGP section */
+#ifndef MAX_BGP_STD_COMMS
 #define MAX_BGP_STD_COMMS       96
+#endif
+#ifndef MAX_BGP_EXT_COMMS
 #define MAX_BGP_EXT_COMMS       96
+#endif
+#ifndef MAX_BGP_LRG_COMMS
 #define MAX_BGP_LRG_COMMS       96
+#endif
 #define MAX_BGP_ASPATH          128
 
 /* MPLS */


### PR DESCRIPTION

### Short description

There are cases where we may see more BGP communities that can fit in a 96 byte string. This diff makes the `MAX_BGP_STD_COMMS`, `MAX_BGP_EXT_COMMS`, and `MAX_BGP_LRG_COMMS` macros compile time configurable.

One could make this configurable at runtime, however that would be a far more invasive change and I haven't seen anyone asking for it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
