### PR TITLE
Fix udp-notif message handling in pmtelemetryd

### DIFF
--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -816,6 +816,8 @@ int telemetry_daemon(void *t_data_void)
               fd = TELEMETRY_UDP_NOTIF_FD;
             }
             else {
+              Log(LOG_WARNING, "WARN ( %s/%s ): consumer buffer size too small (%lu vs. %u bytes), dropping message\n",
+                  config.name, t_data->log_str, sizeof(consumer_buf), payload_len+1);
               unyte_udp_free_all(seg);
               goto select_again;
             }

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -798,10 +798,7 @@ int telemetry_daemon(void *t_data_void)
 #if defined WITH_UNYTE_UDP_NOTIF
       else if (unyte_udp_notif_input) {
         if (seg_ptr) {
-          unyte_seg_met_t *seg = NULL;
-          int payload_len = 0;
-
-          seg = (unyte_seg_met_t *)seg_ptr;
+          unyte_seg_met_t *seg = seg_ptr;
 
           if (unyte_udp_get_media_type(seg) == UNYTE_MEDIATYPE_YANG_JSON && config.telemetry_decoder_id == TELEMETRY_DECODER_JSON) {
             struct sockaddr_storage *unsa = NULL;
@@ -809,9 +806,9 @@ int telemetry_daemon(void *t_data_void)
             unsa = unyte_udp_get_src(seg);
             memcpy(&client, unsa, sizeof(struct sockaddr_storage));
 
-            payload_len = strlen(seg->payload);
+            uint16_t payload_len = unyte_udp_get_payload_length(seg);
             if (payload_len < sizeof(consumer_buf)) {
-              strlcpy((char *)consumer_buf, seg->payload, sizeof(consumer_buf));
+              strlcpy((char *)consumer_buf, seg->payload, payload_len+1);
               unyte_udp_free_all(seg);
               fd = TELEMETRY_UDP_NOTIF_FD;
             }

--- a/src/telemetry/telemetry_logdump.c
+++ b/src/telemetry/telemetry_logdump.c
@@ -98,7 +98,13 @@ int telemetry_log_msg(telemetry_peer *peer, struct telemetry_data *t_data, telem
       json_error_t json_err;
       json_t *log_data_obj = json_loads(log_data, 0, &json_err);
 
-      json_object_set_new_nocheck(obj, "telemetry_data", log_data_obj);
+      if (log_data_obj)
+        json_object_set_new_nocheck(obj, "telemetry_data", log_data_obj);
+      else
+        Log(LOG_DEBUG, "DEBUG ( %s/%s ): JSON error: %s (%d/%d/%d: %s)",
+            config.name, t_data->log_str, json_err.text,
+            json_err.line, json_err.column, json_err.position, json_err.source);
+
       json_object_set_new_nocheck(obj, "serialization", json_string("json"));
     }
     else if (data_decoder == TELEMETRY_DATA_DECODER_GPB) {


### PR DESCRIPTION
pmtelemetryd does not use the udp-notif library function to get the length of the payload buffer. It instead handles it as a string. This may lead to a buffer with additional characters added at the end which is not parsable and the content is dropped silently.

This PR fixes the udp-notif message handling and adds a few additional log messages.