### PR TITLE
Fix buffer corruption in vrf_name aggregate

### DIFF
--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -2043,11 +2043,15 @@ void NF_ingress_vrf_name_handler(struct channels_list_entry *chptr, struct packe
 {
   struct pkt_vlen_hdr_primitives *pvlen = (struct pkt_vlen_hdr_primitives *) ((*data) + chptr->extras.off_pkt_vlen_hdr_primitives);
 
-  if (check_pipe_buffer_space(chptr, pvlen, MAX_VRF_NAME)) {
+  if (strlen(pptrs->ingress_vrf_name) == 0) {
+    return;
+  }
+
+  if (check_pipe_buffer_space(chptr, pvlen, PmLabelTSz+strlen(pptrs->ingress_vrf_name)+1)) {
     vlen_prims_init(pvlen, 0);
     return;
   }
-  else vlen_prims_insert(pvlen, COUNT_INT_INGRESS_VRF_NAME, MAX_VRF_NAME, (u_char *) pptrs->ingress_vrf_name, PM_MSG_STR_COPY);
+  else vlen_prims_insert(pvlen, COUNT_INT_INGRESS_VRF_NAME, strlen(pptrs->ingress_vrf_name)+1, (u_char *) pptrs->ingress_vrf_name, PM_MSG_STR_COPY);
 
 }
 
@@ -2055,22 +2059,31 @@ void NF_egress_vrf_name_handler(struct channels_list_entry *chptr, struct packet
 {
   struct pkt_vlen_hdr_primitives *pvlen = (struct pkt_vlen_hdr_primitives *) ((*data) + chptr->extras.off_pkt_vlen_hdr_primitives);
 
-  if (check_pipe_buffer_space(chptr, pvlen, MAX_VRF_NAME)) {
+  if (strlen(pptrs->egress_vrf_name) == 0) {
+    return;
+  }
+	
+  if (check_pipe_buffer_space(chptr, pvlen, PmLabelTSz+strlen(pptrs->egress_vrf_name)+1)) {
     vlen_prims_init(pvlen, 0);
     return;
   }
-  else vlen_prims_insert(pvlen, COUNT_INT_EGRESS_VRF_NAME, MAX_VRF_NAME, (u_char *) pptrs->egress_vrf_name, PM_MSG_STR_COPY);
+  else vlen_prims_insert(pvlen, COUNT_INT_EGRESS_VRF_NAME, strlen(pptrs->egress_vrf_name)+1, (u_char *) pptrs->egress_vrf_name, PM_MSG_STR_COPY);
 }
 
 void NF_vrf_name_handler(struct channels_list_entry *chptr, struct packet_ptrs *pptrs, char **data)
 {
   struct pkt_vlen_hdr_primitives *pvlen = (struct pkt_vlen_hdr_primitives *) ((*data) + chptr->extras.off_pkt_vlen_hdr_primitives);
 
-  if (check_pipe_buffer_space(chptr, pvlen, MAX_VRF_NAME)) {
+  if (strlen(pptrs->vrf_name) == 0) {
+    return;
+  }
+	
+  if (check_pipe_buffer_space(chptr, pvlen, PmLabelTSz+strlen(pptrs->vrf_name)+1)) {
     vlen_prims_init(pvlen, 0);
     return;
   }
-  else vlen_prims_insert(pvlen, COUNT_INT_VRF_NAME, MAX_VRF_NAME, (u_char *) pptrs->vrf_name, PM_MSG_STR_COPY);
+  else vlen_prims_insert(pvlen, COUNT_INT_VRF_NAME, strlen(pptrs->vrf_name)+1, (u_char *) pptrs->vrf_name, PM_MSG_STR_COPY);
+  
 }
 
 


### PR DESCRIPTION



### Short description
Add PmLabelTSz to check_pipe_buffer_space(), otherwise the buffer corruptions are seen
Also included in the changes are:

1.  Don't add to the buffer if vrf_name is empty
2.  Only allocate enough buffer to hold actual length of the vrf_name instead of max size


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
