### PR TITLE
ci: fix publish-dockerhub (DAEMONS), part II

### DIFF
--- a/.github/actions/build_containers/action.yaml
+++ b/.github/actions/build_containers/action.yaml
@@ -9,7 +9,6 @@ inputs:
   daemons:
     required: true
     type: string
-    default: "pmacctd nfacctd sfacctd uacctd pmbgpd pmbmpd pmtelemetryd"
   ci_num_workers:
     required: false
     type: string
@@ -28,6 +27,12 @@ runs:
         CI_DEPS_DONT_CHECK_CERTIFICATE: ${{ inputs.ci_deps_dont_check_cert }}
       shell: bash
       run: |
+        #Sanity, avoid regression #816
+        N_DAEMONS="$(echo $DAEMONS | wc --words)"
+        if [[ "${N_DAEMONS}" != "7" ]]; then
+            echo "ERROR: invalid number of DAEMONS: ${N_DAEMONS}"
+            exit 1
+        fi
         cd pmacct
         git config --global --add safe.directory $GITHUB_WORKSPACE
         git config --global --add safe.directory $GITHUB_WORKSPACE/src/external_libs/libcdada

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
     - cron: '0 0 * * *'  # every day at midnight
 
 #Global vars
+env:
+  #TODO: avoid duplicity ci/regression_tests
+  DAEMONS: "pmacctd nfacctd sfacctd uacctd pmbgpd pmbmpd pmtelemetryd"
+
 jobs:
   ### Step 1: build container images
   builder-docker:
@@ -114,8 +118,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: 1
 
+      - name: Check DAEMONS env. variable...
+        run: |
+          #Sanity, avoid regression #816
+          N_DAEMONS="$(echo $DAEMONS | wc --words)"
+          if [[ "${N_DAEMONS}" != "7" ]]; then
+              echo "ERROR: invalid number of DAEMONS: ${N_DAEMONS}"
+              exit 1
+          fi
+
       - name: Build containers
         uses: ./pmacct/.github/actions/build_containers/
+        with:
+            daemons: ${{env.DAEMONS}}
 
       - name: Docker save images
         run: |

--- a/.github/workflows/regression_tests.yaml
+++ b/.github/workflows/regression_tests.yaml
@@ -32,6 +32,11 @@ on:
         - signals
         - ha
 
+#Global vars
+env:
+  #TODO: avoid duplicity ci/regression_tests
+  DAEMONS: "pmacctd nfacctd sfacctd uacctd pmbgpd pmbmpd pmtelemetryd"
+
 jobs:
   ### Step 0: Build Traffic Reproducer Images
   ### Step 1: Build Traffic Reproducer Images
@@ -81,6 +86,8 @@ jobs:
 
       - name: Build containers
         uses: ./pmacct/.github/actions/build_containers/
+        with:
+            daemons: ${{env.DAEMONS}}
 
       - name: Download images and prepare artifacts
         run: |


### PR DESCRIPTION
Commit 82b9ba16, part of #816, broke upload of all `DAEMONS` but `base`. The reason why it wasn't detected is because composite action leaves `DAEMONS` set, so step 3 passes and step 4 just uploads the single daemon base.

Fix it by defining it globally, and add a check for the list of `DAEMONS` as part of step2, so that this is not happening again.

---

cc @paololucente @rodonile 