### PR TITLE
tee plugin: reporting tee_send execution count per receiver

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -449,6 +449,8 @@ static const struct _dictionary_line dictionary[] = {
   {"tee_ipprec", cfg_key_nfprobe_ip_precedence},
   {"tee_pipe_size", cfg_key_tee_pipe_size},
   {"tee_kafka_config_file", cfg_key_tee_kafka_config_file},
+  {"tee_counters_refresh_time", cfg_key_tee_counters_refresh_time},
+  {"tee_counters_path", cfg_key_tee_counters_path},
   {"bgp_daemon", cfg_key_bgp_daemon},
   {"bgp_daemon_ip", cfg_key_bgp_daemon_ip},
   {"bgp_daemon_interface", cfg_key_bgp_daemon_interface},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -628,6 +628,8 @@ struct configuration {
   char *tee_receivers;
   int tee_pipe_size;
   char *tee_kafka_config_file;
+  int tee_counters_refresh_time;
+  char *tee_counters_path;
   int uacctd_group;
   int uacctd_nl_size;
   int uacctd_threshold;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -6730,6 +6730,65 @@ int cfg_key_tee_kafka_config_file(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_tee_counters_refresh_time(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0, i, len = strlen(value_ptr);
+
+  for (i = 0; i < len; i++) {
+    if (!isdigit(value_ptr[i]) && !isspace(value_ptr[i])) {
+      Log(LOG_ERR, "WARN: [%s] 'tee_counters_refresh_time' is expected in secs but contains non-digit chars: '%c'\n", filename, value_ptr[i]);
+      return ERR;
+    }
+  }
+
+  value = atoi(value_ptr);
+  if (value <= 0) {
+    Log(LOG_ERR, "WARN: [%s] 'tee_counters_refresh_time' has to be > 0.\n", filename);
+    return ERR;
+  }
+
+  if (!name) {
+    for (; list; list = list->next, changes++) {
+      list->cfg.tee_counters_refresh_time = value;
+    }
+  }
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.tee_counters_refresh_time = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
+int cfg_key_tee_counters_path(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int changes = 0;
+
+  if (!name) {
+    for (; list; list = list->next, changes++) {
+      list->cfg.tee_counters_path = value_ptr;
+    }
+  }
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.tee_counters_path = value_ptr;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 void parse_time(char *filename, char *value, int *mu, int *howmany)
 {
   int k, j, len;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -338,6 +338,8 @@ extern int cfg_key_tee_max_receivers(char *, char *, char *);
 extern int cfg_key_tee_max_receiver_pools(char *, char *, char *);
 extern int cfg_key_tee_pipe_size(char *, char *, char *);
 extern int cfg_key_tee_kafka_config_file(char *, char *, char *);
+extern int cfg_key_tee_counters_refresh_time(char *, char *, char *);
+extern int cfg_key_tee_counters_path(char *, char *, char *);
 extern int cfg_key_bgp_daemon(char *, char *, char *);
 extern int cfg_key_bgp_daemon_msglog_output(char *, char *, char *);
 extern int cfg_key_bgp_daemon_msglog_file(char *, char *, char *);

--- a/src/tee_plugin/tee_plugin.c
+++ b/src/tee_plugin/tee_plugin.c
@@ -51,6 +51,10 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
   int pollagain = TRUE;
   u_int32_t seq = 1, rg_err_count = 0;
 
+  struct insert_data idata;
+  time_t counters_refresh_deadline;
+  int counters_refresh_timeout;
+
 #ifdef WITH_ZMQ
   struct p_zmq_host *zmq_host = &((struct channels_list_entry *)ptr)->zmq_host;
 #else
@@ -157,20 +161,37 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
     exit(0);
   }
 
+  if (config.tee_counters_refresh_time == 0) {
+    config.tee_counters_refresh_time = DEFAULT_TEE_COUNTERS_REFRESH_TIME;
+  }
+
+  memset(&idata, 0, sizeof(idata));
+  idata.now = time(NULL);
+
+  counters_refresh_deadline = idata.now;
+  P_init_refresh_deadline(&counters_refresh_deadline, config.tee_counters_refresh_time, 0, NULL);
+
   /* plugin main loop */
   for (;;) {
     poll_again:
     status->wakeup = TRUE;
     poll_bypass = FALSE;
+    calc_refresh_timeout(counters_refresh_deadline, idata.now, &counters_refresh_timeout);
 
     pfd.fd = pipe_fd;
     pfd.events = POLLIN;
 
-    ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), refresh_timeout);
+    ret = poll(&pfd, (pfd.fd == ERR ? 0 : 1), MIN(refresh_timeout, counters_refresh_timeout));
 
     if (ret < 0) goto poll_again;
 
     poll_ops:
+    P_update_time_reference(&idata);
+    if (idata.now > counters_refresh_deadline) {
+      Tee_report_counters();
+      counters_refresh_deadline += config.tee_counters_refresh_time;
+    }
+
     if (reload_map) {
       if (config.tee_receivers) {
         int recvs_allocated = FALSE;
@@ -272,6 +293,7 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 	      for (recv_idx = 0; recv_idx < receivers.pools[pool_idx].num; recv_idx++) {
 	        target = &receivers.pools[pool_idx].receivers[recv_idx];
 	        Tee_send(msg, (struct sockaddr *) &target->dest, target->fd, config.tee_transparent);
+	        target->tee_sent++;
 	      }
 
 #ifdef WITH_KAFKA
@@ -291,6 +313,7 @@ void tee_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 	    else {
 	      target = receivers.pools[pool_idx].balance.func(&receivers.pools[pool_idx], msg);
 	      Tee_send(msg, (struct sockaddr *) &target->dest, target->fd, config.tee_transparent);
+	      target->tee_sent++;
 	    }
 	  }
 	}
@@ -974,5 +997,42 @@ void Tee_select_templates(unsigned char *pkt, int pkt_len, int nfv, unsigned cha
     }
 
     (*tpl_pkt_len) = tmp_len;
+  }
+}
+
+void Tee_report_counters()
+{
+  if (!config.tee_counters_path) return;
+
+  char tmp_path[SRVBUFLEN];
+  snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", config.tee_counters_path);
+
+  FILE *file = fopen(tmp_path, "w");
+  if (file == NULL) {
+    Log(LOG_ERR, "ERROR ( %s/%s ): Failed to open file: %s\n", config.name, config.type, tmp_path);
+    return;
+  }
+
+  fprintf(file, "POOL_ID,RECEIVER_IP,RECEIVER_PORT,TEE_SENT,REFRESH_TIME\n");
+  for (int pool_idx = 0; pool_idx < receivers.num; pool_idx++) {
+    for (int recv_idx = 0; recv_idx < receivers.pools[pool_idx].num; recv_idx++) {
+      struct tee_receiver *receiver = &receivers.pools[pool_idx].receivers[recv_idx];
+
+      char dest_str[INET6_ADDRSTRLEN];
+      int dest_port;
+
+      sa_to_str(dest_str, sizeof(dest_str), (struct sockaddr *) &receiver->dest, FALSE);
+      sa_to_port(&dest_port, (struct sockaddr *) &receiver->dest);
+
+      fprintf(file, "%d,%s,%d,%" PRIu64 ",%d\n", pool_idx, dest_str, dest_port, receiver->tee_sent, config.tee_counters_refresh_time);
+      receiver->tee_sent = 0;
+    }
+  }
+
+  fclose(file);
+
+  if (rename(tmp_path, config.tee_counters_path) != 0) {
+    Log(LOG_ERR, "ERROR ( %s/%s ): Failed to rename file to: %s\n", config.name, config.type, config.tee_counters_path);
+    unlink(tmp_path);
   }
 }

--- a/src/tee_plugin/tee_plugin.h
+++ b/src/tee_plugin/tee_plugin.h
@@ -37,6 +37,8 @@
 #define TEE_BALANCE_HASH_AGENT	2
 #define TEE_BALANCE_HASH_TAG	3
 
+#define DEFAULT_TEE_COUNTERS_REFRESH_TIME 60
+
 typedef struct tee_receiver *(*tee_balance_algorithm) (void *, struct pkt_msg *);
 
 /* structures */
@@ -44,6 +46,7 @@ struct tee_receiver {
   struct sockaddr_storage dest;
   socklen_t dest_len;
   int fd;
+  u_int64_t tee_sent;
 };
 
 struct tee_balance {
@@ -91,6 +94,7 @@ extern struct tee_receiver *Tee_hash_agent_balance(void *, struct pkt_msg *);
 extern struct tee_receiver *Tee_hash_agent_crc32(void *, struct pkt_msg *);
 extern struct tee_receiver *Tee_hash_tag_balance(void *, struct pkt_msg *);
 extern void Tee_select_templates(unsigned char *, int, int, unsigned char *, int *);
+extern void Tee_report_counters();
 
 #ifdef WITH_KAFKA
 extern void Tee_kafka_send(struct pkt_msg *, struct tee_receivers_pool *);


### PR DESCRIPTION
This Pull Request introduces monitoring of how many times a message has been sent to a specific receiver by tee plugin. The counters are periodically exported to .csv file. Example structure of the file:
```
POOL_ID,RECEIVER_IP,RECEIVER_PORT,TEE_SENT,REFRESH_TIME
0,127.0.0.1,1234,10000,60
1,127.0.0.2,1234,10000,60
```
Two new config properties were added:
`tee_counters_refresh_time` - time interval in seconds at which the counters are reported to file and reset (optional, default 60s)
`tee_counters_path` - file where counters are reported to (if not provided, counters are not reported)