### PR TITLE
docker|ci: run docker-build-test-local on ARM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,11 @@ jobs:
 
   ### Step 3.1: test that local single-platform builds work fine
   docker-build-test-local:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ ubuntu-24.04, ubuntu-24.04-arm ]
     steps:
       - name: Checkout pmacct
         uses: actions/checkout@v1 #Don't use v2 messes everything

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -e -c
 
-PLATFORMS ?= linux/amd64
+PLATFORMS ?=
 DAEMONS ?= pmacctd nfacctd sfacctd uacctd pmbgpd pmbmpd pmtelemetryd
 DEPS_DONT_CHECK_CERTIFICATE ?=
 N_WORKERS ?= 2
@@ -14,6 +14,14 @@ PUSH ?=
 
 ifneq ($(strip $(PUSH)),)
   PUSH_ARG = --push
+endif
+
+ARCH := $(shell uname -m)
+ifneq ($(strip $(PLATFORMS)),)
+  ifneq ($(ARCH), x86_64)
+    $(error PLATFORMS can only be defined if ARCH == 'x86_64'. Got $(ARCH))
+  endif
+  PLATFORMS_ARG = --platform $(PLATFORMS)
 endif
 
 ifneq ($(strip $(BUILD_REGISTRY)),)
@@ -45,11 +53,14 @@ __dump_env:
 	$(QUIET) echo "  TAGS: $(TAGS)"
 	$(QUIET) echo "  V: $(V)"
 	$(QUIET) echo "  ---"
+	$(QUIET) echo "  ARCH: $(ARCH)"
 	$(QUIET) echo "  BUILD_REGISTRY_REPO: $(BUILD_REGISTRY_REPO)"
+	$(QUIET) echo "  PLATFORMS_ARG: $(PLATFORMS_ARG)"
 	$(QUIET) echo "  PUSH_ARG: $(PUSH_ARG)"
 	$(QUIET) echo "  LOAD: $(LOAD)"
 	$(QUIET) echo "  QUIET: $(QUIET)"
 
+ifeq ($(ARCH),x86_64)
 __builder_setup:
 	$(QUIET) echo "Installing QEMU-based multi-arch builder..."
 	$(QUIET) if [[ "$(BUILD_REGISTRY)" != "" ]]; then \
@@ -64,24 +75,32 @@ __builder_setup:
 			echo "Using default buildx builder..."; \
 		fi; \
 		docker run --privileged multiarch/qemu-user-static --reset -p yes
+else
+__builder_setup:
+endif
+
 build_base:
 	$(QUIET) echo "Building base container..."
 	$(QUIET) TAGS_BASE=""; for TAG in $(TAGS); do TAGS_BASE="$$TAGS_BASE -t $(PUSH)/base:$${TAG} "; done; \
-	docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) -t $(BUILD_REGISTRY_REPO)base:_build $(LOAD) $(BUILD_REGISTRY_PUSH) --build-arg NUM_WORKERS=$(N_WORKERS) --build-arg DEPS_DONT_CHECK_CERTIFICATE=$(DEPS_DONT_CHECK_CERTIFICATE) -f base/Dockerfile .. ; \
+	docker buildx build $(PROGRESS) --memory $(MEMORY) $(PLATFORMS_ARG) -t $(BUILD_REGISTRY_REPO)base:_build $(LOAD) $(BUILD_REGISTRY_PUSH) --build-arg NUM_WORKERS=$(N_WORKERS) --build-arg DEPS_DONT_CHECK_CERTIFICATE=$(DEPS_DONT_CHECK_CERTIFICATE) -f base/Dockerfile .. ; \
 	if [ -n "$(PUSH)"  ]; then \
-		docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) $${TAGS_BASE} $(PUSH_ARG) --build-arg NUM_WORKERS=$(N_WORKERS) --build-arg DEPS_DONT_CHECK_CERTIFICATE=$(DEPS_DONT_CHECK_CERTIFICATE) -f base/Dockerfile .. ; \
+		docker buildx build $(PROGRESS) --memory $(MEMORY) $(PLATFORMS_ARG) $${TAGS_BASE} $(PUSH_ARG) --build-arg NUM_WORKERS=$(N_WORKERS) --build-arg DEPS_DONT_CHECK_CERTIFICATE=$(DEPS_DONT_CHECK_CERTIFICATE) -f base/Dockerfile .. ; \
 	fi
 
 build_daemons:
 	$(QUIET) for DAEMON in $(DAEMONS); do \
 		TAGS_DAEMON=""; for TAG in $(TAGS); do TAGS_DAEMON="$$TAGS_DAEMON -t $(PUSH)/$${DAEMON}:$${TAG} "; done; \
 		echo "Building '$${DAEMON}'"; \
-		docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) -t $(BUILD_REGISTRY_REPO)$${DAEMON}:_build $(LOAD) $(BUILD_REGISTRY_PUSH) --build-arg BUILD_REGISTRY=$(BUILD_REGISTRY) -f $${DAEMON}/Dockerfile .. ; \
+		docker buildx build $(PROGRESS) --memory $(MEMORY) $(PLATFORMS_ARG) -t $(BUILD_REGISTRY_REPO)$${DAEMON}:_build $(LOAD) $(BUILD_REGISTRY_PUSH) --build-arg BUILD_REGISTRY=$(BUILD_REGISTRY) -f $${DAEMON}/Dockerfile .. ; \
 		if [ -n "$(PUSH)"  ]; then \
-			docker buildx build $(PROGRESS) --memory $(MEMORY) --platform $(PLATFORMS) $${TAGS_DAEMON} $(PUSH_ARG) --build-arg BUILD_REGISTRY=$(BUILD_REGISTRY) -f $${DAEMON}/Dockerfile .. ; \
+			docker buildx build $(PROGRESS) --memory $(MEMORY) $(PLATFORMS_ARG) $${TAGS_DAEMON} $(PUSH_ARG) --build-arg BUILD_REGISTRY=$(BUILD_REGISTRY) -f $${DAEMON}/Dockerfile .. ; \
 		fi \
 	done
 
+ifeq ($(ARCH),x86_64)
 clean:
 	$(QUIET) docker run --privileged multiarch/qemu-user-static --reset
 	$(QUIET) docker buildx rm xbuilder
+else
+clean:
+endif

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,8 @@ the build process, particularly for [multi-platform images](https://docs.docker.
 A number of environment variables control the build process (`make`):
 
 * `PLATFORMS`: comma separated list of platforms to pass to `docker buildx
-                --platforms`. Default: `linux/amd64`.
+                --platform`. This option is only valid in x86_64 architectures.
+               Default: ``
 * `BUILD_REGISTRY`: intermediate registry to build multi-platform images.
                     Default: `""` (none).
 * `PUSH`: push to docker registry `$PUSH`. The registry should NOT have


### PR DESCRIPTION

### Short description

This commit modifies the ci.yaml file to run the docker build and local docker-compose smoke tests on ARM runners, now that they are officially available (preview) for OSS.

Note: if ever pmacct gets unit tests (ha!) - `make check` - the the build stage should also run in at least one of the permutations in ARM.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->

I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
