### PR TITLE
ci: fix flake compiling docker multi platform

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,15 @@ jobs:
     env:
       PLATFORMS: linux/amd64,linux/arm64
     steps:
+      - name: Cleanup disk to maximize runner disk space
+        uses: AdityaGarg8/remove-unwanted-software@v3 #easimon/maximize-build-space@v10
+        with:
+          remove-android: true
+          remove-dotnet: True
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
+
       - name: Checkout pmacct
         uses: actions/checkout@v1 #Don't use v2 messes everything
         with:


### PR DESCRIPTION

### Short description

`docker-multiplatform-build-test-publish` sometimes fails due to GCC segfaulting.

The suspected root cause is the runner running out of HD space and swapping. Attempt to fix it by freeing some HD space before launching the build.

### Checklist
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
