### PR TITLE
Fix inconsistency of command line options

### DIFF
--- a/src/pmacct-defines.h
+++ b/src/pmacct-defines.h
@@ -23,11 +23,11 @@
 #define ARGS_NFACCTD "n:dDhP:b:f:F:c:m:p:r:s:S:L:l:o:t:O:MuRVaAE:I:WZ:Y:T:"
 #define ARGS_SFACCTD "n:dDhP:b:f:F:c:m:p:r:s:S:L:l:o:t:O:MuRVaAE:I:WZ:Y:T:"
 #define ARGS_PMACCTD "n:NdDhP:b:f:F:c:i:I:m:p:r:s:S:o:t:O:MuwWZ:Y:L:RVazAE:T:"
-#define ARGS_UACCTD "n:NdDhP:b:f:F:c:m:p:r:s:S:o:t:O:MuRg:L:VaAE:T:"
+#define ARGS_UACCTD "n:dDhP:b:f:F:c:m:p:r:s:S:o:t:O:MuRg:L:VaAE:T:"
 #define ARGS_PMTELEMETRYD "hVL:u:t:f:dDS:F:o:O:i:T:"
 #define ARGS_PMBGPD "hVL:l:f:dDS:F:o:O:i:gm:T:"
 #define ARGS_PMBMPD "hVL:l:f:dDS:F:o:O:i:I:Z:Y:R:T:"
-#define ARGS_PMACCT "hSsc:Cet:p:P:M:arN:n:lT:O:E:uVUiI0"
+#define ARGS_PMACCT "hSsc:Cetp:M:arN:n:lT:O:E:uVUiI0"
 #define N_PRIMITIVES 128
 #define N_FUNCS 10 
 #define MAX_N_PLUGINS 32

--- a/src/pmacct.c
+++ b/src/pmacct.c
@@ -690,7 +690,7 @@ int main(int argc,char **argv)
 #if defined (WITH_NDPI)
   char ndpi_class[SUPERSHORTBUFLEN];
 #endif
-  char path[SRVBUFLEN], file[SRVBUFLEN], password[9], rd_str[SRVBUFLEN], tmpbuf[SRVBUFLEN];
+  char path[SRVBUFLEN], file[SRVBUFLEN], rd_str[SRVBUFLEN], tmpbuf[SRVBUFLEN];
   char *as_path, empty_aspath[] = "^$", empty_string[] = "", *bgp_comm;
   int sd, buflen, unpacked, printed;
   int counter=0, sep_len=0, is_event;
@@ -730,7 +730,6 @@ int main(int argc,char **argv)
   memset(&empty_ptun, 0, sizeof(struct pkt_tunnel_primitives));
   memset(&empty_pvlen, 0, sizeof(struct pkt_vlen_hdr_primitives));
   memset(count, 0, sizeof(count));
-  memset(password, 0, sizeof(password)); 
   memset(sep, 0, sizeof(sep));
   memset(&pmc_custom_primitives_registry, 0, sizeof(pmc_custom_primitives_registry));
   memset(&custom_primitives_input, 0, sizeof(custom_primitives_input));
@@ -1202,9 +1201,6 @@ int main(int argc,char **argv)
       break;
     case 'p':
       strlcpy(path, optarg, sizeof(path));
-      break;
-    case 'P':
-      strlcpy(password, optarg, sizeof(password));
       break;
     case 'a':
       want_all_fields = TRUE;

--- a/src/pmtelemetryd.c
+++ b/src/pmtelemetryd.c
@@ -45,9 +45,6 @@ void usage_daemon(char *prog_name)
   printf("  -L  \tBind to the specified IP address\n");
   printf("  -u  \tListen on the specified UDP port\n");
   printf("  -t  \tListen on the specified TCP port\n");
-#ifdef WITH_ZMQ
-  printf("  -Z  \tConnect to the specified ZeroMQ queue address\n");
-#endif
   printf("  -f  \tLoad configuration from the specified file\n");
   printf("  -D  \tDaemonize\n");
   printf("  -d  \tEnable debug\n");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

While playing around with the code, I noticed an inconsistency in the cli options. So I threw some quick-and-hacky scripting at the sourcecode to compare the `ARGS_*` defines in `pmacct-defines.h` against the `usage_*` functions and `optstr()`-switch-cases in the executables main C files, and from there proceeded to cause-research and fixing:

* `uacctd`'s `-N` was removed in 445f96cd but still present in the optstring.
* `pmacct`'s `-t` was defined in the optstring with an required argument, but it takes none. The argument was wrongly "inherited" in 45c860a776 by the removal of `-m`.
* `pmacct`'s `-P` was missing in the usage output since the beginning in 1f7b559c. Because it's unused since f78fe098, remove the option completely.
* `pmtelemetryd`'s `-Z` was removed in e3cce045 but still present in the usage output.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
