### PR TITLE
CI: add env var to allow switching off dockerhub publish job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
   publish-dockerhub:
     needs: [pmacct-docker, build-and-test]
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && vars.SKIP_DOCKERHUB_PUBLISH != 'true'
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
### Short description
As discussed with @msune , this PR adds a config env variable that can be declared in the actions variables to skip the dockerhub image publishing job. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [ ] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
