### PR TITLE
Fix issue where egress_vrf_name was added to export record when egres…

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -3927,14 +3927,14 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
       }
     }
 #if defined (USE_VRF_NAME_PTR)
+    pptrs->ingress_vrf_name = NULL;
+    pptrs->egress_vrf_name = NULL;
     if (ingress_vrfid) {
       ret = cdada_map_find(entry->vrf_name_map, &ingress_vrfid, (void **) &pptrs->ingress_vrf_name);
 
       if (ret == CDADA_SUCCESS) {
         Log(LOG_DEBUG, "DEBUG ( %s/core ): Found VRF Name in hashmap for ingress_vrf_id %d to ptr %s\n", config.name, ingress_vrfid, pptrs->ingress_vrf_name);
-      } else {
-        pptrs->ingress_vrf_name = NULL;
-      }
+      } 
     }
     if (egress_vrfid) {
       char *egress_vrf_name;
@@ -3942,11 +3942,11 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
 
       if (ret == CDADA_SUCCESS) {
         Log(LOG_DEBUG, "DEBUG ( %s/core ): Found VRF Name in hashmap for egress_vrf_id %d to ptr %s\n", config.name, egress_vrfid, pptrs->egress_vrf_name);
-      } else {
-        pptrs->egress_vrf_name = NULL;
-      }
+      } 
     }
 #else
+    pptrs->ingress_vrf_name[0] = '\0';
+    pptrs->egress_vrf_name[0] = '\0';
     if (ingress_vrfid) {
       char *ingress_vrf_name;
       ret = cdada_map_find(entry->vrf_name_map, &ingress_vrfid, (void **) &ingress_vrf_name);
@@ -3954,9 +3954,7 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
       if (ret == CDADA_SUCCESS) {
         Log(LOG_DEBUG, "DEBUG ( %s/core ): Found VRF Name in hashmap for ingress_vrf_id %d to name %s\n", config.name, ingress_vrfid, ingress_vrf_name);
         memcpy (pptrs->ingress_vrf_name, ingress_vrf_name, MAX_VRF_NAME);
-      } else {
-        pptrs->ingress_vrf_name[0] = '\0';
-      } 
+      }
     }
     if (egress_vrfid) {
       char *egress_vrf_name;
@@ -3965,10 +3963,7 @@ void NF_mpls_vpn_rd_from_options(struct packet_ptrs *pptrs)
       if (ret == CDADA_SUCCESS) {
         Log(LOG_DEBUG, "DEBUG ( %s/core ): Found VRF Name in hashmap for egress_vrf_id %d to name %s\n", config.name, egress_vrfid, egress_vrf_name);
         memcpy (pptrs->egress_vrf_name, egress_vrf_name, MAX_VRF_NAME);
-      } else {
-        pptrs->egress_vrf_name[0] = '\0';
-      }      
-
+      } 
     }
 #endif
 


### PR DESCRIPTION
…s_vrf_id is 0

### Short description
The egress_vrf_name was set to the value in the previous exported record because if the egress_vrf_is is 0, the vrf_name was not set to null.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [ ] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
