### PR TITLE
Add nightly minimal E2E testing (datahangar)

### DIFF
--- a/.github/workflows/e2e_dh.yaml
+++ b/.github/workflows/e2e_dh.yaml
@@ -1,0 +1,12 @@
+name: e2e_datahangar_test
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
+
+jobs:
+  datahangar-single-test-run:
+    uses: datahangar/datahangar/.github/workflows/single_test_run.yaml@main
+    with:
+      pmacct-ref: "${{github.sha}}"
+      db: "druid"


### PR DESCRIPTION
### Short description

This commit adds a nightly run of pmacct `HEAD` of `master` running a full e2e data pipeline (based on the [datahangar](https://github.com/datahangar/datahangar) project, which runs natively in K8s), to better mimic a real scenario. This hopefully automates the work that I've been doing manually for the last months :).

The current coverage is _very_ minimal, but sufficient to add _some_ value already.

It tests the following features of `nfacctd`:

* Netflow ingestion. Fields actively tested:
  * "timestamp_start", "timestamp_end", "etype", "src_as", "in_iface",
    "peer_src_ip", "peer_dst_ip", "peer_src_as", "peer_dst_as", "as_path",
     "dst_as", "src_net", "src_mask", "dst_net", "dst_mask", "src_host",
     "src_host_country", "dst_host", "dst_host_country"
* Output to Kafka using - at the moment - SCRAM auth.
* Multiple instances of the Kafka plugin.
* Deployability in K8s environments

The immediate next steps are:

* Being more rigorous with counters (Paolo&I are chasing a potential
  bug in accounting as a result of this test, see:
  https://github.com/datahangar/datahangar/blob/main/.github/actions/test/files/count-db-records.yaml#L24).
* Add BGP and test flow enrichment using BGP.
* Use Kafka with encryption
* Test geolocation plugin.

:warning: The top-most commit, [`to be removed`](https://github.com/pmacct/pmacct/commit/93fffe20b44c37af300f12a3ae8cd5524ef93012), which makes the workflow to run on `push` is only there to test this PR _before_ merging, and should be removed before merging :warning: 

### Checklist

I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
