### PR TITLE
docker: build and publish linux/arm64 images (experimental)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,3 +51,6 @@ src/external_libs/rootfs
 
 # Dockerfiles makes no sense in the build context
 **/Dockerfile
+
+# Exclude Makefile (dev only)
+docker/Makefile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,40 +107,21 @@ jobs:
           docker exec -i $CONTAINER_ID ./ci/script.sh
           docker stop $CONTAINER_ID
 
-  ### Step 3: official docker image generation
-  pmacct-docker:
+  ### Step 3.1: test that local single-platform builds work fine
+  docker-build-test-local:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout pmacct
-        uses: actions/checkout@v4
+        uses: actions/checkout@v1 #Don't use v2 messes everything
         with:
           path: pmacct
-          fetch-depth: 0
-          fetch-tags: 1
 
-      - name: Check DAEMONS env. variable...
+      - name: Build single-platform
         run: |
-          #Sanity, avoid regression #816
-          N_DAEMONS="$(echo $DAEMONS | wc --words)"
-          if [[ "${N_DAEMONS}" != "7" ]]; then
-              echo "ERROR: invalid number of DAEMONS: ${N_DAEMONS}"
-              exit 1
-          fi
-
-      - name: Build containers
-        uses: ./pmacct/.github/actions/build_containers/
-        with:
-            daemons: ${{env.DAEMONS}}
-
-      - name: Docker save images
-        run: |
-          echo "Saving images as artifacts..."
-          mkdir -p /tmp/docker/
-          docker save -o /tmp/docker/pmacct_docker_images.tar base:_build $(for DAEMON in ${DAEMONS};do echo "${DAEMON}:_build "; done)
+          cd docker && V=1 make
 
       - name: Docker (compose) smoke test
         run: |
-          cd pmacct
           echo "Running smoke test using docker compose..."
           TAG=_build docker compose -f ci/smoke-test/docker-compose.yml up -d
           sleep 10
@@ -151,51 +132,31 @@ jobs:
           echo "Stopping containers..."
           TAG=_build docker compose -f ci/smoke-test/docker-compose.yml down
 
-      - name: Export pmacct docker images as an artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pmacct_docker_images
-          retention-days: 1
-          path: /tmp/docker
-
-  ### Step 4: Upload images to dockerhub (bleeding-edge, latest and releases)
-  publish-dockerhub:
-    needs: [pmacct-docker, build-and-test]
+  ### Step 3.2: Build test and publish (bleeding-edge, latest and releases)
+  docker-multiplatform-build-test-publish:
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request' && vars.SKIP_DOCKERHUB_PUBLISH != 'true'
+    needs: [build-and-test, docker-build-test-local]
     env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      PLATFORMS: linux/amd64,linux/arm64
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: pmacct_docker_images
-          path: /tmp/docker
-
-      - name: Import pmacct docker images in the local registry
-        run: |
-          docker load -i /tmp/docker/pmacct_docker_images.tar
-
       - name: Checkout pmacct
         uses: actions/checkout@v1 #Don't use v2 messes everything
         with:
           path: pmacct
 
-      - name: Build and upload containers
+      - name: Deduce PMACCT version and tags
         run: |
           echo "Fix mess with tags in actions/checkout..."
           git fetch -f && git fetch -f --tags
           echo "Deducing PMACCT_VERSION..."
           PMACCT_VERSION=$(git describe --abbrev=0 --match="v*")
-          echo "PMACCT_VERSION=$PMACCT_VERSION"
-          echo "Uploading to dockerhub ...";
-          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin;
 
           #Always push bleeding-edge when pushed to master
           GIT_IS_BLEEDING_EDGE=$( (git branch --all --contains HEAD | grep master ) || echo "")
           echo "GIT_IS_BLEEDING_EDGE=$GIT_IS_BLEEDING_EDGE"
           if [ "$GIT_IS_BLEEDING_EDGE" != "" ]; then
             echo "Tagging and uploading 'bleeding-edge'..."
+            TAGS="$TAGS bleeding-edge"
           else
             echo "NOT uploading 'bleeding-edge'... Not HEAD of master"
           fi
@@ -205,12 +166,14 @@ jobs:
           if [ "$GIT_RELEASE_TAG" != "" ]; then
             echo "GIT_RELEASE_TAG=$GIT_RELEASE_TAG"
             echo "Tagging and uploading release '$GIT_RELEASE_TAG'..."
+            TAGS="$TAGS $GIT_RELEASE_TAG"
 
             #Latest tag
             GIT_LAST_TAG=$(git tag --sort=v:refname | tail -n 1);
             echo "GIT_LAST_TAG=$GIT_LAST_TAG"
             if [ "$GIT_RELEASE_TAG" == "$GIT_LAST_TAG" ]; then
               echo "Tagging and uploading 'latest'..."
+              TAGS="$TAGS latest"
             else
               echo "NOT uploading 'latest'..."
             fi
@@ -218,19 +181,54 @@ jobs:
             echo "NOT uploading '$GIT_RELEASE_TAG' nor 'latest'. Not a release!"
           fi
 
-          #Let's do it!
-          EXT_DAEMONS="base ${DAEMONS}"
-          for DAEMON in ${EXT_DAEMONS}; do
-            if [ "$GIT_IS_BLEEDING_EDGE" != "" ]; then
-              docker tag ${DAEMON}:_build ${DOCKER_USERNAME}/${DAEMON}:bleeding-edge;
-              docker push ${DOCKER_USERNAME}/${DAEMON}:bleeding-edge;
-            fi
-            if [ "$GIT_RELEASE_TAG" != "" ]; then
-              docker tag ${DAEMON}:_build ${DOCKER_USERNAME}/${DAEMON}:${PMACCT_VERSION};
-              docker push ${DOCKER_USERNAME}/${DAEMON}:${PMACCT_VERSION};
-              if [ "$GIT_RELEASE_TAG" == "$GIT_LAST_TAG" ]; then
-                docker tag ${DAEMON}:_build ${DOCKER_USERNAME}/${DAEMON}:latest;
-                docker push ${DOCKER_USERNAME}/${DAEMON}:latest;
-              fi
-            fi
-          done
+          #Summarize deduced tags
+          echo "Deduced tags: $TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
+
+      - name: Get Runner's IP Address
+        run: |
+           RUNNER_IP=$(hostname -I | awk '{print $1}')
+           echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+           echo "Deduced RUNNER_IP: $RUNNER_IP"
+
+      - name: Spawn docker registry
+        run: |
+          echo "Instruct dockerd to trust $RUNNER_IP:5000 as an insecure registry..."
+          sudo mkdir -p /etc/docker
+          echo "{
+            \"insecure-registries\": [\"http://$RUNNER_IP:5000\"]
+          }" | sudo tee /etc/docker/daemon.json > /dev/null
+          sudo systemctl restart docker
+          echo "Starting temporary docker registry..."
+          docker run -d -p 5000:5000 --name registry registry:2
+
+      - name: Build for platforms
+        run: |
+          echo "Building platforms: ${{ env.PLATFORMS }}..."
+          echo "Got tags from previous step: $TAGS"
+          cd docker && BUILD_REGISTRY=$RUNNER_IP:5000 PLATFORMS="${{env.PLATFORMS}}" V=1 make
+
+      - name: Docker (compose) smoke test
+        run: |
+          echo "Running smoke test using docker compose..."
+          export DOCKER_OPTS="--insecure-registry $RUNNER_IP:5000"
+          TAG=_build REPO=$RUNNER_IP:5000/ docker compose -f ci/smoke-test/docker-compose.yml up -d
+          sleep 10
+          echo "Check that all containers are up and running, without restarts ..."
+          if [[ "$(docker inspect `docker ps -aq` | grep RestartCount | grep -v '\"RestartCount\": 0')" != "" ]]; then
+            echo "Some containers restarted!" && docker inspect `docker ps -aq` && /bin/false
+          fi
+          echo "Stopping containers..."
+          TAG=_build docker compose -f ci/smoke-test/docker-compose.yml down
+
+      - name: Tag and push to dockerhub
+        if: ${{ github.event_name != 'pull_request' && vars.SKIP_DOCKERHUB_PUBLISH != 'true' && env.TAGS != '' }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "Logging in...";
+          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+          echo "Publishing platforms(archs): ${{ env.PLATFORMS }}..."
+          echo "Got tags from previous step: $TAGS"
+          cd docker && BUILD_REGISTRY=$RUNNER_IP:5000 PUSH=${{secrets.DOCKER_USERNAME}} TAGS="${TAGS}" PLATFORMS="${{env.PLATFORMS}}" V=1 make

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ test-framework/**/*.bak
 tests/**/*.bak
 test-framework/results/
 
+#Docker stuff
+docker/.buildx_config.toml

--- a/ci/deps.sh
+++ b/ci/deps.sh
@@ -35,10 +35,10 @@ mkdir -p /tmp
 cd /tmp
 
 # Dependencies (not fulfilled by Dockerfile)
-git clone --depth 1 https://github.com/akheron/jansson
+git clone --depth 1 -b v2.14 https://github.com/akheron/jansson
 cd jansson ; rm -rf ./.git ; autoreconf -i ; ./configure --prefix=/usr/local/ ; make ; sudo make install ; cd ..
 
-git clone --depth 1 https://github.com/edenhill/librdkafka
+git clone --depth 1 -b v2.6.1 https://github.com/confluentinc/librdkafka
 cd librdkafka ; rm -rf ./.git ; ./configure --prefix=/usr/local/ ; make ; sudo make install ; cd ..
 
 # rabbitmq-c 0.14.0 depends on cmake 3.22 or greater
@@ -50,7 +50,7 @@ else
     cd rabbitmq-c-0.13.0 ; mkdir build ; cd build ; cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib .. ; sudo cmake --build . --target install ; cd .. ; cd ..
 fi
 
-git clone --depth 1 --recursive https://github.com/maxmind/libmaxminddb
+git clone --depth 1 -b 1.11.0 --recursive https://github.com/maxmind/libmaxminddb
 cd libmaxminddb ; rm -rf ./.git ; ./bootstrap ; ./configure --prefix=/usr/local/ ; make ; sudo make install ; cd ..
 
 git clone --depth 1 -b 4.8-stable https://github.com/ntop/nDPI

--- a/ci/smoke-test/docker-compose.yml
+++ b/ci/smoke-test/docker-compose.yml
@@ -1,44 +1,42 @@
-version: "3"
-
 services:
   nfacctd:
-    image: nfacctd:${TAG}
+    image: ${REPO:-}nfacctd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure
 
   pmacctd:
-    image: pmacctd:${TAG}
+    image: ${REPO:-}pmacctd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure
 
   pmbgpd:
-    image: pmbgpd:${TAG}
+    image: ${REPO:-}pmbgpd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure
 
   pmbmpd:
-    image: pmbmpd:${TAG}
+    image: ${REPO:-}pmbmpd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure
 
   pmtelemetryd:
-    image: pmtelemetryd:${TAG}
+    image: ${REPO:-}pmtelemetryd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure
 
   sfacctd:
-    image: sfacctd:${TAG}
+    image: ${REPO:-}sfacctd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure
 
   uacctd:
-    image: uacctd:${TAG}
+    image: ${REPO:-}uacctd:${TAG}
     volumes:
       - ./etc/pmacct:/etc/pmacct
     restart: on-failure

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+!Makefile

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,87 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -e -c
+
+PLATFORMS ?= linux/amd64
+DAEMONS ?= pmacctd nfacctd sfacctd uacctd pmbgpd pmbmpd pmtelemetryd
+DEPS_DONT_CHECK_CERTIFICATE ?=
+N_WORKERS ?= 2
+PROGRESS ?= --progress=plain
+MEMORY ?= 8g
+TAGS ?=
+BUILD_REGISTRY ?=
+LOAD ?=
+PUSH ?=
+
+ifneq ($(strip $(PUSH)),)
+  PUSH_ARG = --push
+endif
+
+ifneq ($(strip $(BUILD_REGISTRY)),)
+  BUILD_REGISTRY_REPO=$(BUILD_REGISTRY)/
+  BUILD_REGISTRY_PUSH=--push
+else
+  LOAD=--load
+endif
+
+ifeq ($(V),1)
+  QUIET =
+else
+  QUIET = @
+endif
+
+all: build
+
+build: __dump_env __builder_setup build_base build_daemons
+
+__dump_env:
+	$(QUIET) echo "Env:"
+	$(QUIET) echo "  PLATFORMS: $(PLATFORMS)"
+	$(QUIET) echo "  DAEMONS: $(DAEMONS)"
+	$(QUIET) echo "  DEPS_DONT_CHECK_CERTIFICATE: $(DEPS_DONT_CHECK_CERTIFICATE)"
+	$(QUIET) echo "  N_WORKERS: $(N_WORKERS)"
+	$(QUIET) echo "  MEMORY: $(MEMORY)"
+	$(QUIET) echo "  BUILD_REGISTRY: $(BUILD_REGISTRY)"
+	$(QUIET) echo "  PUSH: $(PUSH)"
+	$(QUIET) echo "  TAGS: $(TAGS)"
+	$(QUIET) echo "  V: $(V)"
+	$(QUIET) echo "  ---"
+	$(QUIET) echo "  BUILD_REGISTRY_REPO: $(BUILD_REGISTRY_REPO)"
+	$(QUIET) echo "  PUSH_ARG: $(PUSH_ARG)"
+	$(QUIET) echo "  LOAD: $(LOAD)"
+	$(QUIET) echo "  QUIET: $(QUIET)"
+
+__builder_setup:
+	$(QUIET) echo "Installing QEMU-based multi-arch builder..."
+	$(QUIET) if [[ "$(BUILD_REGISTRY)" != "" ]]; then \
+			if [ -z "$$(docker buildx ls | grep xbuilder)" ]; then \
+				echo "" > .buildx_config.toml; \
+				echo '[registry."$(BUILD_REGISTRY)"]' >> .buildx_config.toml; \
+				echo '  http = true' >> .buildx_config.toml; \
+				docker buildx create --name xbuilder --driver docker-container --config .buildx_config.toml --use; \
+			fi; \
+			docker buildx use xbuilder; \
+		else \
+			echo "Using default buildx builder..."; \
+		fi; \
+		docker run --privileged multiarch/qemu-user-static --reset -p yes
+build_base:
+	$(QUIET) echo "Building base container..."
+	$(QUIET) TAGS_BASE=""; for TAG in $(TAGS); do TAGS_BASE="$$TAGS_BASE -t $(PUSH)/base:$${TAG} "; done; \
+	docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) -t $(BUILD_REGISTRY_REPO)base:_build $(LOAD) $(BUILD_REGISTRY_PUSH) --build-arg NUM_WORKERS=$(N_WORKERS) --build-arg DEPS_DONT_CHECK_CERTIFICATE=$(DEPS_DONT_CHECK_CERTIFICATE) -f base/Dockerfile .. ; \
+	if [ -n "$(PUSH)"  ]; then \
+		docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) $${TAGS_BASE} $(PUSH_ARG) --build-arg NUM_WORKERS=$(N_WORKERS) --build-arg DEPS_DONT_CHECK_CERTIFICATE=$(DEPS_DONT_CHECK_CERTIFICATE) -f base/Dockerfile .. ; \
+	fi
+
+build_daemons:
+	$(QUIET) for DAEMON in $(DAEMONS); do \
+		TAGS_DAEMON=""; for TAG in $(TAGS); do TAGS_DAEMON="$$TAGS_DAEMON -t $(PUSH)/$${DAEMON}:$${TAG} "; done; \
+		echo "Building '$${DAEMON}'"; \
+		docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) -t $(BUILD_REGISTRY_REPO)$${DAEMON}:_build $(LOAD) $(BUILD_REGISTRY_PUSH) --build-arg BUILD_REGISTRY=$(BUILD_REGISTRY) -f $${DAEMON}/Dockerfile .. ; \
+		if [ -n "$(PUSH)"  ]; then \
+			docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) $${TAGS_DAEMON} $(PUSH_ARG) --build-arg BUILD_REGISTRY=$(BUILD_REGISTRY) -f $${DAEMON}/Dockerfile .. ; \
+		fi \
+	done
+
+clean:
+	$(QUIET) docker run --privileged multiarch/qemu-user-static --reset
+	$(QUIET) docker buildx rm xbuilder

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,101 @@
+# Building pmacct docker containers
+
+This folder contains a `Makefile` to build pmacct docker images. It simplifies
+the build process, particularly for [multi-platform images](https://docs.docker.com/build/building/multi-platform/).
+
+## Env. variables
+
+A number of environment variables control the build process (`make`):
+
+* `PLATFORMS`: comma separated list of platforms to pass to `docker buildx
+                --platforms`. Default: `linux/amd64`.
+* `BUILD_REGISTRY`: intermediate registry to build multi-platform images.
+                    Default: `""` (none).
+* `PUSH`: push to docker registry `$PUSH`. The registry should NOT have
+          a trailing `/`. Default `""` (don't push).
+* `TAGS`: when `PUSH` is defined, it will push all the tags listed in `TAGS`.
+          Default: `""`.
+* `V`: when set to `1` output is verbose. Default: `""`.
+
+## Building for the host platform (single platform)
+
+To build:
+
+```
+make
+```
+
+Once completed, `base:_build` and all `<daemon>:_build` images will be loaded to
+your local images.
+
+## Multi-platform builds
+
+Building multi-platform images for pmacct using `docker buildx` is a bit tricky.
+Today `docker`/`dockerd`'s local image registry doesn't support more than one
+platfor (the host's one). In other words, docker buildx's argument `--load`
+only works for a single platform matching your host. This limitation might be
+lifted in the future, but for now we need to live with it.
+
+`pmacct` daemon Dockerfile files require the base container to build.
+Technically, daemon containers are the same container with a different
+entrypoint.
+
+TL;DR you will need an auxiliary docker registry that supports multiple
+platforms to build multi-platform images.
+
+It is **highly recommended** to use a temporary/adhoc docker registry for the
+build process, to avoid clogging the real registries with `_build` tags and
+avoid concurrency issues when parallel builds are fired (e.g. from CI).
+
+### Spawning a temporary build registry
+
+Launch a temporary registry:
+
+```
+docker run -d -p 5000:5000 --name registry registry:2
+```
+
+Use `docker inspect` to get the IP address of the container:
+
+```
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry
+```
+
+### Launching the build
+
+With the hostname or IP address of the registry above, launch the multi-platform
+build process:
+
+```
+PLATFORMS="linux/amd64,linux/arm64" \
+BUILD_REGISTRY_REPO=<REGISTRY_HOSTNAME_IP>:5000 \
+PUSH=<REGISTRY_TO_PUSH> \
+TAGS="<list of comma separated tags to push to REGISTRY_TO_PUSH>" \
+make
+```
+
+Get some :popcorn: for the xcompilation...
+
+### Cleaning up the house
+
+Make sure to tear down and remove the registry:
+
+```
+docker stop registry
+docker rm registry
+```
+
+## Pushing images to a remote repository
+
+Define `PUSH=<registry>` without the trailing `/`. Make sure to add some
+meaningful `TAGS`. `_base` tag will NOT be pushed.
+
+## Advanced env. variables
+
+Don't touch unless you know what are you doing:
+
+* `N_WORKERS`: number of parallel workers to pass to make for compiling C/C++
+               code. Default: `2`
+* `MEMORY`: memory limit passed to `docker buildx`. Default: `8g`.
+* `DAEMONS`: list of `DAEMONS` to build the container for. Default: all pmacct
+             daemons.

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -65,7 +65,7 @@ RUN export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
   make install
 
 FROM debian:bookworm-slim AS base
-LABEL maintainer "pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
 COPY --from=build-stage /usr/local/ /usr/local

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -14,6 +14,7 @@ COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
 #   * this only covers build deps
 RUN apt-get update && \
   apt-get install -y \
+    build-essential \
     autoconf \
     automake \
     bash \
@@ -35,12 +36,14 @@ RUN apt-get update && \
     libsqlite3-dev \
     libssl-dev \
     libgnutls28-dev \
+    libnsl-dev \
     libtool \
     make \
     pkg-config \
     sudo \
     wget \
     zlib1g-dev
+
 WORKDIR /tmp/pmacct/
 # About to deal with deps installation
 COPY ci/deps.sh ci/

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates a base docker image with pmacct and other useful
 #tools for network telemetry and monitoring
 
-FROM debian:bookworm-slim as build-stage
+FROM debian:bookworm-slim AS build-stage
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
 # This is not the runtime/final image:
@@ -64,7 +64,7 @@ RUN export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
                               --enable-unyte-udp-notif &&       \
   make install
 
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 LABEL maintainer "pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes

--- a/docker/nfacctd/Dockerfile
+++ b/docker/nfacctd/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates an image for nfacctd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/nfacctd"]
 CMD ["-f", "/etc/pmacct/nfacctd.conf"]

--- a/docker/nfacctd/Dockerfile
+++ b/docker/nfacctd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for nfacctd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/nfacctd"]

--- a/docker/pmacctd/Dockerfile
+++ b/docker/pmacctd/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates an image for pmacctd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmacctd"]
 CMD ["-f", "/etc/pmacct/pmacctd.conf"]

--- a/docker/pmacctd/Dockerfile
+++ b/docker/pmacctd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for pmacctd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmacctd"]

--- a/docker/pmbgpd/Dockerfile
+++ b/docker/pmbgpd/Dockerfile
@@ -3,10 +3,10 @@
 
 #Author: Marc Sune <marcdevel (at) gmail.com>
 
-#This Dockerfile creates an image for pmbgpd 
+#This Dockerfile creates an image for pmbgpd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmbgpd"]
 CMD ["-f", "/etc/pmacct/pmbgpd.conf"]

--- a/docker/pmbgpd/Dockerfile
+++ b/docker/pmbgpd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for pmbgpd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmbgpd"]

--- a/docker/pmbmpd/Dockerfile
+++ b/docker/pmbmpd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for pmbmpd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmbmpd"]

--- a/docker/pmbmpd/Dockerfile
+++ b/docker/pmbmpd/Dockerfile
@@ -3,10 +3,10 @@
 
 #Author: Marc Sune <marcdevel (at) gmail.com>
 
-#This Dockerfile creates an image for pmbmpd 
+#This Dockerfile creates an image for pmbmpd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmbmpd"]
 CMD ["-f", "/etc/pmacct/pmbmpd.conf"]

--- a/docker/pmtelemetryd/Dockerfile
+++ b/docker/pmtelemetryd/Dockerfile
@@ -3,10 +3,10 @@
 
 #Author: Marc Sune <marcdevel (at) gmail.com>
 
-#This Dockerfile creates an image for pmtelemetryd 
+#This Dockerfile creates an image for pmtelemetryd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmtelemetryd"]
 CMD ["-f", "/etc/pmacct/pmtelemetryd.conf"]

--- a/docker/pmtelemetryd/Dockerfile
+++ b/docker/pmtelemetryd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for pmtelemetryd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/pmtelemetryd"]

--- a/docker/sfacctd/Dockerfile
+++ b/docker/sfacctd/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates an image for sfacctd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/sfacctd"]
 CMD ["-f", "/etc/pmacct/sfacctd.conf"]

--- a/docker/sfacctd/Dockerfile
+++ b/docker/sfacctd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for sfacctd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/sfacctd"]

--- a/docker/uacctd/Dockerfile
+++ b/docker/uacctd/Dockerfile
@@ -5,7 +5,9 @@
 
 #This Dockerfile creates an image for uacctd
 
-FROM base:_build
+ARG BUILD_REGISTRY=
+
+FROM ${BUILD_REGISTRY:+${BUILD_REGISTRY}/}base:_build
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/uacctd"]

--- a/docker/uacctd/Dockerfile
+++ b/docker/uacctd/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates an image for uacctd
 
 FROM base:_build
-MAINTAINER pmacct Docker Doctors <docker-doctors (at) pmacct.net>
+LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 
 ENTRYPOINT ["/usr/local/sbin/uacctd"]
 CMD ["-f", "/etc/pmacct/uacctd.conf"]

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -30,6 +30,12 @@ Containers are published with the following tags:
   * `bleeding-edge`: only for the brave. Latest commit on `master`. This container
                      is not recommended to be used in production.
 
+### Architectures
+
+Official docker images are built for `linux/amd64` and `linux/arm64`.
+
+:warning: **`linux/arm64` support is experimental**.
+
 ## How to use them (docker/docker-compose only)
 
 Docker:
@@ -325,11 +331,11 @@ Solution:
 docker run -v /home/marc/tmp/pmacctd.conf:/etc/pmacct/pmacctd.conf pmacct/pmacctd:latest
 ```
 
-2. Question: 
+2. Question:
 
 ```
 If i want to daemonize pmacct running inside a Docker container, should i use either the
-"daemonize: true" config knob or the -d pmacct command-line flag?   
+"daemonize: true" config knob or the -d pmacct command-line flag?
 ```
 
 Answer:
@@ -354,7 +360,8 @@ of the containers.
 This image can be used to to create your customized docker image, with different
 entrypoints or other tools in.
 
-### Building your Docker image from scratch
+### And more...
 
 If you still feel you need to compile your own custom version of pmacct, you
-can take a look at the `Dockerfile` in the folder `docker/base` as a starting point.
+can take a look at the `Dockerfile`s in the folder `docker/` as a starting
+point. Make sure to review the [README.md](../docker/README.md).


### PR DESCRIPTION
This patchset adds support for building and publishing ARM64 images.

ARM64 support is at this point in time largely untested, given that Github [doesn't provide yet hosted ARM runners for OSS](https://github.com/github/roadmap/issues/970), but it _should_ just work. It would be ideal to get some manual validation from someone in the community with an ARM64 machine, I don't have that (@paololucente do you?). Alternatively we could spawn some VMs on a public cloud.

You can see a snapshot of the result of the build&push here:

![image](https://github.com/user-attachments/assets/f72b9493-f729-47ac-8c50-15446fda487e)


### Details

This patchset:

* Fixed some warnings on Dockerfiles and smoke tests compose file.
* Pins the few unpinned dependencies:
```
    ci/deps.sh: pin dependency versions
    
    Pin dependency versions:
    
    * libjansson: v2.14
    * librdkafka: v2.6.1
    * libmaxminddb: 1.11.0
```
* Adds a convenient `Makefile` under `docker` folder to help building images, especially multi-platform images:
```
    docker: use buildx, add ARM64 experimental support
    
    This commit refactors pmacct docker build system to use buildx. This
    enables building AMD64 and ARM64 images simultaneously.
    
    To build docker images a utility Makefile, docker/Makefile, is added.
    There are two main use-cases for this new build infrastructure:
    
    1. Building docker images locally. This is the default. Simply
       hit `make` and images with the `_build` tag are populated in the local
       dockerd image directory.
    2. To build multi-platform images (mainly CI). As explained in the
       docker/Makefile, to build multi-platform images a temporary docker
       registry is required, as daemon container images depend on base.
       Please read the README for more details.
    
    WARNING: the support for ARM64 should be considered experimental at
    this point in time.
```
* Refactors CI based on the prep work. Please note pipeline times are increased ~1h. I will attempt to start `docker-multiplatform-build-test-publish` without `needs` of other jobs to save roughly 20-30min in another PR:

```
    ci: build and publish ARM64 images (experimental)
    
    This commit modifies the CI code (`ci.yaml`) to use the new docker build
    infrastructure (`Makefile`) in `docker/` to build linux/arm64 images in addition
    to linux/amd64.
    
    Several considerations:
    
    * The original step 3 is split in:
      - 3.1: where the basic (local) build for the host arch and the docker-compose
             smoke test is run. This is to mimic what a user would do locally.
      - 3.2: where the multi-platform images are built, smoke tested (host arch only
             and published.
    * Due to the limitations of `docker buildx` (see previous commit and
      `docker/README.md`), a temporary build docker registry is spawned as part of
      step 3.2.
    * docker image publishing is moved to step of 3.2 (`docker-build-test-publish`),
      which allows PRs to execute most of the sections of 3.1/3.2 and skip the
      publishing step only.
    
    ARM64 generation is slow. Building and - especially - pushing multi-platform
    images is much easier than _trying_ to do that across jobs. There isn't much
    to optimize on the ARM side of things (just a byproduct of cross-compiling).
    However, stage 3.2 could start in parallel with stage 1/2, but gate publishing
    to dockerhub until stage 1,2 and 3.1 have successfully completed (e.g. using
    artifacts to pass status). This is out of scope of this commit.
```
 * Modifies docs to warn ARM64 support is experimental

### Next steps

* Improve pipeline times by using a barrier (artifacts?) before before the 3.2 publishing step
* Once ARM runners are available (https://github.com/github/roadmap/issues/970), run `build-and-test` - with all options - on an ARM64 runner.

### Checklist

I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
