### PR TITLE
CI/Regression Tests: minor quality of life updates to testing-framework

### DIFF
--- a/.github/workflows/regression_tests.yaml
+++ b/.github/workflows/regression_tests.yaml
@@ -22,23 +22,26 @@ on:
         type: choice
         options:
         - ''
-        - basic
+        - ci
+        - light
+        - ha
         - ipfix
-        - bmp
         - bgp
+        - bmp
         - avro
         - json
         - redis
         - signals
-        - ha
 
 #Global vars
 env:
   #TODO: avoid duplicity ci/regression_tests
   DAEMONS: "pmacctd nfacctd sfacctd uacctd pmbgpd pmbmpd pmtelemetryd"
+  MARKER: "ci"    # Default marker for normal CI execution
+  COMMIT_ID: ${{ github.sha }}
+  DEFAULT_ONLY: false
 
 jobs:
-  ### Step 0: Build Traffic Reproducer Images
   ### Step 1: Build Traffic Reproducer Images
   traf-repro-docker:
     runs-on: ubuntu-22.04
@@ -84,10 +87,21 @@ jobs:
           fetch-depth: 0
           fetch-tags: 1
 
+      - name: Overwrite environment variables for the workflow_dispatch event
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "MARKER=${{ inputs.marker }}" >> $GITHUB_ENV
+            if [ ! -z "${{ inputs.commit_id }}" ]; then
+              echo "COMMIT_ID=${{ inputs.commit_id }}" >> $GITHUB_ENV
+            fi
+            echo "DEFAULT_ONLY=${{ inputs.default_only }}" >> $GITHUB_ENV
+          fi
+
       - name: Build containers
         uses: ./pmacct/.github/actions/build_containers/
         with:
             daemons: ${{env.DAEMONS}}
+            commit-id: ${{env.COMMIT_ID}}
 
       - name: Download images and prepare artifacts
         run: |
@@ -123,21 +137,44 @@ jobs:
         with:
           path: pmacct
 
-      - name: Collect list of tests from tests/ folder
-        id: set-matrix
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Framework Requirements
         run: |
-          cd pmacct/tests
-          MATRIX="{"test": $(find . -mindepth 1 -maxdepth 1 -type d | cut -c 3- | cut -c 1-3 | sort | jq -R -s -c 'split("\n")[:-1]')}"
+          sudo apt update
+          sudo apt install librdkafka-dev docker
+          pip install --upgrade pip
+          pip install -r pmacct/test-framework/requirements.txt
+
+      - name: Overwrite environment variables for the workflow_dispatch event
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "MARKER=${{ inputs.marker }}" >> $GITHUB_ENV
+            if [ ! -z "${{ inputs.commit_id }}" ]; then
+              echo "COMMIT_ID=${{ inputs.commit_id }}" >> $GITHUB_ENV
+            fi
+            echo "DEFAULT_ONLY=${{ inputs.default_only }}" >> $GITHUB_ENV
+          fi
+
+      - name: Collect list of tests matching with the provided marker
+        id: set-matrix
+        env:
+          MARKER: ${{ env.MARKER }}
+        run: |
+          cd pmacct/test-framework
+          dry_run_output=$(sudo env PATH="$PATH" ./runtest.sh --dry * --mark="$MARKER")
+          MATRIX="{"test": $(echo "$dry_run_output" | grep -oP '(?<=<Module )\d+(?=_test\.py)' | jq -R -s -c 'split("\n")[:-1]')}"
           echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
-          echo "Collected tests:"
+          echo "Collected Tests:"
           echo $MATRIX
 
   ### Step 4: Setup Framework and Run Tests
   pytest-runtests:
     needs: [collect-tests, traf-repro-docker, cache-docker-images]
     runs-on: ubuntu-22.04
-    env:
-      SKIP: 'false'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.collect-tests.outputs.matrix) }}
@@ -162,63 +199,42 @@ jobs:
           pip install --upgrade pip
           pip install -r pmacct/test-framework/requirements.txt
 
-      - name: Dry-run to check collected tests
-        if: ${{ success() && inputs.marker != '' }}
-        env:
-          MARKER: ${{ inputs.marker }}
-        run: |
-          function intercept_pytest_no_tests_collected {
-            exit_code=$?
-            if [[ ${exit_code} -eq 5 ]]
-            then
-              echo "Intercepting pytest exit code 5 (no tests collected) and replacing with 0"
-              echo "Setting early_exit to true!"
-              echo "SKIP=true" >> "$GITHUB_ENV"
-              exit 0
-            fi
-          }
-          trap intercept_pytest_no_tests_collected EXIT
-          cd pmacct/test-framework
-          sudo env PATH="$PATH" ./runtest.sh --dry ${{ matrix.test }} --mark="$MARKER"
-
       - name: Download Artifacts
-        if: ${{ success() && env.SKIP == 'false' }}
         uses: actions/download-artifact@v4
         with:
           pattern: '*_docker_images'
           path: /tmp/docker
 
       - name: Import images in the local registry
-        if: ${{ success() && env.SKIP == 'false' }}
         run: |
           docker load -i /tmp/docker/traffic_reproducer_docker_images/traffic_reproducer_docker_images.tar
           docker load -i /tmp/docker/hub_pulled_docker_images/hub_pulled_docker_images.tar
           echo "List Images"
           docker images | grep 'confluentinc\|redis\|traffic\|_build'
 
+      - name: Overwrite environment variables for the workflow_dispatch event
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "MARKER=${{ inputs.marker }}" >> $GITHUB_ENV
+            if [ ! -z "${{ inputs.commit_id }}" ]; then
+              echo "COMMIT_ID=${{ inputs.commit_id }}" >> $GITHUB_ENV
+            fi
+            echo "DEFAULT_ONLY=${{ inputs.default_only }}" >> $GITHUB_ENV
+          fi
+
       - name: Run the test(s)
-        if: ${{ success() && env.SKIP == 'false' }}
         env:
-          DEFAULT_ONLY: ${{ inputs.default_only }}
-          MARKER: ${{ inputs.marker }}
+          DEFAULT_ONLY: ${{ env.DEFAULT_ONLY }}
         run: |
           cd pmacct/test-framework
           if [[ "$DEFAULT_ONLY" == "true" ]]; then
-            if [[ "$MARKER" == "" ]]; then
-              sudo env PATH="$PATH" ./runtest.sh ${{ matrix.test }}:00
-            else
-              sudo env PATH="$PATH" ./runtest.sh ${{ matrix.test }}:00 --mark="$MARKER"
-            fi
+            sudo env PATH="$PATH" ./runtest.sh ${{ matrix.test }}:00
           else
-            if [[ "$MARKER" == "" ]]; then
-              sudo env PATH="$PATH" ./runtest.sh ${{ matrix.test }}
-            else
-              sudo env PATH="$PATH" ./runtest.sh ${{ matrix.test }} --mark="$MARKER"
-            fi
+            sudo env PATH="$PATH" ./runtest.sh ${{ matrix.test }}
           fi
 
       - name: Prepare Results Folder for Upload (permissions and folder name)
-        if: ${{ !cancelled() && env.SKIP == 'false' }}    # always run this step, unless job manually cancelled or we are skipping the test
+        if: '!cancelled()'                            # always run this step, unless job manually cancelled
         run: |
           cd pmacct/test-framework
           sudo chown -R 1000:1000 results/
@@ -229,7 +245,7 @@ jobs:
           echo "TEST_FOLDER_NAME=$TEST_FOLDER_NAME" >> "$GITHUB_ENV"
 
       - name: Upload Results Folder
-        if: ${{ !cancelled() && env.SKIP == 'false' }}    # always run this step, unless job manually cancelled or we are skipping the test
+        if: '!cancelled()'                            # always run this step, unless job manually cancelled
         uses: actions/upload-artifact@v4
         with:
           retention-days: 7
@@ -305,18 +321,28 @@ jobs:
         with:
           path: github-pages/
 
+      - name: Overwrite environment variables for the workflow_dispatch event
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "MARKER=${{ inputs.marker }}" >> $GITHUB_ENV
+            if [ ! -z "${{ inputs.commit_id }}" ]; then
+              echo "COMMIT_ID=${{ inputs.commit_id }}" >> $GITHUB_ENV
+            fi
+            echo "DEFAULT_ONLY=${{ inputs.default_only }}" >> $GITHUB_ENV
+          fi
+
       - name: Add info to markdown summary
         env:
-          MARKER: ${{ inputs.marker }}
-          COMMIT_ID: ${{ inputs.commit_id }}
-          DEFAULT_ONLY: ${{ inputs.default_only }}
+          MARKER: ${{ env.MARKER }}
+          COMMIT_ID: ${{ env.COMMIT_ID }}
+          DEFAULT_ONLY: ${{ env.DEFAULT_ONLY }}
         run: |
           echo "## :loudspeaker: Pytest Run Information: :loudspeaker:" >> $GITHUB_STEP_SUMMARY
           echo "### Test Results:" >> $GITHUB_STEP_SUMMARY
           echo "The Pytest HTML report is only deployed on github pages for runs triggered from the master branch (for security reasons), \
                 and is only available for the latest CI run. This is due to current Github Actions limitations of not supporting \
                 different URLs for deployments. Nonetheless, reports are anyway available for download as artifacts for up to 15 days \
-                after the test run (see Artifacts section above)." >> $GITHUB_STEP_SUMMARY
+                after the test run (see Artifacts section below)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Quick links for downloading:**" >> $GITHUB_STEP_SUMMARY
           echo "- Pytest HTML Report: ${{ steps.upload-artifact-html-report.outputs.artifact-url }}'" >> $GITHUB_STEP_SUMMARY
@@ -324,10 +350,10 @@ jobs:
                   ${{ steps.upload-artifact-results.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo
-          echo "### Input Arguments (use for manual workflow dispatch of the CI only):" >> $GITHUB_STEP_SUMMARY
-          echo "Marker provided: $MARKER" >> $GITHUB_STEP_SUMMARY
-          echo "Commit ID provided: $COMMIT_ID" >> $GITHUB_STEP_SUMMARY
-          echo "Default_only: $DEFAULT_ONLY" >> $GITHUB_STEP_SUMMARY
+          echo "### Input Arguments (can be changed when launching manual workflow_dispatch runs):" >> $GITHUB_STEP_SUMMARY
+          echo "Test default scenarios only: $DEFAULT_ONLY" >> $GITHUB_STEP_SUMMARY
+          echo "Pytest Marker: $MARKER" >> $GITHUB_STEP_SUMMARY
+          echo "Commit ID: https://github.com/${{github.repository}}/tree/$COMMIT_ID" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo
 

--- a/test-framework/README.md
+++ b/test-framework/README.md
@@ -96,6 +96,16 @@ Example (run test case 300 [default scenario] with python without the ./runtest.
 python3 -m pytest tests/300* --runconfig=300:00 -c=pytest.ini --log-cli-level=DEBUG --log-file=results/pytestlog.log --html=results/report.html
 ```
 
+Example (overwrite the expected output files for test 203 [more info [here](#expected-json-output)]):
+```shell
+sudo env PATH="$PATH" OVERWRITE=true ./runtest.sh 203 --loglevel=DEBUG
+```
+
+Example (overwrite the expected output files for test with BMP data [more info [here](#expected-json-output)]):
+```shell
+sudo env PATH="$PATH" OVERWRITE=true ./runtest.sh * --mark=bmp --loglevel=DEBUG
+```
+
 A list of markers (ie. ipfix, bmp, etc.) are available to run a specific subset of tests. The full list is part of the
 [pytest.ini](pytest.ini) file.
 
@@ -202,35 +212,18 @@ The [Traffic Reproducer Project](https://github.com/network-analytics/traffic-re
 
 ### Expected json output
 
-The framework can also be used to generate the expected json output files that pmacct produces to kafka. Just keep in mind that the json output needs to be manually checked to verify that the data received is as expected.
+The framework can also be used to generate or update the expected json output files by setting the OVERWRITE env var when running the tests:
 
-This is possible since the framework will always provide the kafka dumps (in the [results](results) folder) for each test after execution. The only problem is that without any output-XXX.json files, the tests will fail throwing a *file_not_found* error.
-
-As example, if we want to generate the output files for test 100 (assuming that the output-flow-00.json file is not existing yet), we cannot just run the test normally as the *read_and_compare_messages* function will throw an error.
+Example:
 ```
-def main(consumers):
-    th = KTestHelper(testParams, consumers)
-    assert th.spawn_traffic_container('traffic-reproducer')
-
-    th.set_ignored_fields(['stamp_inserted', 'stamp_updated', 'timestamp_max', 'timestamp_arrival', 'timestamp_min'])
-    assert th.read_and_compare_messages('daisy.flow', 'flow-00')
+sudo env PATH="$PATH" OVERWRITE=true ./runtest.sh 203 --loglevel=DEBUG   # overwrite all output files for test 203
 ```
 
-To overcome this, we can temporarily replace that function with another one specifically developed for this purpose:
-``` # Add this import if not already there
-    import library.py.test_tools as test_tools 
-    
-    consumer = consumers.get_consumer_of_topic_like('daisy.flow')
-    assert test_tools.read_messages_dump_only(consumer, testParams, wait_time=120)             # wait_time is optional (default=120s)
-```
+Keep in mind that the output file (e.g. output-flow-00.json) needs to exist at least as empty file, otherwise it will fail. 
 
-This way we can simply call:
-```
-./runtest 100
-```
-and the test will be executed omitting the output check, just consuming and dumping all messages sent to the kafka topic for the specified wait_time.
+Remark: this process is significantly slower than the normal test execution, since we are currently waiting for a default 120s timeout to ensure all messages arrive, due to the internal flow record bucketing. During the normal test execution, instead, as soon as the expected number of packets arrives we can stop the kafka consume process. This can be improved (TODO).
 
-The json data can be found in the [results/100-IPFIXv10-CISCO/kafka_dumps](results/100-IPFIXv10-CISCO/kafka_dumps) folder and its content can be used to generate the output-flow-00.json file. 
+The json data can also be found in the [results/203-BMP-HUAWEI-dump/kafka_dumps](results/203-BMP-HUAWEI-dump/kafka_dumps) folder.
 
 ### Expected log output
 

--- a/test-framework/library/py/json_tools.py
+++ b/test-framework/library/py/json_tools.py
@@ -151,3 +151,47 @@ def compare_messages_to_json_file(message_dicts: List[Dict], jsonfile: str, igno
     if multi_match_allowed:
         return compare_json_lists_multi_match(jsons, lines, ignore_fields, max_matches)
     return compare_json_lists(jsons, lines, ignore_fields)
+
+# Removes fields from a json object
+def remove_fields_from_json(input_file, fields_to_remove):
+    logger.info(f'Removing fields "{fields_to_remove}" from JSON message')
+
+    with open(input_file, 'r') as infile:
+        content = infile.readlines()
+
+    modified_content = []
+    for line in content:
+        json_message = json.loads(line)
+        for field in fields_to_remove:
+            if field in json_message:
+                del json_message[field]
+        modified_content.append(json.dumps(json_message))
+
+    with open(input_file, 'w') as outfile:
+        outfile.write('\n'.join(modified_content))
+
+# Aligns json columns for better visualization (used for development/debugging only)
+def align_json_columns(input_file):
+    logger.info(f'Aligning json columns for better visualization')
+
+    with open(input_file, 'r') as infile:
+        lines = infile.readlines()
+
+    json_objects = [json.loads(line) for line in lines]
+    
+    all_keys = sorted(set(key for obj in json_objects for key in obj.keys()))
+
+    max_key_length = max(len(key) for key in all_keys)
+    max_value_lengths = {key: max(len(json.dumps(obj.get(key, ''))) for obj in json_objects) for key in all_keys}
+
+    formatted_lines = []
+    for obj in json_objects:
+        formatted_line = '{'
+        for key in all_keys:
+            value = json.dumps(obj.get(key, ''))
+            formatted_line += f'"{key}": {value.ljust(max_value_lengths[key])}, '
+        formatted_line = formatted_line.rstrip(', ') + '}'
+        formatted_lines.append(formatted_line)
+
+    with open(input_file, 'w') as outfile:
+        outfile.write('\n'.join(formatted_lines))

--- a/test-framework/library/py/test_helper.py
+++ b/test-framework/library/py/test_helper.py
@@ -41,10 +41,16 @@ class KTestHelper:
     # Consumes from the provided kafka topic topic_name as many messages as the number of lines in the json
     # reference file implied by the keyword reference_json (searched for with *like* in the tests folder). Then,
     # it compares the received messages with the jsons corresponding to the lines in the reference file.
+    # If OVERWRITE=true environment variable is set, the output test files are overwritten (used for test development)
     def read_and_compare_messages(self, topic_name: str, reference_json: str, wait_time: int = 120) -> bool:
         consumer = self.consumers.get_consumer_of_topic_like(topic_name)
-        return test_tools.read_and_compare_messages(consumer, self.params, reference_json,
-                                                    self.ignored_fields, wait_time)
+
+        if self.params.overwrite_json_output:
+            return test_tools.read_messages_and_overwrite_output_files(consumer, self.params, reference_json,
+                                                                       wait_time) 
+        else:
+            return test_tools.read_and_compare_messages(consumer, self.params, reference_json,
+                                                        self.ignored_fields, wait_time)
 
     # Identifies the reference log file corresponding to log_tag and transforms it with respect to
     # traffic reproduction IP address and other wildcards/regexes used therein. The traffic reproduction

--- a/test-framework/library/py/test_params.py
+++ b/test-framework/library/py/test_params.py
@@ -45,6 +45,7 @@ class KModuleParams:
         self.pmacct = []
         self.results_folder = self.results_dump_folder = None
         self.test_output_files = self.test_log_files = self.test_conf_files = []
+        self.overwrite_json_output = os.getenv('OVERWRITE', 'false').lower() == 'true'
 
     @property
     def pmacct_log_file(self):

--- a/test-framework/library/py/test_tools.py
+++ b/test-framework/library/py/test_tools.py
@@ -8,6 +8,7 @@ import logging
 import secrets
 import time
 import datetime
+import shutil
 import library.py.json_tools as jsontools
 import library.py.helpers as helpers
 import library.py.escape_regex as escape_regex
@@ -78,14 +79,13 @@ def read_messages_dump_only(consumer: KMessageReader, params: KModuleParams, wai
 
 
 # Reads all messages from Kafka topic within a specified timeout (wait_time)
-# and overwrites the relative output json file
-# --> used for test-case development
+# and overwrites the relative output json file (used for test-case development)
+# While doing so, it also:
+# - removes (pmacct internal) timestamp fields from the output json file
+# - aligns columns in the output json file
 def read_messages_and_overwrite_output_files(consumer: KMessageReader, params: KModuleParams, json_name: str,
                                              wait_time: int = 120) -> bool:
 
-    # Reading messages from Kafka topic
-    # The get_messages method with wait_time as only argument consumes all messages and returns 
-    # when wait_time (default=120s) has passed
     logger.info('Consuming from kafka [timeout=' + str(wait_time) + 's]')
     messages = consumer.get_messages(wait_time)
     if len(messages) < 1:
@@ -101,7 +101,18 @@ def read_messages_and_overwrite_output_files(consumer: KMessageReader, params: K
     with open(output_json_file, 'w') as output_json:
         output_json.write(content)
 
+    # Remove (pmacct internal) timestamp fields from the output json file
+    fields_to_remove = ['timestamp_arrival', 'timestamp_min', 'timestamp_max', 'stamp_inserted', 'stamp_updated']
+    jsontools.remove_fields_from_json(output_json_file, fields_to_remove)
+
     logger.warning('OVERWRITE=true - file changed: ' + output_json_file)
+
+    # Move the kafka_dump_file to a new file with a timestamp
+    # (to support consuming multiple times from the same topic)
+    timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    new_kafka_dump_file = consumer.dumpfile + '_' + timestamp + '.json'
+    shutil.move(kafka_dump_file, new_kafka_dump_file)
+    logger.info('Moved kafka dump file to: ' + new_kafka_dump_file)
 
     return True 
 

--- a/test-framework/pytest.ini
+++ b/test-framework/pytest.ini
@@ -13,7 +13,8 @@ log_file_date_format=%Y-%m-%d %H:%M:%S
 
 markers =
     ; Custom test groups
-    basic:          basic set of tests (useful i.e. to run in constrained environments).
+    ci:             default set of tests always running in github CI.
+    light:          basic set of light tests (useful i.e. to run in constrained environments).
     ha:             tests with high availability setup
 
     ; Traffic (pcap content) markers

--- a/tests/100-IPFIXv10-CISCO/100_test.py
+++ b/tests/100-IPFIXv10-CISCO/100_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only

--- a/tests/101-NFv9-CISCO-cust_primitives/101_test.py
+++ b/tests/101-NFv9-CISCO-cust_primitives/101_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only

--- a/tests/102-NFv9-CISCO-f2rd-pretag-sampling-reload/102_test.py
+++ b/tests/102-NFv9-CISCO-f2rd-pretag-sampling-reload/102_test.py
@@ -9,13 +9,13 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only
 @pytest.mark.nfv9
 @pytest.mark.avro
-@pytest.mark.basic
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)
 

--- a/tests/103-IPFIXv10-CISCO-pretag-JSON_encoding/103_test.py
+++ b/tests/103-IPFIXv10-CISCO-pretag-JSON_encoding/103_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only

--- a/tests/104-IPFIXv10-IPv6-CISCO-sampling_option/104_test.py
+++ b/tests/104-IPFIXv10-IPv6-CISCO-sampling_option/104_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv6_subnet='cafe::')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only

--- a/tests/110-IPFIXv10-NFv9-multiple-sources/110_test.py
+++ b/tests/110-IPFIXv10-NFv9-multiple-sources/110_test.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
-
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only

--- a/tests/111-IPFIXv10-NFv9-IPv6-IPv4-mix_sources/111_test.py
+++ b/tests/111-IPFIXv10-NFv9-IPv6-IPv4-mix_sources/111_test.py
@@ -8,14 +8,13 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
-
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfix_only
 @pytest.mark.ipfixv10
 @pytest.mark.nfv9
 @pytest.mark.avro
-@pytest.mark.basic
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)
 

--- a/tests/200-BMP-HUAWEI-locrib_instance/200_test.py
+++ b/tests/200-BMP-HUAWEI-locrib_instance/200_test.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.bmp
 @pytest.mark.bmp_only

--- a/tests/201-BMP-CISCO-rd_instance/201_test.py
+++ b/tests/201-BMP-CISCO-rd_instance/201_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.bmp
 @pytest.mark.bmp_only

--- a/tests/202-BMP-CISCO-HUAWEI-multiple-sources/202_test.py
+++ b/tests/202-BMP-CISCO-HUAWEI-multiple-sources/202_test.py
@@ -7,12 +7,11 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='pmbmpd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
 @pytest.mark.pmbmpd
 @pytest.mark.bmp
 @pytest.mark.bmp_only
 @pytest.mark.bmpv3
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/203-BMP-HUAWEI-dump/203_test.py
+++ b/tests/203-BMP-HUAWEI-dump/203_test.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.bmp
 @pytest.mark.bmp_only

--- a/tests/204-BMP-CISCO-peer_down/204_test.py
+++ b/tests/204-BMP-CISCO-peer_down/204_test.py
@@ -7,12 +7,11 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
-
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.bmp
 @pytest.mark.bmp_only
 @pytest.mark.bmpv3
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/205-BMP-6wind-FRR-peer_down/205_test.py
+++ b/tests/205-BMP-6wind-FRR-peer_down/205_test.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.bmp
 @pytest.mark.bmp_only

--- a/tests/207-BMP-CISCO-HUAWEI-multiple-sources-dump-spreading/207_test.py
+++ b/tests/207-BMP-CISCO-HUAWEI-multiple-sources-dump-spreading/207_test.py
@@ -8,11 +8,11 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='pmbmpd', ipv4_subnet='192.168.100.')
 
+@pytest.mark.ci
 @pytest.mark.pmbmpd
 @pytest.mark.bmp
 @pytest.mark.bmp_only
 @pytest.mark.bmpv3
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/300-BGP-IPv6-CISCO-extNH_enc/300_test.py
+++ b/tests/300-BGP-IPv6-CISCO-extNH_enc/300_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv6_subnet='cafe::')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.bgp
 @pytest.mark.bgp_only

--- a/tests/301-BGP-CISCO-pretag/301_test.py
+++ b/tests/301-BGP-CISCO-pretag/301_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='pmbgpd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.pmbgpd
 @pytest.mark.bgp
 @pytest.mark.bgp_only

--- a/tests/302-BGP-IPv6-multiple-sources/302_test.py
+++ b/tests/302-BGP-IPv6-multiple-sources/302_test.py
@@ -8,10 +8,10 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.', ipv6_subnet='cafe::')
 
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.bgp
 @pytest.mark.bgp_only
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/304-BGP-IPv6-multiple-sources-dump-spreading/304_test.py
+++ b/tests/304-BGP-IPv6-multiple-sources-dump-spreading/304_test.py
@@ -8,10 +8,10 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.', ipv6_subnet='cafe::')
 
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.bgp
 @pytest.mark.bgp_only
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/400-IPFIXv10-BMP-CISCO-SRv6-multiple-sources/400_test.py
+++ b/tests/400-IPFIXv10-BMP-CISCO-SRv6-multiple-sources/400_test.py
@@ -8,12 +8,13 @@ logger = logging.getLogger(__name__)
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
 
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfixv10
 @pytest.mark.bmp
 @pytest.mark.bmpv3
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/401-IPFIXv10-BMP-IPv6-CISCO-MPLS-multiple-sources/401_test.py
+++ b/tests/401-IPFIXv10-BMP-IPv6-CISCO-MPLS-multiple-sources/401_test.py
@@ -7,13 +7,12 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
-
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfixv10
 @pytest.mark.bmp
 @pytest.mark.bmpv3
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/403-IPFIXv10-BMP-IPv6-CISCO-locrib-peerdown-vrf/403_test.py
+++ b/tests/403-IPFIXv10-BMP-IPv6-CISCO-locrib-peerdown-vrf/403_test.py
@@ -6,12 +6,12 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
+@pytest.mark.ci
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.ipfixv10
 @pytest.mark.bmp
 @pytest.mark.bmpv3
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/500-IPFIXv10-BGP-CISCO-SRv6/500_test.py
+++ b/tests/500-IPFIXv10-BGP-CISCO-SRv6/500_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.bgp

--- a/tests/501-IPFIXv10-BGP-IPv6-CISCO-MPLS/501_test.py
+++ b/tests/501-IPFIXv10-BGP-IPv6-CISCO-MPLS/501_test.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.bgp

--- a/tests/502-IPFIXv10-BGP-IPv6-CISCO-SRv6-lcomms/502_test.py
+++ b/tests/502-IPFIXv10-BGP-IPv6-CISCO-SRv6-lcomms/502_test.py
@@ -7,11 +7,11 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.ipfix
 @pytest.mark.bgp
-@pytest.mark.basic
 @pytest.mark.avro
 def test(test_core, consumer_setup_teardown):
     main(consumer_setup_teardown)

--- a/tests/900-kafka-connection-loss/900_test.py
+++ b/tests/900-kafka-connection-loss/900_test.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.signals
 @pytest.mark.nfacctd
 def test(test_core, consumer_setup_teardown):

--- a/tests/901-redis-connection-loss/901_test.py
+++ b/tests/901-redis-connection-loss/901_test.py
@@ -9,10 +9,11 @@ logger = logging.getLogger(__name__)
 
 testParams = KModuleParams(__file__, daemon='nfacctd', ipv4_subnet='192.168.100.')
 
-
-# added redis fixture below, that's why the test_core fixture is not used here
+@pytest.mark.ci
+@pytest.mark.light
 @pytest.mark.nfacctd
 @pytest.mark.redis
+# added redis fixture below, that's why the test_core fixture is not used here
 def test(check_root_dir, kafka_infra_setup_teardown, prepare_test, redis_setup_teardown, pmacct_setup_teardown,
          prepare_pcap, consumer_setup_teardown):
     main(consumer_setup_teardown)


### PR DESCRIPTION
### Short description
This PR adds the following:

- new "ci" marker to tag all tests that have to be executed by default. The regression_tests workflow will now by default only run tests tagged with this marker. We still have the possibility to run any tests with the manual workflow dispatch (where we can select another marker). This gives us an easy way to deactivate a test, by simply removing the ci marker from the python test file.

- automatic json-output-files overwrite which can be enabled by OVERWRITE env variable. In case of new feature that changes the default output schema we can now regenerate the output without manual intervention in the python files.

Example (update output files for test 200):
```shell
sudo env PATH="$PATH" OVERWRITE=true ./runtest.sh 200--loglevel=DEBUG
``` 


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
