### PR TITLE
dh_e2h: fix use bleeding-edge instead of SHA

### DIFF
--- a/.github/workflows/e2e_dh.yaml
+++ b/.github/workflows/e2e_dh.yaml
@@ -8,5 +8,5 @@ jobs:
   datahangar-single-test-run:
     uses: datahangar/datahangar/.github/workflows/single_test_run.yaml@main
     with:
-      pmacct-ref: "${{github.sha}}"
+      pmacct-ref: "bleeding-edge"
       db: "druid"


### PR DESCRIPTION
Images are not tagged with the SHA, only bleeding-edge, latest and vX.Y.Z. Therefore, and since this workflow is only run nightly, run with `bleeding-edge`.

It might be that in the future we want to also tag with the SHA to E2E test after freezing a version in both branches (but that would require changes in this workflow too, to run on other events).

### Checklist
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
