### PR TITLE
feat: adding *_trigger_exec script parameters support

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1509,7 +1509,8 @@ DESC:		Defines the executable to be launched at fixed time intervals to post-pro
 		can only be fired each time data is written to the backend (ie. each print_refresh_time) and
 		no environment variables are set; this may be useful also to upload data to cloud storage
 		that supports upload via API end-points. When running in Docker, to avoid the accumulation
-		of zombie processes, run the container with the --init flag, ie. "docker run --init [ .. ]". 
+		of zombie processes, run the container with the --init flag, ie. "docker run --init [ .. ]".
+		Trigger script parameters are now supported. 
 DEFAULT:	none
 
 KEY:		sql_trigger_time


### PR DESCRIPTION
### Short description

Ciao Paolo! Sorry for the long PR, but in a nutshell:

I've been using PMACCT for a while and appreciate the project greatly! However, I've encountered an issue where `*_trigger_exec` lacks script parameters support. Currently, I use a Python script to handle logic but can't pass parameters through the `nfacctd`/`sfacctd` configuration. To manage this, I've created about 14 wrapper scripts that simply call the Python script with the necessary parameters, which is not ideal to maintain.

This pull request introduces script parameters support for `*_trigger_exec`. I've compiled and tested this feature using `print_trigger_exec` in a few scenarios (please see the logs for details). However, given the widespread use of this function, it may require additional testing and review.

My C programming skills are a bit rusty, as I haven't worked extensively with it since my university days, which were quite some time ago. Please feel free to correct, suggest improvements, or make any changes as needed. Also, if you think this feature should not be implemented, feel free to reject or close this PR.

The Docker build used is a standard one from the PMACCT repository, with the only differences being the inclusion of this PR's code and the necessary config/script to the image.

Once again, thank you very much for your work on this amazing project!

### Checklist

Build:
![image](https://github.com/pmacct/pmacct/assets/13142853/cf3bb95e-6d58-4614-9431-609f8a288f8c)

Run:
```bash
~/pmacct$ docker run -it --name xpto -p 2100:2100/udp pmacct-args
root@8680c5e0932f:/# cd
root@8680c5e0932f:~# nfacctd -f nfacctd.conf -d
DEBUG: [nfacctd.conf] plugin name/type: 'default'/'core'.
DEBUG: [nfacctd.conf] plugin name/type: 'all'/'print'.
DEBUG: [nfacctd.conf] plugin name/type: 'one'/'print'.
DEBUG: [nfacctd.conf] plugin name/type: 'random'/'print'.
DEBUG: [nfacctd.conf] plugin name/type: 'none'/'print'.
DEBUG: [nfacctd.conf] debug:true
DEBUG: [nfacctd.conf] daemonize:false
DEBUG: [nfacctd.conf] pidfile:/var/run/nfacctd.pid
DEBUG: [nfacctd.conf] logfile:/var/log/nfacct.log
DEBUG: [nfacctd.conf] plugin_pipe_size:10240000
DEBUG: [nfacctd.conf] plugin_buffer_size:10240
DEBUG: [nfacctd.conf] nfacctd_renormalize:true
DEBUG: [nfacctd.conf] timestamps_since_epoch:true
DEBUG: [nfacctd.conf] timestamps_secs:true
DEBUG: [nfacctd.conf] aggregate[all]:peer_src_ip, sampling_rate
DEBUG: [nfacctd.conf] print_refresh_time[all]:30
DEBUG: [nfacctd.conf] print_history[all]:30
DEBUG: [nfacctd.conf] print_history_roundoff[all]:m
DEBUG: [nfacctd.conf] print_output_file[all]:/root/data/all/flow_5m_avg_%s.json
DEBUG: [nfacctd.conf] print_output[all]:json
DEBUG: [nfacctd.conf] print_output_file_append[all]:true
DEBUG: [nfacctd.conf] print_trigger_exec[all]:/root/exec.sh -f example -t xpto
DEBUG: [nfacctd.conf] plugin_buffer_size[all]:102400
DEBUG: [nfacctd.conf] plugin_pipe_size[all]:10240000
DEBUG: [nfacctd.conf] aggregate[one]:peer_src_ip, sampling_rate
DEBUG: [nfacctd.conf] print_refresh_time[one]:30
DEBUG: [nfacctd.conf] print_history[one]:30
DEBUG: [nfacctd.conf] print_history_roundoff[one]:m
DEBUG: [nfacctd.conf] print_output_file[one]:/root/data/one/flow_5m_avg_%s.json
DEBUG: [nfacctd.conf] print_output[one]:json
DEBUG: [nfacctd.conf] print_output_file_append[one]:true
DEBUG: [nfacctd.conf] print_trigger_exec[one]:/root/exec.sh -f example
DEBUG: [nfacctd.conf] plugin_buffer_size[one]:102400
DEBUG: [nfacctd.conf] plugin_pipe_size[one]:10240000
DEBUG: [nfacctd.conf] aggregate[random]:peer_src_ip, in_vlan, in_cvlan, etype, src_mac, dst_mac, proto, sampling_rate
DEBUG: [nfacctd.conf] print_refresh_time[random]:30
DEBUG: [nfacctd.conf] print_history[random]:30
DEBUG: [nfacctd.conf] print_history_roundoff[random]:m
DEBUG: [nfacctd.conf] print_output_file[random]:/root/data/random/flow_5m_avg_%s.json
DEBUG: [nfacctd.conf] print_output[random]:json
DEBUG: [nfacctd.conf] print_output_file_append[random]:true
DEBUG: [nfacctd.conf] print_trigger_exec[random]:/root/exec.sh test0 test1 test2 -h test3 test4  test5
DEBUG: [nfacctd.conf] plugin_buffer_size[random]:102400
DEBUG: [nfacctd.conf] plugin_pipe_size[random]:10240000
DEBUG: [nfacctd.conf] aggregate[none]:peer_src_ip, in_vlan, in_cvlan, etype, src_mac, dst_mac, proto, sampling_rate
DEBUG: [nfacctd.conf] print_refresh_time[none]:30
DEBUG: [nfacctd.conf] print_history[none]:30
DEBUG: [nfacctd.conf] print_history_roundoff[none]:m
DEBUG: [nfacctd.conf] print_output_file[none]:/root/data/none/flow_5m_avg_%s.json
DEBUG: [nfacctd.conf] print_output[none]:json
DEBUG: [nfacctd.conf] print_output_file_append[none]:true
DEBUG: [nfacctd.conf] print_trigger_exec[none]:/root/exec.sh
DEBUG: [nfacctd.conf] plugin_buffer_size[none]:102400
DEBUG: [nfacctd.conf] plugin_pipe_size[none]:10240000
DEBUG: [nfacctd.conf] debug:true
===================================================================================================
===================================================================================================
=> 2024-05-14 22:48:01 - script (/root/exec.sh -f example -t xpto) exection results has been written to /tmp/output.
===================================================================================================
=> 2024-05-14 22:48:01 - script (/root/exec.sh -f example) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
===================================================================================================
=> 2024-05-14 22:48:01 - script (/root/exec.sh test0 test1 test2 -h test3 test4 test5) exection results has been written to /tmp/output.
===================================================================================================
=> 2024-05-14 22:48:01 - script (/root/exec.sh ) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
===================================================================================================
=> 2024-05-14 22:48:31 - script (/root/exec.sh -f example) exection results has been written to /tmp/output.
===================================================================================================
=> 2024-05-14 22:48:31 - script (/root/exec.sh -f example -t xpto) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:48:31 - script (/root/exec.sh ) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:48:31 - script (/root/exec.sh test0 test1 test2 -h test3 test4 test5) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:01 - script (/root/exec.sh -f example -t xpto) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:01 - script (/root/exec.sh -f example) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:01 - script (/root/exec.sh ) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:01 - script (/root/exec.sh test0 test1 test2 -h test3 test4 test5) exection results has been written to /tmp/output.
===================================================================================================
^C===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:09 - script (/root/exec.sh -f example -t xpto) exection results has been written to /tmp/output.
===================================================================================================
=> 2024-05-14 22:49:09 - script (/root/exec.sh -f example) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:09 - script (/root/exec.sh test0 test1 test2 -h test3 test4 test5) exection results has been written to /tmp/output.
===================================================================================================
===================================================================================================
=> 2024-05-14 22:49:09 - script (/root/exec.sh ) exection results has been written to /tmp/output.
===================================================================================================
root@8680c5e0932f:~#
```

Testing script log output:
```bash
root@8680c5e0932f:~# cat /tmp/output
2024-05-14 22:48:01 - /root/exec.sh -f example -t xpto
2024-05-14 22:48:01 - /root/exec.sh -f example
2024-05-14 22:48:01 - /root/exec.sh test0 test1 test2 -h test3 test4 test5
2024-05-14 22:48:01 - No parameters
2024-05-14 22:48:31 - /root/exec.sh -f example
2024-05-14 22:48:31 - /root/exec.sh -f example -t xpto
2024-05-14 22:48:31 - No parameters
2024-05-14 22:48:31 - /root/exec.sh test0 test1 test2 -h test3 test4 test5
2024-05-14 22:49:01 - /root/exec.sh -f example -t xpto
2024-05-14 22:49:01 - /root/exec.sh -f example
2024-05-14 22:49:01 - No parameters
2024-05-14 22:49:01 - /root/exec.sh test0 test1 test2 -h test3 test4 test5
2024-05-14 22:49:09 - /root/exec.sh -f example -t xpto
2024-05-14 22:49:09 - /root/exec.sh -f example
2024-05-14 22:49:09 - /root/exec.sh test0 test1 test2 -h test3 test4 test5
2024-05-14 22:49:09 - No parameters
```

`nfacctd` testing configuration:
```bash
~/pmacct$ cat nfacctd.conf
!
debug: true
daemonize: false
pidfile: /var/run/nfacctd.pid
logfile : /var/log/nfacct.log
!
plugin_pipe_size: 10240000
!
plugin_buffer_size: 10240
!
nfacctd_renormalize: true
!
timestamps_since_epoch: true
timestamps_secs: true
!
plugins: print[all], print[one], print[random], print[none]

aggregate[all]: peer_src_ip, sampling_rate
print_refresh_time[all]: 30
print_history[all]: 30
print_history_roundoff[all]: m
print_output_file[all]: /root/data/all/flow_5m_avg_%s.json
print_output[all]: json
print_output_file_append[all]: true
print_trigger_exec[all]: /root/exec.sh -f example -t xpto
plugin_buffer_size[all]: 102400
plugin_pipe_size[all]: 10240000

aggregate[one]: peer_src_ip, sampling_rate
print_refresh_time[one]: 30
print_history[one]: 30
print_history_roundoff[one]: m
print_output_file[one]: /root/data/one/flow_5m_avg_%s.json
print_output[one]: json
print_output_file_append[one]: true
print_trigger_exec[one]: /root/exec.sh -f example
plugin_buffer_size[one]: 102400
plugin_pipe_size[one]: 10240000

aggregate[random]: peer_src_ip, in_vlan, in_cvlan, etype, src_mac, dst_mac, proto, sampling_rate
print_refresh_time[random]: 30
print_history[random]: 30
print_history_roundoff[random]: m
print_output_file[random]: /root/data/random/flow_5m_avg_%s.json
print_output[random]: json
print_output_file_append[random]: true
print_trigger_exec[random]: /root/exec.sh test0 test1 test2 -h test3 test4  test5
plugin_buffer_size[random]: 102400
plugin_pipe_size[random]: 10240000

aggregate[none]: peer_src_ip, in_vlan, in_cvlan, etype, src_mac, dst_mac, proto, sampling_rate
print_refresh_time[none]: 30
print_history[none]: 30
print_history_roundoff[none]: m
print_output_file[none]: /root/data/none/flow_5m_avg_%s.json
print_output[none]: json
print_output_file_append[none]: true
print_trigger_exec[none]: /root/exec.sh
plugin_buffer_size[none]: 102400
plugin_pipe_size[none]: 10240000
```

Testing trigger exec script:
```bash
~/pmacct$ cat exec.sh
#!/bin/bash

output_file="/tmp/output"

if [ $# -eq 0 ]; then
  echo "$(date '+%Y-%m-%d %H:%M:%S') - No parameters" >> "$output_file"
  echo "==================================================================================================="
  echo "=> $(date '+%Y-%m-%d %H:%M:%S') - script ($0 $@) exection results has been written to $output_file."
  echo "==================================================================================================="
  exit 0
fi

echo "$(date '+%Y-%m-%d %H:%M:%S') - $0 $@" >> "$output_file"

echo "==================================================================================================="
echo "=> $(date '+%Y-%m-%d %H:%M:%S') - script ($0 $@) exection results has been written to $output_file."
echo "==================================================================================================="
```

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
--  File already exist.
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
