### PR TITLE
plugin_cmn_avro: fix a label value check

### DIFF
--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -1908,7 +1908,7 @@ int compose_label_avro_data_opt(char *str_ptr, avro_value_t v_type_record)
     memset(&lbl, 0, sizeof(lbl));
     cdada_list_get(ll, idx_0, &lbl);
     /* handling label with value */
-    if (lbl.value) {
+    if (*lbl.value) {
       if (avro_value_get_by_name(&v_type_record, "label", &v_type_union, NULL) == 0) {
         avro_value_set_branch(&v_type_union, TRUE, &v_type_branch);
         if (avro_value_add(&v_type_branch, lbl.key, &v_type_string, NULL, NULL) == 0) {


### PR DESCRIPTION
The original "if (lbl.value)" check always is true and the else path never was reached.