### PR TITLE
chore(docker): upgrade Docker base image to Debian Trixie and bump Apache Avro to 1.12.0

### DIFF
--- a/ci/deps.sh
+++ b/ci/deps.sh
@@ -59,8 +59,8 @@ cd nDPI ; rm -rf ./.git ; ./autogen.sh ; ./configure --prefix=/usr/local/ ; make
 git clone --depth 1 -b v4.3.5 https://github.com/zeromq/libzmq
 cd libzmq ; ./autogen.sh ; ./configure --prefix=/usr/local/ ; make ; sudo make install ; cd ..
 
-wget ${WGET_FLAGS} -O - https://github.com/apache/avro/archive/refs/tags/release-1.11.4.tar.gz | tar xzf -
-cd avro-release-1.11.4/lang/c ; mkdir build ; cd build ; cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. ; make ; sudo make install ; cd .. ; cd .. ; cd .. ; cd ..
+wget ${WGET_FLAGS} -O - https://github.com/apache/avro/archive/refs/tags/release-1.12.0.tar.gz | tar xzf -
+cd avro-release-1.12.0/lang/c ; mkdir build ; cd build ; cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. ; make ; sudo make install ; cd .. ; cd .. ; cd .. ; cd ..
 
 git clone --depth 1 -b v7.5.3 https://github.com/confluentinc/libserdes
 cd libserdes ; rm -rf ./.git ; ./configure --prefix=/usr/local/ ; make ; sudo make install ; cd ..

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -6,7 +6,7 @@
 #This Dockerfile creates a base docker image with pmacct and other useful
 #tools for network telemetry and monitoring
 
-FROM debian:bookworm-slim AS build-stage
+FROM debian:trixie-slim AS build-stage
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes
 # This is not the runtime/final image:
@@ -68,7 +68,7 @@ RUN export AVRO_LIBS="-L/usr/local/avro/lib -lavro" && \
                               --enable-unyte-udp-notif &&       \
   make install
 
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 LABEL maintainer="pmacct Docker Doctors <docker-doctors (at) pmacct.net>"
 # We don't want man pages
 COPY ci/dpkg.cfg.d/excludes /etc/dpkg/dpkg.cfg.d/excludes


### PR DESCRIPTION
### Short description

Upgrades Docker base image to Debian Trixie, and bump Apache Avro to 1.12.0.
Why: Debian Trixie includes GCC 14, which enforces stricter pointer-type checking and can treat `-Wincompatible-pointer-types` as fatal. Avro 1.12.0 includes the fix ([AVRO-3957](https://avro.apache.org/blog/2024/08/05/avro-1.12.0/) https://github.com/apache/avro/commit/52f051dbeefad0b7e73187becad6c33747b047d3) that corrects the incompatible pointer usage, which resolves the compilation failures.

### Checklist

* Updated docker base image to Debian Trixie;
* Bump Apache Avro from 1.11.4 with 1.12.0. Note: Although no issues were found, this change may introduce compatibility issues;
* Built image locally without issues;
````
» docker build --no-cache --progress=plain -t test_build . -f docker/base/Dockerfile 2>&1 | tee build.log
...
#15 DONE 0.5s

» docker run -it test_build
root@c0fb08cfd29c:/# pmacctd -V
Promiscuous Mode Accounting Daemon, pmacctd 1.7.10-git [20250828-1 (cc96e73a)]

Arguments:
 '--enable-mysql' '--enable-pgsql' '--enable-sqlite3' '--enable-kafka' '--enable-geoipv2' '--enable-jansson' '--enable-rabbitmq' '--enable-nflog' '--enable-ndpi' '--enable-zmq' '--enable-avro' '--enable-serdes' '--enable-redis' '--enable-gnutls' '--enable-unyte-udp-notif' 'AVRO_CFLAGS=-I/usr/local/avro/include' 'AVRO_LIBS=-L/usr/local/avro/lib -lavro' '--enable-l2' '--enable-traffic-bins' '--enable-bgp-bins' '--enable-bmp-bins' '--enable-st-bins'

Libs:
cdada 0.6.0
libpcap version 1.10.5 (with TPACKET_V3)
MariaDB 11.8.2
PostgreSQL 170005
sqlite3 3.46.1
rabbimq-c 0.13.0
rdkafka 2.6.1
jansson 2.14
MaxmindDB 1.11.0
ZeroMQ 4.3.5
Redis 1.2.0
GnuTLS 3.8.9
avro-c
serdes
unyte-udp-notif
nDPI 4.14.0
netfilter_log

Plugins:
memory
print
nfprobe
sfprobe
tee
mysql
postgresql
sqlite
amqp
kafka

System:
Linux 6.10.14-linuxkit #1 SMP Thu Oct 24 19:28:55 UTC 2024 aarch64

Compiler:
gcc 14.2.0

For suggestions, critics, bugs, contact me: Paolo Lucente <paolo@pmacct.net>.

root@c0fb08cfd29c:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.0
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

root@c0fb08cfd29c:/# ldd /usr/local/sbin/pmacctd | grep -i avro
        libavro.so.24 => /usr/local/lib/libavro.so.24 (0x0000ffff87090000)
````

Build logs: [build.log.tgz](https://github.com/user-attachments/files/22100653/build.log.tgz)

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes)
