### PR TITLE
doc: removing obsolete property to avoid warning logs

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -43,8 +43,7 @@ Docker-compose example configuration/usage:
 Create `docker-compose.yml` file with container specifications:
 
 ```yaml
-version: '3'
-
+---
 services:
   sflow-collector1:
     image: pmacct/sfacctd:bleeding-edge


### PR DESCRIPTION
### Short description
Removing [obsolete property "version"](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional) for the docker-compose example included in the [MR781](https://github.com/pmacct/pmacct/pull/781) to avoid annoying warning logs.

### Checklist
Documentation update/fix.

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
-- File already exist, nothing related to license changed.
- [ ] compiled & tested this code
-- Documentation update only.
- [x] included documentation (including possible behaviour changes)
