### PR TITLE
Added support for engine_id / source_id pretag keys for sflow

### DIFF
--- a/src/pretag_handlers.c
+++ b/src/pretag_handlers.c
@@ -559,7 +559,8 @@ int PT_map_engine_id_handler(char *filename, struct id_entry *e, char *value, st
     }
   }
 
-  if (config.acct_type == ACCT_NF) e->func[x] = pretag_engine_id_handler;
+  if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_engine_id_handler;
+  else if (config.acct_type == ACCT_NF) e->func[x] = pretag_engine_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_ENGINE_ID;
 
   return FALSE;
@@ -2687,6 +2688,15 @@ int SF_pretag_bgp_nexthop_handler(struct packet_ptrs *pptrs, void *unused, void 
   }
 
   return (TRUE ^ entry->key.bgp_nexthop.neg);
+}
+
+int SF_pretag_engine_id_handler(struct packet_ptrs *pptrs, void *unused, void *e)
+{
+  struct id_entry *entry = e;
+  SFSample *sample = (SFSample *) pptrs->f_data;
+
+  if (entry->key.engine_id.n == sample->ds_index) return (FALSE | entry->key.engine_id.neg);
+  else return (TRUE ^ entry->key.engine_id.neg);
 }
 
 int SF_pretag_agent_id_handler(struct packet_ptrs *pptrs, void *unused, void *e)

--- a/src/pretag_handlers.h
+++ b/src/pretag_handlers.h
@@ -180,6 +180,7 @@ extern int SF_pretag_input_handler(struct packet_ptrs *, void *, void *);
 extern int SF_pretag_output_handler(struct packet_ptrs *, void *, void *);
 extern int SF_pretag_nexthop_handler(struct packet_ptrs *, void *, void *);
 extern int SF_pretag_bgp_nexthop_handler(struct packet_ptrs *, void *, void *);
+extern int SF_pretag_engine_id_handler(struct packet_ptrs *, void *, void *);
 extern int SF_pretag_agent_id_handler(struct packet_ptrs *, void *, void *);
 extern int SF_pretag_src_as_handler(struct packet_ptrs *, void *, void *);
 extern int SF_pretag_dst_as_handler(struct packet_ptrs *, void *, void *);


### PR DESCRIPTION
### Short description
The current pretag keys `engine_id` (or `source_id`) were only supported with netflow.
sflows have a `source_id` information, so its support was added for pretag in this pull request. 

### Checklist
No need to add a license: no new file were added. Only existing `src/pretag_handlers.h` and `src/pretag_handlers.c` were slightly modified.
No documentation provided. I suppose `examples/pretag.map.example`would just need to mention that sflow is supported for the keys `engine_id` (and its alias `source_id`).
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
