### PR TITLE
Add libzstd to docker base image

### DIFF
--- a/ci/Dockerfile-ubuntu-focal-for-pmacct
+++ b/ci/Dockerfile-ubuntu-focal-for-pmacct
@@ -25,6 +25,7 @@ RUN apt-get update && \
     libpcap-dev \
     libpq-dev \
     libsnappy-dev \
+    libzstd-dev \
     libsqlite3-dev \
     libssl-dev \
     libgnutls28-dev \

--- a/ci/Dockerfile-ubuntu-jammy-for-pmacct
+++ b/ci/Dockerfile-ubuntu-jammy-for-pmacct
@@ -25,6 +25,7 @@ RUN apt-get update && \
     libpcap-dev \
     libpq-dev \
     libsnappy-dev \
+    libzstd-dev \
     libsqlite3-dev \
     libssl-dev \
     libgnutls28-dev \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     libpcap-dev \
     libpq-dev \
     libsnappy-dev \
+    libzstd-dev \
     libsqlite3-dev \
     libssl-dev \
     libgnutls28-dev \
@@ -83,6 +84,7 @@ RUN apt-get update && \
     libjson-c5 \
     libnetfilter-log1 \
     libsnappy1v5 \
+    libzstd-dev \
     libsqlite3-0 \
     libssl3 && \
   apt-get -y clean && \


### PR DESCRIPTION
### Short description
Adds `libzstd` to the docker base image to support the use of `zstd` kafka compression. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
