### PR TITLE
Addressing pretag label overflow issue

### DIFF
--- a/src/pretag.c
+++ b/src/pretag.c
@@ -938,7 +938,6 @@ int pretag_copy_label(pt_label_t *dst, pt_label_t *src)
   else {
     if (src->len) {
       pretag_malloc_label(dst, src->len + 1);
-      dst->len = src->len; /* fix length in case of multiple mallocs */
 
       if (!dst->val) {
         Log(LOG_ERR, "ERROR ( %s/%s ): malloc() failed (pretag_copy_label).\n", config.name, config.type);
@@ -946,7 +945,16 @@ int pretag_copy_label(pt_label_t *dst, pt_label_t *src)
       }
 
       strncpy(dst->val, src->val, src->len);
-      dst->val[dst->len] = '\0';
+
+      if (dst->val[src->len - 1] == '\0') {
+         /* fix length in case of multiple mallocs */
+        dst->len = src->len;
+      }
+      else {
+         /* add null char only when not already there */
+        dst->val[dst->len - 1] = '\0';
+      }    
+
     }
   }
   


### PR DESCRIPTION
This PR slightly adjusts the login in the pretag_copy_label() function to check if the null character is already in the dst string before adding one. This prevents the length to increase with multiple function calls, but also ensures that the pt_label_t struct will contain the correct length (label + null char).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
