### PR TITLE
Improve handling of unknown map keys

### DIFF
--- a/docs/SIGNALS
+++ b/docs/SIGNALS
@@ -47,7 +47,7 @@ SIGUSR2:	if 'maps_refresh' config directive is enabled, it causes maps
 		be derived by the logs, ie.:
 
 		INFO ( default/core ): [/path/to/primitives.lst] (re)loading map.
-		INFO ( default/core ): [/path/to/primitives.lst] map successfully (re)loaded.
+		INFO ( default/core ): [/path/to/primitives.lst] map successfully (re)loaded with 3 entries.
 
 		primitives.lst is loaded by the core process and a signal to
 		reload such map should be sent to the Core Process. There is

--- a/src/pretag.c
+++ b/src/pretag.c
@@ -230,7 +230,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n",
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -246,7 +246,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -262,7 +262,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -278,7 +278,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -294,7 +294,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -310,7 +310,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -326,7 +326,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n",
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
                                                 config.name, config.type, filename, tot_lines, key);
                     else {
 		      Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
@@ -344,7 +344,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n",
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
                                                 config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
 		    ignoring = TRUE;
@@ -361,7 +361,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
                   }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n",
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
                                                 config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -377,7 +377,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
 		  }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -393,7 +393,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
                     else err = E_NOTFOUND; /* key not found */
 		  }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break;
@@ -421,7 +421,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
 		    }
 		  }
                   if (err) {
-                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] unknown key '%s'. Ignored.\n", 
+                    if (err == E_NOTFOUND) Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored because of unknown key '%s'.\n",
 						config.name, config.type, filename, tot_lines, key);
                     else Log(LOG_WARNING, "WARN ( %s/%s ): [%s:%u] Line ignored.\n", config.name, config.type, filename, tot_lines);
                     break; 

--- a/src/pretag.c
+++ b/src/pretag.c
@@ -65,6 +65,7 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
   struct stat st;
   int v6_num = 0;
   u_int64_t sz;
+  unsigned int new_map_size;
 
   if (!filename || !map_allocated) return;
 
@@ -817,10 +818,17 @@ void load_id_file(int acct_type, char *filename, struct id_table *t, struct plug
     }
   }
 
+  new_map_size = tmp.num;
+  if (t)
+    new_map_size = t->num;
+  if (acct_type == MAP_CUSTOM_PRIMITIVES)
+    new_map_size = ((struct custom_primitives *) req->key_value_table)->num;
+
   if (tmp.e) free(tmp.e) ;
   if (buf) free(buf) ;
 
-  Log(LOG_INFO, "INFO ( %s/%s ): [%s] map successfully (re)loaded.\n", config.name, config.type, filename);
+  Log(LOG_INFO, "INFO ( %s/%s ): [%s] map successfully (re)loaded with %d entries.\n",
+    config.name, config.type, filename, new_map_size);
 
   return;
 

--- a/src/pretag_handlers.c
+++ b/src/pretag_handlers.c
@@ -268,7 +268,7 @@ int PT_map_ip_handler(char *filename, struct id_entry *e, char *value, struct pl
   }
 
   e->func[x] = pretag_dummy_ip_handler;
-  if (e->func[x]) e->func_type[x] = PRETAG_IP;
+  e->func_type[x] = PRETAG_IP;
 
   return FALSE;
 }
@@ -304,6 +304,7 @@ int PT_map_input_handler(char *filename, struct id_entry *e, char *value, struct
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_input_handler;
   else if (config.acct_type == ACCT_PM) e->func[x] = PM_pretag_input_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_IN_IFACE;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -339,6 +340,7 @@ int PT_map_output_handler(char *filename, struct id_entry *e, char *value, struc
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_output_handler;
   else if (config.acct_type == ACCT_PM) e->func[x] = PM_pretag_output_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_OUT_IFACE;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -363,6 +365,7 @@ int PT_map_nexthop_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_nexthop_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_nexthop_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_NEXTHOP;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -430,6 +433,7 @@ int BPAS_map_bgp_nexthop_handler(char *filename, struct id_entry *e, char *value
     e->func[x] = BPAS_bgp_nexthop_handler;
     e->func_type[x] = PRETAG_BGP_NEXTHOP;
   }
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -450,6 +454,7 @@ int BPAS_map_bgp_peer_dst_as_handler(char *filename, struct id_entry *e, char *v
     e->func[x] = BPAS_bgp_peer_dst_as_handler;
     e->func_type[x] = PRETAG_BGP_NEXTHOP;
   }
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -470,6 +475,7 @@ int BITR_map_mpls_label_bottom_handler(char *filename, struct id_entry *e, char 
   /* Currently supported only in nfacctd */
   if (config.acct_type == ACCT_NF) e->func[x] = BITR_mpls_label_bottom_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_MPLS_LABEL_BOTTOM;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -496,6 +502,7 @@ int BITR_map_mpls_vpn_id_handler(char *filename, struct id_entry *e, char *value
 
   if (config.acct_type == ACCT_NF) e->func[x] = BITR_mpls_vpn_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_MPLS_VPN_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -530,6 +537,7 @@ int PT_map_engine_type_handler(char *filename, struct id_entry *e, char *value, 
   }
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_engine_type_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_ENGINE_TYPE;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -562,6 +570,7 @@ int PT_map_engine_id_handler(char *filename, struct id_entry *e, char *value, st
   if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_engine_id_handler;
   else if (config.acct_type == ACCT_NF) e->func[x] = pretag_engine_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_ENGINE_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -604,7 +613,7 @@ int PT_map_filter_handler(char *filename, struct id_entry *e, char *value, struc
   }
 
   e->func[x] = pretag_filter_handler;
-  if (e->func[x]) e->func_type[x] = PRETAG_FILTER;
+  e->func_type[x] = PRETAG_FILTER;
   req->bpf_filter = TRUE;
   return FALSE;
 }
@@ -623,6 +632,7 @@ int PT_map_agent_id_handler(char *filename, struct id_entry *e, char *value, str
   }
   if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_agent_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_SF_AGENTID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -641,6 +651,7 @@ int PT_map_flowset_id_handler(char *filename, struct id_entry *e, char *value, s
   }
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_flowset_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_FLOWSET_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -723,6 +734,7 @@ int PT_map_sample_type_handler(char *filename, struct id_entry *e, char *value, 
   if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_sample_type_handler;
   else if (config.acct_type == ACCT_NF) e->func[x] = pretag_sample_type_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_SAMPLE_TYPE;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -748,6 +760,7 @@ int PT_map_is_bi_flow_handler(char *filename, struct id_entry *e, char *value, s
   }
 
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_is_bi_flow_handler;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -773,6 +786,7 @@ int PT_map_is_nsel_handler(char *filename, struct id_entry *e, char *value, stru
   }
 
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_is_nsel_handler;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -798,6 +812,7 @@ int PT_map_is_nel_handler(char *filename, struct id_entry *e, char *value, struc
   }
 
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_is_nel_handler;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -821,6 +836,7 @@ int PT_map_direction_handler(char *filename, struct id_entry *e, char *value, st
   else if (config.acct_type == ACCT_NF) e->func[x] = pretag_direction_handler;
   else if (config.acct_type == ACCT_PM) e->func[x] = PM_pretag_direction_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_DIRECTION;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1204,6 +1220,7 @@ int PT_map_mpls_vpn_id_in_handler(char *filename, struct id_entry *e, char *valu
 
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_mpls_vpn_id_in_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_MPLS_VPN_ID_IN;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1230,6 +1247,7 @@ int PT_map_mpls_vpn_id_out_handler(char *filename, struct id_entry *e, char *val
   
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_mpls_vpn_id_out_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_MPLS_VPN_ID_OUT;
+  else return E_NOTFOUND;
   
   return FALSE;
 }
@@ -1276,6 +1294,7 @@ int PT_map_mpls_pw_id_handler(char *filename, struct id_entry *e, char *value, s
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_mpls_pw_id_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_mpls_pw_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_MPLS_PW_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1303,6 +1322,7 @@ int PT_map_src_mac_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_src_mac_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_src_mac_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_SRC_MAC;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1330,6 +1350,7 @@ int PT_map_dst_mac_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_dst_mac_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_dst_mac_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_DST_MAC;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1359,6 +1380,7 @@ int PT_map_vlan_id_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_vlan_id_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_vlan_id_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_VLAN_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1387,6 +1409,7 @@ int PT_map_cvlan_id_handler(char *filename, struct id_entry *e, char *value, str
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_cvlan_id_handler;
 
   if (e->func[x]) e->func_type[x] = PRETAG_CVLAN_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1414,6 +1437,7 @@ int PT_map_src_net_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_src_net_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_src_net_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_SRC_NET;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1441,6 +1465,7 @@ int PT_map_dst_net_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_dst_net_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_dst_net_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_DST_NET;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1465,6 +1490,7 @@ int PT_map_ip_proto_handler(char *filename, struct id_entry *e, char *value, str
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_ip_proto_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_ip_proto_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_IP_PROTO;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1489,6 +1515,7 @@ int PT_map_src_port_handler(char *filename, struct id_entry *e, char *value, str
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_src_port_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_src_port_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_SRC_PORT;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1513,6 +1540,7 @@ int PT_map_dst_port_handler(char *filename, struct id_entry *e, char *value, str
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_dst_port_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_dst_port_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_DST_PORT;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1537,6 +1565,7 @@ int PT_map_tcp_flags_handler(char *filename, struct id_entry *e, char *value, st
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_tcp_flags_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_tcp_flags_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_TCP_FLAGS;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1564,6 +1593,7 @@ int PT_map_is_multicast_handler(char *filename, struct id_entry *e, char *value,
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_is_multicast_handler;
   else if (config.acct_type == ACCT_SF) e->func[x] = SF_pretag_is_multicast_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_IS_MULTICAST;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1596,6 +1626,7 @@ int PT_map_set_tos_handler(char *filename, struct id_entry *e, char *value, stru
   if (config.acct_type == ACCT_NF) e->set_func[x] = pretag_set_tos_handler;
 
   if (e->set_func[x]) e->set_func_type[x] = PRETAG_SET_TOS;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1628,6 +1659,7 @@ int BTA_map_lookup_bgp_port_handler(char *filename, struct id_entry *e, char *va
   if (acct_type == MAP_BGP_TO_XFLOW_AGENT) e->set_func[x] = BTA_lookup_bgp_port_handler;
 
   if (e->set_func[x]) e->set_func_type[x] = PRETAG_LOOKUP_BGP_PORT;
+  else return E_NOTFOUND;
 
   return FALSE;
 }
@@ -1726,6 +1758,7 @@ int PT_map_fwd_status_handler(char *filename, struct id_entry *e, char *value, s
 
   if (config.acct_type == ACCT_NF) e->func[x] = pretag_fwd_status_handler;
   if (e->func[x]) e->func_type[x] = PRETAG_FWDSTATUS_ID;
+  else return E_NOTFOUND;
 
   return FALSE;
 }

--- a/tests/102-NFv9-CISCO-f2rd-pretag-sampling-reload/output-log-00.txt
+++ b/tests/102-NFv9-CISCO-f2rd-pretag-sampling-reload/output-log-00.txt
@@ -1,12 +1,12 @@
 ${TIMESTAMP} INFO ( nfacctd_core/core ): Reading configuration file '/etc/pmacct/nfacctd.conf'.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/sampling.map] (re)loading map.
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/sampling.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/sampling.map] map successfully (re)loaded with 1 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] (re)loading map.
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] map successfully (re)loaded with 16 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/custom-primitives.map] (re)loading map.
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/custom-primitives.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/custom-primitives.map] map successfully (re)loaded with 5 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] (re)loading map.
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] map successfully (re)loaded with 3 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] (re)loading map.
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] map successfully (re)loaded with 3 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): waiting for NetFlow/IPFIX data on interface=all ip=0.0.0.0 port=9991/udp

--- a/tests/102-NFv9-CISCO-f2rd-pretag-sampling-reload/output-log-01.txt
+++ b/tests/102-NFv9-CISCO-f2rd-pretag-sampling-reload/output-log-01.txt
@@ -2,11 +2,11 @@ ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] (re)loading map.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] maps_index: destroying index ${IGNORE_REST}
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] maps_index: creating index ${IGNORE_REST}
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] pretag_index_report(): ${IGNORE_REST}
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/f2rd.map] map successfully (re)loaded with 7 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/sampling.map] (re)loading map.
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/sampling.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/sampling.map] map successfully (re)loaded with 1 entries.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] (re)loading map.
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] maps_index: destroying index ${IGNORE_REST}
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] maps_index: creating index ${IGNORE_REST}
 ${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] pretag_index_report(): ${IGNORE_REST}
-${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] map successfully (re)loaded.
+${TIMESTAMP} INFO ( nfacctd_core/core ): [/etc/pmacct/pretag.map] map successfully (re)loaded with 3 entries.


### PR DESCRIPTION
# Short description
Improve the way unknown map keys are reported/logged during map loading, making it easier and more obvious if/when things are wrong. This is done by improving the log messages and the info they provide, as well as reporting it as an error if the key is known but not supported by the current daemon.

# Long description

To demonstrate the issue I am trying to solve, assume the following two config files, `uacctd.conf` and `pre-tag.map`. These make uacctd do a simple aggregation by source, add a label, and print the result to stdout.
```
uacctd_group: 30

pre_tag_map: pre-tag.map

aggregate: src_host, label

plugins: print

print_output: csv 
print_output_file: /dev/stdout
print_refresh_time: 3
```
```
set_label=rule src_net=255.255.255.255/32
set_label=catchall
```

Running `uacctd -f uacctd.conf` will produce the following console output:

```
INFO ( default/core ): Linux NetFilter NFLOG Accounting Daemon, uacctd (20250121-2 (912fb121))
INFO ( default/core ):  '--enable-nflog' '--disable-shared' '--enable-debug' '--enable-l2' '--enable-traffic-bins' '--enable-bgp-bins' '--enable-bmp-bins' '--enable-st-bins'
INFO ( default/core ): Reading configuration file '/tmp/pmacct/uacctd.conf'.
INFO ( default_print/print ): plugin_pipe_size=4096000 bytes plugin_buffer_size=1284 bytes
INFO ( default_print/print ): ctrl channel: obtained=212992 bytes target=25520 bytes
INFO ( default/core ): [pre-tag.map] (re)loading map.
INFO ( default_print/print ): cache entries=16411 base cache memory=56322552 bytes
INFO ( default/core ): [pre-tag.map] map successfully (re)loaded.
INFO ( default/core ): [pre-tag.map] (re)loading map.
INFO ( default/core ): [pre-tag.map] map successfully (re)loaded.
INFO ( default/core ): Successfully connected Netlink NFLOG socket
INFO ( default_print/print ): *** Purging cache - START (PID: 69470) ***
LABEL,SRC_IP,PACKETS,BYTES
rule,127.0.0.1,2,168
INFO ( default_print/print ): *** Purging cache - END (PID: 69470, QN: 1/1, ET: 0) ***
INFO ( default/core ): SIGINT received. Exiting ...
```

Please note that [`src_net` is not supported in uacctd pre-tag-maps](https://github.com/pmacct/pmacct/blob/912fb121c5099d83b637e3f29bfc316f065b2a97/examples/pretag.map.example#L25), but there are no warnings or errors regarding the pre-tag-map containing unknown or unsupported keys.
Also note that the flow is labeled with `rule` and not `catchall` despite it not matching the given `src_net` key. This is because for acct-type `ACCT_PM` (which is used by uacctd), the [`PT_map_src_net_handler()`](https://github.com/pmacct/pmacct/blob/912fb121c5099d83b637e3f29bfc316f065b2a97/src/pretag_handlers.c#L1394) adds no function to the map entry but also returns `FALSE` (aka "no error"), effectively skipping the `src_net` match and the loaded rule/entry only consists of the `set_label=rule` key, which then (of course) is matched by every flow.
I am unsure why [`load_plugins()`](https://github.com/pmacct/pmacct/blob/912fb121c5099d83b637e3f29bfc316f065b2a97/src/plugin_hooks.c#L332) loads the pre-tag-map twice while there is only one plugin, but that's research for another day.

After applying the changes from this PR, the following console output will be produced:

```
INFO ( default/core ): Linux NetFilter NFLOG Accounting Daemon, uacctd (20250209-2 (efd7860))
INFO ( default/core ):  '--enable-nflog' '--disable-shared' '--enable-debug' '--enable-l2' '--enable-traffic-bins' '--enable-bgp-bins' '--enable-bmp-bins' '--enable-st-bins'
INFO ( default/core ): Reading configuration file '/tmp/pmacct/uacctd.conf'.
INFO ( default_print/print ): plugin_pipe_size=4096000 bytes plugin_buffer_size=1284 bytes
INFO ( default_print/print ): ctrl channel: obtained=212992 bytes target=25520 bytes
INFO ( default/core ): [pre-tag.map] (re)loading map.
INFO ( default_print/print ): cache entries=16411 base cache memory=56322552 bytes
WARN ( default/core ): [pre-tag.map:1] Line ignored because of unknown key 'src_net'.
INFO ( default/core ): [pre-tag.map] map successfully (re)loaded with 1 entries.
INFO ( default/core ): [pre-tag.map] (re)loading map.
WARN ( default/core ): [pre-tag.map:1] Line ignored because of unknown key 'src_net'.
INFO ( default/core ): [pre-tag.map] map successfully (re)loaded with 1 entries.
INFO ( default/core ): Successfully connected Netlink NFLOG socket
INFO ( default_print/print ): *** Purging cache - START (PID: 70902) ***
LABEL,SRC_IP,PACKETS,BYTES
catchall,127.0.0.1,2,168
INFO ( default_print/print ): *** Purging cache - END (PID: 70902, QN: 1/1, ET: 0) ***
INFO ( default/core ): SIGINT received. Exiting ...
``` 

There are now warnings that the `src_net` key in line 1 of the pre-tag-map is unknown (aka unsupported), and that the respective line/rule is ignored. You can now also see that the loaded map contains only one entry/rule, and that the flow is correctly labeled `catchall`.

# Commits

## Return NotFound for unimplemented pre-tag-map keys
When there is no implementation for the current key, instead of making it a no-op and return ok, return an NotFound error which a) gets logged and b) makes the whole line/rule getting ignored.

## Make unknown key log message more specific
The original log messages makes it sound like only the unknown key is ignored, but actually the whole line/rule is.

## Log map size after (re-)load
After successfully (re-)loading a map, also log the number of entries it then has. This makes it possible to sanity-check if the map was loaded as expected.

# Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
