### PR TITLE
telemetry: fix timeout handling for udp-notif and grpc collectors

### DIFF
--- a/src/telemetry/telemetry_util.c
+++ b/src/telemetry/telemetry_util.c
@@ -56,7 +56,7 @@ void telemetry_peer_close(telemetry_peer *peer, int type)
     peer->bmp_se = NULL;
   }
 
-  if (config.telemetry_port_udp) {
+  if (config.telemetry_port_udp || unyte_udp_notif_input || grpc_collector_input) {
     telemetry_peer_cache tpc;
 
     memcpy(&tpc.addr, &peer->addr, sizeof(struct host_addr));


### PR DESCRIPTION
For udp-notif and grpc collectors the peer information is only partially deleted on timeout. When a peer starts to send data again after a timeout the data might either be assigned to the wrong peer or not forwarded to the output plugin at all. This PR fixes the timeout handling.