### PR TITLE
Fix Actions: replace docker-compose (deprecated) with docker compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,15 +171,15 @@ jobs:
 
       - name: Docker (compose) smoke test
         run: |
-          echo "Running smoke test using docker-compose..."
-          TAG=_build docker-compose -f ci/smoke-test/docker-compose.yml up -d
+          echo "Running smoke test using docker compose..."
+          TAG=_build docker compose -f ci/smoke-test/docker-compose.yml up -d
           sleep 10
           echo "Check that all containers are up and running, without restarts ..."
           if [[ "$(docker inspect `docker ps -aq` | grep RestartCount | grep -v '\"RestartCount\": 0')" != "" ]]; then
             echo "Some containers restarted!" && docker inspect `docker ps -aq` && /bin/false
           fi
           echo "Stopping containers..."
-          TAG=_build docker-compose -f ci/smoke-test/docker-compose.yml down
+          TAG=_build docker compose -f ci/smoke-test/docker-compose.yml down
 
       - name: Export pmacct docker images as an artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Actions were failing due to docker-compose command no longer available in GitHub action runners (https://github.com/actions/runner-images/issues/9557).


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behavior changes)
