### PR TITLE
chore: Update the Docker base image from Debian bullseye to bookworm

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates a base docker image with pmacct and other useful
 #tools for network telemetry and monitoring
 
-FROM debian:bullseye-slim as build-stage
+FROM debian:bookworm-slim as build-stage
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
 # This is not the runtime/final image:
@@ -63,7 +63,7 @@ RUN export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
                               --enable-redis --enable-gnutls && \
   make install
 
-FROM debian:bullseye-slim as base
+FROM debian:bookworm-slim as base
 LABEL maintainer "pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
@@ -80,7 +80,7 @@ RUN apt-get update && \
     libnetfilter-log1 \
     libsnappy1v5 \
     libsqlite3-0 \
-    libssl1.1 && \
+    libssl3 && \
   apt-get -y clean && \
   rm -rf /var/lib/apt/lists/* && \
   ldconfig


### PR DESCRIPTION
### Short description
Update the Docker base image from Debian bullseye to bookworm due to the outdated/old software on Debian bullseye.


### Checklist
- Updated docker base image from Debian bullseye to bookworm;
- Replaced libssl1.1 (deprecated) with libssl3. Note: Although no issues were found, this change may introduce compatibility issues;
- Built image locally without issues;
```
% docker build --no-cache -t test_build . -f docker/base/Dockerfile
...
#15 DONE 0.4s
%
```
- Checked that the image is functional, and software was compiled/executing correctly:
```
% docker run -it test_build
root@eb05f3542292:/# nfacctd -V | head -5
NetFlow Accounting Daemon, nfacctd 1.7.10-git [20240502-0 (9c896d54)]

Arguments:
 '--enable-mysql' '--enable-pgsql' '--enable-sqlite3' '--enable-kafka' '--enable-geoipv2' '--enable-jansson' '--enable-rabbitmq' '--enable-nflog' '--enable-ndpi' '--enable-zmq' '--enable-avro' '--enable-serdes' '--enable-redis' '--enable-gnutls' 'AVRO_CFLAGS=-I/usr/local/avro/include' 'AVRO_LIBS=-L/usr/local/avro/lib -lavro' '--enable-l2' '--enable-traffic-bins' '--enable-bgp-bins' '--enable-bmp-bins' '--enable-st-bins'

```
Build logs: [build_log.tgz](https://github.com/pmacct/pmacct/files/15210991/build_log.tgz)


I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
-- The file already exists in the repository; it has simply been updated.
- [X] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
-- Not necessary, as we are not altering the software itself.