### PR TITLE
ci: fix/revert uploading of images job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
   publish-dockerhub:
     needs: [pmacct-docker, build-and-test]
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'schedule' && github.repository == 'pmacct/pmacct' }}
+    if: github.event_name != 'pull_request'
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Commit 91df0c752, part of #774, broke `publish-dockerhub` job by changing the run condition, which makes it skip runs that should otherwise run.

```
  runs-on: ubuntu-22.04
- if: github.event_name != 'pull_request'
+ if: ${{ github.event_name == 'schedule' && github.repository == 'pmacct/pmacct' }}
```

Reverting this part of 91df0c752.

---

@paololucente @rodonile hopefully this won't happen anymore thanks to #816. But please do NOT conflate these changes in unrelated commits, else these things slip in unnoticed - especially if commits are as big as 91df0c752 is:

https://github.com/pmacct/pmacct/commit/91df0c7529266467a99a0d02c042f19bbffda22e#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL162