### PR TITLE
test-framework: temporarily ignore bmp_rib_type and is_filtered fiels

### DIFF
--- a/tests/200-BMP-HUAWEI-locrib_instance/200_test.py
+++ b/tests/200-BMP-HUAWEI-locrib_instance/200_test.py
@@ -22,7 +22,7 @@ def main(consumers):
     th = KTestHelper(testParams, consumers)
     assert th.spawn_traffic_container('traffic-reproducer-200')
 
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     logfile = testParams.log_files.get_path_like('log-00')

--- a/tests/201-BMP-CISCO-rd_instance/201_test.py
+++ b/tests/201-BMP-CISCO-rd_instance/201_test.py
@@ -21,7 +21,7 @@ def main(consumers):
     th = KTestHelper(testParams, consumers)
     assert th.spawn_traffic_container('traffic-reproducer-201')
 
-    th.set_ignored_fields(['seq', 'timestamp', 'bmp_router_port', 'timestamp_arrival'])
+    th.set_ignored_fields(['seq', 'timestamp', 'bmp_router_port', 'timestamp_arrival', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     th.transform_log_file('log-00', 'traffic-reproducer-201')

--- a/tests/202-BMP-CISCO-HUAWEI-multiple-sources/202_test.py
+++ b/tests/202-BMP-CISCO-HUAWEI-multiple-sources/202_test.py
@@ -23,7 +23,7 @@ def main(consumers):
     for suffix in ['a', 'b', 'c']:
         th.spawn_traffic_container('traffic-reproducer-202' + suffix, detached=True)
 
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     # Make sure the expected logs exist in pmacct log

--- a/tests/203-BMP-HUAWEI-dump/203_test.py
+++ b/tests/203-BMP-HUAWEI-dump/203_test.py
@@ -21,7 +21,7 @@ def main(consumers):
     th = KTestHelper(testParams, consumers)
     assert th.spawn_traffic_container('traffic-reproducer-203', detached=True)
 
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     th.transform_log_file('log-00', 'traffic-reproducer-203')

--- a/tests/204-BMP-CISCO-peer_down/204_test.py
+++ b/tests/204-BMP-CISCO-peer_down/204_test.py
@@ -22,7 +22,7 @@ def main(consumers):
     th = KTestHelper(testParams, consumers)
     assert th.spawn_traffic_container('traffic-reproducer-204', detached=True)
 
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     assert not th.check_regex_in_pmacct_log('ERROR|WARN')

--- a/tests/205-BMP-6wind-FRR-peer_down/205_test.py
+++ b/tests/205-BMP-6wind-FRR-peer_down/205_test.py
@@ -21,7 +21,7 @@ def main(consumers):
     th = KTestHelper(testParams, consumers)
     assert th.spawn_traffic_container('traffic-reproducer-205', detached=True)
 
-    th.set_ignored_fields(['seq', 'timestamp', 'bmp_router_port', 'timestamp_arrival'])
+    th.set_ignored_fields(['seq', 'timestamp', 'bmp_router_port', 'timestamp_arrival', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     assert not th.check_regex_in_pmacct_log('ERROR|WARN(?!.*Unable to get kafka_host)')

--- a/tests/206-BMP-high-availability/206_test.py
+++ b/tests/206-BMP-high-availability/206_test.py
@@ -66,15 +66,16 @@ def main(consumers):
     assert th.wait_and_check_regex_sequence_in_pmacct_log([loglines[1], loglines[2]], 10, 2, 'nfacctd-00')
 
     # Compare BMP Init Message (timestamp is not from packets and cannot be matched)
-    th.set_ignored_fields(['seq', 'timestamp', 'bmp_router_port', 'timestamp_arrival', 'writer_id'])
+    th.set_ignored_fields(['seq', 'timestamp', 'bmp_router_port', 'timestamp_arrival', 'writer_id', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
-    # Compare all other received messages to reference file output-bgp-01.json
+    # Compare all other received messages to reference file output-bmp-01.json
     messages = consumers[0].get_all_pending_messages()
     output_json_file = test_tools.replace_ips_and_get_reference_file(testParams, 'bmp-01')
     logger.info('Comparing messages received with json lines in file ' + helpers.short_name(output_json_file))
     assert json_tools.compare_messages_to_json_file(messages, output_json_file, ['seq', 'bmp_router_port',
-                                                                                 'timestamp_arrival','writer_id'], 
+                                                                                 'timestamp_arrival','writer_id',
+                                                                                 'bmp_rib_type', 'is_filtered'], 
                                                                                  multi_match_allowed=True)
 
     # Ensuring all 2 writer_id's show up in the messages

--- a/tests/207-BMP-CISCO-HUAWEI-multiple-sources-dump-spreading/207_test.py
+++ b/tests/207-BMP-CISCO-HUAWEI-multiple-sources-dump-spreading/207_test.py
@@ -28,7 +28,7 @@ def main(consumers):
         th.spawn_traffic_container('traffic-reproducer-207' + suffix, detached=True)
 
     # TODO DAISY: investigate why with table dump enabled bgp_nexthop sometimes changes to :ffff...
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bgp_nexthop'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bgp_nexthop', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     # Make sure the expected logs exist in pmacct log
@@ -42,5 +42,5 @@ def main(consumers):
     assert th.wait_and_check_logs('log-00', 120, 10)
 
     # Check messages from BMP table dump
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'dump_period'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'dump_period', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp.dump', 'bmp-dump-00', wait_time=120)

--- a/tests/400-IPFIXv10-BMP-CISCO-SRv6-multiple-sources/400_test.py
+++ b/tests/400-IPFIXv10-BMP-CISCO-SRv6-multiple-sources/400_test.py
@@ -31,7 +31,7 @@ def main(consumers):
     assert th.read_and_compare_messages('daisy.flow', 'flow-00')
 
     # Compare received messages on topic daisy.bmp to reference file output-bmp-00.json
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     # Check logs for BMP peer up notification

--- a/tests/401-IPFIXv10-BMP-IPv6-CISCO-MPLS-multiple-sources/401_test.py
+++ b/tests/401-IPFIXv10-BMP-IPv6-CISCO-MPLS-multiple-sources/401_test.py
@@ -26,7 +26,7 @@ def main(consumers):
 
     th.set_ignored_fields(['stamp_inserted', 'stamp_updated', 'timestamp_max', 'timestamp_arrival', 'timestamp_min'])
     assert th.read_and_compare_messages('daisy.flow', 'flow-00')
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     assert not th.check_regex_in_pmacct_log('ERROR|WARN(?!.*Unable to get kafka_host)')

--- a/tests/402-IPFIXv10-BMP-IPv6-high-availability/402_test.py
+++ b/tests/402-IPFIXv10-BMP-IPv6-high-availability/402_test.py
@@ -49,7 +49,7 @@ def main(consumers):
     assert th.wait_and_check_regex_in_pmacct_log(loglines[3], 10, 2, 'nfacctd-01')
 
     # Check the BMP topic (has to contain only messages from active daemon, i.e. nfacctd_00_loc_A)
-    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port'])
+    th.set_ignored_fields(['seq', 'timestamp', 'timestamp_arrival', 'bmp_router_port', 'bmp_rib_type', 'is_filtered'])
     assert th.read_and_compare_messages('daisy.bmp', 'bmp-00')
 
     # Check the flow topic: we need to receive the exact same messages from both daemons


### PR DESCRIPTION
### Short description
As discussed, let's for exclude for now "bmp_rib_type" and "is_filtered" from the BMP tests. We need more time to update the expected output files according to recent commits.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
