### PR TITLE
fix for new bmp_daemon_set_pd config and "pd" field

### DIFF
--- a/src/bmp/bmp.h
+++ b/src/bmp/bmp.h
@@ -89,7 +89,6 @@ struct bmp_chars {
   u_int8_t is_out;
   u_int8_t is_loc;
   u_int8_t rib_type; /* new replacing is_in, is_out, is_loc, is_post */
-  rd_t rd;
   rd_t pd;
 
   /* non-key */

--- a/src/bmp/bmp_logdump.c
+++ b/src/bmp/bmp_logdump.c
@@ -408,24 +408,19 @@ int bmp_log_msg_stats(struct bgp_peer *peer, struct bmp_data *bdata, struct cdad
       json_object_set_new_nocheck(obj, "is_loc", json_integer((json_int_t)bdata->chars.is_loc));
     }
     else if (bdata->chars.is_out) {
-      json_object_set_new_nocheck(obj, "is_post", json_integer((json_int_t)bdata->chars.is_post));
-      json_object_set_new_nocheck(obj, "is_out", json_integer((json_int_t)bdata->chars.is_out));
+        json_object_set_new_nocheck(obj, "is_post", json_integer((json_int_t)bdata->chars.is_post));
+        json_object_set_new_nocheck(obj, "is_out", json_integer((json_int_t)bdata->chars.is_out));
     }
 
-    if (!is_empty_256b(&bdata->chars.rd, sizeof(bdata->chars.rd))) {
-      char rd_str[SHORTSHORTBUFLEN];
-
-      bgp_rd2str(rd_str, &bdata->chars.rd);
-      json_object_set_new_nocheck(obj, "rd", json_string(rd_str));
-      json_object_set_new_nocheck(obj, "rd_origin", json_string(bgp_rd_origin_print(bdata->chars.rd.type)));
-    }
+    const char* pd_target = config.bmp_daemon_set_pd ? "pd" : "rd";
+    const char* pd_origin_target = config.bmp_daemon_set_pd ? "pd_origin" : "rd_origin";
 
     if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
       char pd_str[SHORTSHORTBUFLEN];
 
       bgp_rd2str(pd_str, &bdata->chars.pd);
-      json_object_set_new_nocheck(obj, "pd", json_string(pd_str));
-      json_object_set_new_nocheck(obj, "pd_origin", json_string(bgp_rd_origin_print(bdata->chars.pd.type)));
+      json_object_set_new_nocheck(obj, pd_target, json_string(pd_str));
+      json_object_set_new_nocheck(obj, pd_origin_target, json_string(bgp_rd_origin_print(bdata->chars.pd.type)));
     }
 
     json_object_set_new_nocheck(obj, "bgp_id", json_string(inet_ntoa(bdata->bgp_id.address.ipv4)));
@@ -547,46 +542,27 @@ int bmp_log_msg_stats(struct bgp_peer *peer, struct bmp_data *bdata, struct cdad
       pm_avro_check(avro_value_set_int(&p_avro_branch, bdata->chars.is_out));
     }
 
-    if (!is_empty_256b(&bdata->chars.rd, sizeof(bdata->chars.rd))) {
+    const char* pd_target = config.bmp_daemon_set_pd ? "pd" : "rd";
+    const char* pd_origin_target = config.bmp_daemon_set_pd ? "pd_origin" : "rd_origin";
+
+    if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
       char rd_str[SHORTSHORTBUFLEN];
 
-      bgp_rd2str(rd_str, &bdata->chars.rd);
-      pm_avro_check(avro_value_get_by_name(obj, "rd", &p_avro_field, NULL));
+      bgp_rd2str(rd_str, &bdata->chars.pd);
+      pm_avro_check(avro_value_get_by_name(obj, pd_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
       pm_avro_check(avro_value_set_string(&p_avro_branch, rd_str));
 
-      pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_origin_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-      pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.rd.type)));
+      pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.pd.type)));
     }
     else {
-      pm_avro_check(avro_value_get_by_name(obj, "rd", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
 
-      pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_origin_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-    }
-
-    if (config.bmp_daemon_set_pd) {
-      if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
-        char pd_str[SHORTSHORTBUFLEN];
-
-        bgp_rd2str(pd_str, &bdata->chars.pd);
-        pm_avro_check(avro_value_get_by_name(obj, "pd", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-        pm_avro_check(avro_value_set_string(&p_avro_branch, pd_str));
-
-        pm_avro_check(avro_value_get_by_name(obj, "pd_origin", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-        pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.pd.type)));
-      }
-      else {
-        pm_avro_check(avro_value_get_by_name(obj, "pd", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-
-        pm_avro_check(avro_value_get_by_name(obj, "pd_origin", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-      }
     }
 
     pm_avro_check(avro_value_get_by_name(obj, "bgp_id", &p_avro_field, NULL));
@@ -950,20 +926,15 @@ int bmp_log_msg_peer_up(struct bgp_peer *peer, struct bmp_data *bdata, struct cd
     addr_to_str(ip_address, &blpu->local_ip);
     json_object_set_new_nocheck(obj, "local_ip", json_string(ip_address));
 
-    if (!is_empty_256b(&bdata->chars.rd, sizeof(bdata->chars.rd))) {
-      char rd_str[SHORTSHORTBUFLEN];
-
-      bgp_rd2str(rd_str, &bdata->chars.rd);
-      json_object_set_new_nocheck(obj, "rd", json_string(rd_str));
-      json_object_set_new_nocheck(obj, "rd_origin", json_string(bgp_rd_origin_print(bdata->chars.rd.type)));
-    }
+    const char* pd_target = config.bmp_daemon_set_pd ? "pd" : "rd";
+    const char* pd_origin_target = config.bmp_daemon_set_pd ? "pd_origin" : "rd_origin";
 
     if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
       char pd_str[SHORTSHORTBUFLEN];
 
       bgp_rd2str(pd_str, &bdata->chars.pd);
-      json_object_set_new_nocheck(obj, "pd", json_string(pd_str));
-      json_object_set_new_nocheck(obj, "pd_origin", json_string(bgp_rd_origin_print(bdata->chars.pd.type)));
+      json_object_set_new_nocheck(obj, pd_target, json_string(pd_str));
+      json_object_set_new_nocheck(obj, pd_origin_target, json_string(bgp_rd_origin_print(bdata->chars.pd.type)));
     }
 
     if (tlvs) {
@@ -1103,46 +1074,27 @@ int bmp_log_msg_peer_up(struct bgp_peer *peer, struct bmp_data *bdata, struct cd
     pm_avro_check(avro_value_get_by_name(obj, "local_ip", &p_avro_field, NULL));
     pm_avro_check(avro_value_set_string(&p_avro_field, ip_address));
 
-    if (!is_empty_256b(&bdata->chars.rd, sizeof(bdata->chars.rd))) {
+    const char* pd_target = config.bmp_daemon_set_pd ? "pd" : "rd";
+    const char* pd_origin_target = config.bmp_daemon_set_pd ? "pd_origin" : "rd_origin";
+
+    if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
       char rd_str[SHORTSHORTBUFLEN];
 
-      bgp_rd2str(rd_str, &bdata->chars.rd);
-      pm_avro_check(avro_value_get_by_name(obj, "rd", &p_avro_field, NULL));
+      bgp_rd2str(rd_str, &bdata->chars.pd);
+      pm_avro_check(avro_value_get_by_name(obj, pd_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
       pm_avro_check(avro_value_set_string(&p_avro_branch, rd_str));
 
-      pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_origin_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-      pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.rd.type)));
+      pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.pd.type)));
     }
     else {
-      pm_avro_check(avro_value_get_by_name(obj, "rd", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
 
-      pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_origin_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-    }
-
-    if (config.bmp_daemon_set_pd) {
-      if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
-        char pd_str[SHORTSHORTBUFLEN];
-
-        bgp_rd2str(pd_str, &bdata->chars.pd);
-        pm_avro_check(avro_value_get_by_name(obj, "pd", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-        pm_avro_check(avro_value_set_string(&p_avro_branch, pd_str));
-
-        pm_avro_check(avro_value_get_by_name(obj, "pd_origin", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-        pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.pd.type)));
-      }
-      else {
-        pm_avro_check(avro_value_get_by_name(obj, "pd", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-
-        pm_avro_check(avro_value_get_by_name(obj, "pd_origin", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-      }
     }
 
     memset(&bmp_peer_up_tlvs, 0, sizeof(bmp_peer_up_tlvs));
@@ -1248,20 +1200,15 @@ int bmp_log_msg_peer_down(struct bgp_peer *peer, struct bmp_data *bdata, struct 
       json_object_set_new_nocheck(obj, "is_out", json_integer((json_int_t)bdata->chars.is_out));
     }
 
-    if (!is_empty_256b(&bdata->chars.rd, sizeof(bdata->chars.rd))) {
-      char rd_str[SHORTSHORTBUFLEN];
-
-      bgp_rd2str(rd_str, &bdata->chars.rd);
-      json_object_set_new_nocheck(obj, "rd", json_string(rd_str));
-      json_object_set_new_nocheck(obj, "rd_origin", json_string(bgp_rd_origin_print(bdata->chars.rd.type)));
-    }
+    const char* pd_target = config.bmp_daemon_set_pd ? "pd" : "rd";
+    const char* pd_origin_target = config.bmp_daemon_set_pd ? "pd_origin" : "rd_origin";
 
     if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
       char pd_str[SHORTSHORTBUFLEN];
 
       bgp_rd2str(pd_str, &bdata->chars.pd);
-      json_object_set_new_nocheck(obj, "pd", json_string(pd_str));
-      json_object_set_new_nocheck(obj, "pd_origin", json_string(bgp_rd_origin_print(bdata->chars.pd.type)));
+      json_object_set_new_nocheck(obj, pd_target, json_string(pd_str));
+      json_object_set_new_nocheck(obj, pd_origin_target, json_string(bgp_rd_origin_print(bdata->chars.pd.type)));
     }
 
     json_object_set_new_nocheck(obj, "reason_type", json_integer((json_int_t)blpd->reason));
@@ -1398,46 +1345,27 @@ int bmp_log_msg_peer_down(struct bgp_peer *peer, struct bmp_data *bdata, struct 
       pm_avro_check(avro_value_set_int(&p_avro_branch, bdata->chars.is_out));
     }
 
-    if (!is_empty_256b(&bdata->chars.rd, sizeof(bdata->chars.rd))) {
+    const char* pd_target = config.bmp_daemon_set_pd ? "pd" : "rd";
+    const char* pd_origin_target = config.bmp_daemon_set_pd ? "pd_origin" : "rd_origin";
+
+    if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
       char rd_str[SHORTSHORTBUFLEN];
 
-      bgp_rd2str(rd_str, &bdata->chars.rd);
-      pm_avro_check(avro_value_get_by_name(obj, "rd", &p_avro_field, NULL));
+      bgp_rd2str(rd_str, &bdata->chars.pd);
+      pm_avro_check(avro_value_get_by_name(obj, pd_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
       pm_avro_check(avro_value_set_string(&p_avro_branch, rd_str));
 
-      pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_origin_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-      pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.rd.type)));
+      pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.pd.type)));
     }
     else {
-      pm_avro_check(avro_value_get_by_name(obj, "rd", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
 
-      pm_avro_check(avro_value_get_by_name(obj, "rd_origin", &p_avro_field, NULL));
+      pm_avro_check(avro_value_get_by_name(obj, pd_origin_target, &p_avro_field, NULL));
       pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-    }
-
-    if (config.bmp_daemon_set_pd) {
-      if (!is_empty_256b(&bdata->chars.pd, sizeof(bdata->chars.pd))) {
-        char pd_str[SHORTSHORTBUFLEN];
-
-        bgp_rd2str(pd_str, &bdata->chars.pd);
-        pm_avro_check(avro_value_get_by_name(obj, "pd", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-        pm_avro_check(avro_value_set_string(&p_avro_branch, pd_str));
-
-        pm_avro_check(avro_value_get_by_name(obj, "pd_origin", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, TRUE, &p_avro_branch));
-        pm_avro_check(avro_value_set_string(&p_avro_branch, bgp_rd_origin_print(bdata->chars.pd.type)));
-      }
-      else {
-        pm_avro_check(avro_value_get_by_name(obj, "pd", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-
-        pm_avro_check(avro_value_get_by_name(obj, "pd_origin", &p_avro_field, NULL));
-        pm_avro_check(avro_value_set_branch(&p_avro_field, FALSE, &p_avro_branch));
-      }
     }
 
     pm_avro_check(avro_value_get_by_name(obj, "reason_type", &p_avro_field, NULL));

--- a/src/bmp/bmp_lookup.c
+++ b/src/bmp/bmp_lookup.c
@@ -122,7 +122,7 @@ u_int32_t bmp_route_info_modulo_mplsvpnrd(struct bgp_peer *peer, rd_t *rd, path_
 
   if (bmed) { /* BMP message being parsed (RD is stored in bmed->data->rd) */
     struct bmp_chars *bmed_bmp_chars = (struct bmp_chars *) bmed->data;
-    if (bmed_bmp_chars->rd.val) local_rd = (bmed_bmp_chars->rd.type + bmed_bmp_chars->rd.as + bmed_bmp_chars->rd.val);
+    if (bmed_bmp_chars->pd.val) local_rd = (bmed_bmp_chars->pd.type + bmed_bmp_chars->pd.as + bmed_bmp_chars->pd.val);
   }
   else { /* Correlating with flow */
     if (rd) local_rd = (rd->type + rd->as + rd->val);
@@ -164,7 +164,7 @@ int bgp_lookup_node_match_cmp_bmp(struct bgp_info *info, struct node_match_cmp_t
 	if (info->bmed.id == BGP_MSG_EXTRA_DATA_BMP) {
 	  struct bmp_chars *bmed_bmp = (struct bmp_chars *) info->bmed.data;
 
-	  if (bmed_bmp && !memcmp(&bmed_bmp->rd, nmct2->rd, sizeof(rd_t))) {
+	  if (bmed_bmp && !memcmp(&bmed_bmp->pd, nmct2->rd, sizeof(rd_t))) {
 	    no_match--;
 	  }
 	}

--- a/src/bmp/bmp_msg.c
+++ b/src/bmp/bmp_msg.c
@@ -317,12 +317,7 @@ void bmp_process_msg_peer_up(char **bmp_packet, u_int32_t *len, struct bmp_peer 
   bmp_peer_hdr_get_peer_ip(bph, &bdata.peer_ip, &bdata.family);
   bmp_peer_hdr_get_bgp_id(bph, &bdata.bgp_id);
 
-  if (config.bmp_daemon_set_pd) {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
-  }
-  else {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.rd);
-  }
+  bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
 
   bmp_peer_hdr_get_tstamp(bph, &bdata.tstamp);
   bmp_peer_hdr_get_peer_asn(bph, &bdata.peer_asn);
@@ -448,12 +443,7 @@ void bmp_process_msg_peer_up(char **bmp_packet, u_int32_t *len, struct bmp_peer 
   bmpp_bgp_peer->log = bmpp->self.log;
   bmpp_bgp_peer->bmp_se = bmpp; /* using bmp_se field to back-point a BGP peer to its parent BMP peer */
 
-  if (config.bmp_daemon_set_pd) {
-    bmpp_bgp_peer->peer_distinguisher = bdata.chars.pd;
-  }
-  else {
-    bmpp_bgp_peer->peer_distinguisher = bdata.chars.rd;
-  }
+  bmpp_bgp_peer->peer_distinguisher = bdata.chars.pd;
 
   /* Search (or create if not existing) the BGP peer structure for this peer_up msg */
   if (bdata.family == AF_INET) {
@@ -556,12 +546,7 @@ void bmp_process_msg_peer_down(char **bmp_packet, u_int32_t *len, struct bmp_pee
   bmp_peer_hdr_get_peer_ip(bph, &bdata.peer_ip, &bdata.family);
   bmp_peer_hdr_get_bgp_id(bph, &bdata.bgp_id);
 
-  if (config.bmp_daemon_set_pd) {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
-  }
-  else {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.rd);
-  }
+  bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
 
   bmp_peer_hdr_get_tstamp(bph, &bdata.tstamp);
   bmp_peer_hdr_get_peer_asn(bph, &bdata.peer_asn);
@@ -664,20 +649,10 @@ void bmp_process_msg_peer_down(char **bmp_packet, u_int32_t *len, struct bmp_pee
 
   /* Find the relevant BGP peer (matching peer_ip and peer_distinguisher) */
   if (bdata.family == AF_INET) {
-    if (config.bmp_daemon_set_pd) {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v4, bmp_peer_host_addr_peer_dist_cmp);
-    }
-    else {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v4, bgp_peer_host_addr_peer_dist_cmp);
-    }
+    ret = pm_tfind(&bdata, &bmpp->bgp_peers_v4, bgp_peer_host_addr_peer_dist_cmp);
   }
   else if (bdata.family == AF_INET6) {
-    if (config.bmp_daemon_set_pd) {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v6, bmp_peer_host_addr_peer_dist_cmp);
-    }
-    else {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v6, bgp_peer_host_addr_peer_dist_cmp);
-    }
+    ret = pm_tfind(&bdata, &bmpp->bgp_peers_v6, bgp_peer_host_addr_peer_dist_cmp);
   }
 
   if (ret) {
@@ -686,20 +661,10 @@ void bmp_process_msg_peer_down(char **bmp_packet, u_int32_t *len, struct bmp_pee
     bgp_peer_info_delete(bmpp_bgp_peer);
 
     if (bdata.family == AF_INET) {
-      if (config.bmp_daemon_set_pd) {
-        pm_tdelete(&bdata, &bmpp->bgp_peers_v4, bmp_peer_host_addr_peer_dist_cmp);
-      }
-      else {
-        pm_tdelete(&bdata, &bmpp->bgp_peers_v4, bgp_peer_host_addr_peer_dist_cmp);
-      }
+      pm_tdelete(&bdata, &bmpp->bgp_peers_v4, bgp_peer_host_addr_peer_dist_cmp);
     }
     else if (bdata.family == AF_INET6) {
-      if (config.bmp_daemon_set_pd) {
-        pm_tdelete(&bdata, &bmpp->bgp_peers_v6, bmp_peer_host_addr_peer_dist_cmp);
-      }
-      else {
-        pm_tdelete(&bdata, &bmpp->bgp_peers_v6, bgp_peer_host_addr_peer_dist_cmp);
-      }
+      pm_tdelete(&bdata, &bmpp->bgp_peers_v6, bgp_peer_host_addr_peer_dist_cmp);
     }
   }
   /* missing BMP peer up message, ie. case of replay/replication of BMP messages */
@@ -756,12 +721,7 @@ void bmp_process_msg_route_monitor(char **bmp_packet, u_int32_t *len, struct bmp
   bmp_peer_hdr_get_peer_ip(bph, &bdata.peer_ip, &bdata.family);
   bmp_peer_hdr_get_bgp_id(bph, &bdata.bgp_id);
 
-  if (config.bmp_daemon_set_pd) {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
-  }
-  else {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.rd);
-  }
+  bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
 
   bmp_peer_hdr_get_tstamp(bph, &bdata.tstamp);
   bmp_peer_hdr_get_peer_asn(bph, &bdata.peer_asn);
@@ -773,20 +733,10 @@ void bmp_process_msg_route_monitor(char **bmp_packet, u_int32_t *len, struct bmp
 
   /* Find the relevant BGP peer (matching peer_ip and peer_distinguisher) */
   if (bdata.family == AF_INET) {
-    if (config.bmp_daemon_set_pd) {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v4, bmp_peer_host_addr_peer_dist_cmp);
-    }
-    else {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v4, bgp_peer_host_addr_peer_dist_cmp);
-    }
+    ret = pm_tfind(&bdata, &bmpp->bgp_peers_v4, bgp_peer_host_addr_peer_dist_cmp);
   }
   else if (bdata.family == AF_INET6) {
-    if (config.bmp_daemon_set_pd) {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v6, bmp_peer_host_addr_peer_dist_cmp);
-    }
-    else {
-      ret = pm_tfind(&bdata, &bmpp->bgp_peers_v6, bgp_peer_host_addr_peer_dist_cmp);
-    }
+    ret = pm_tfind(&bdata, &bmpp->bgp_peers_v6, bgp_peer_host_addr_peer_dist_cmp);
   }
 
   /* missing BMP peer up message, ie. case of replay/replication of BMP messages */
@@ -1023,12 +973,7 @@ void bmp_process_msg_stats(char **bmp_packet, u_int32_t *len, struct bmp_peer *b
   bmp_peer_hdr_get_peer_ip(bph, &bdata.peer_ip, &bdata.family);
   bmp_peer_hdr_get_bgp_id(bph, &bdata.bgp_id);
 
-  if (config.bmp_daemon_set_pd) {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
-  }
-  else {
-    bmp_peer_hdr_get_rd(bph, &bdata.chars.rd);
-  }
+  bmp_peer_hdr_get_rd(bph, &bdata.chars.pd);
 
   bmp_peer_hdr_get_tstamp(bph, &bdata.tstamp);
   bmp_peer_hdr_get_peer_asn(bph, &bdata.peer_asn);

--- a/src/bmp/bmp_util.h
+++ b/src/bmp/bmp_util.h
@@ -29,7 +29,6 @@
 /* prototypes */
 extern int bgp_peer_cmp_bmp(const void *, const void *);
 extern int bgp_peer_host_addr_peer_dist_cmp(const void *, const void *);
-extern int bmp_peer_host_addr_peer_dist_cmp(const void *, const void *);
 
 extern char *bmp_get_and_check_length(char **, u_int32_t *, u_int32_t);
 extern int bmp_jump_offset(char **, u_int32_t *, u_int32_t);


### PR DESCRIPTION
### Short description
The current implementation of bmp_daemon_set_pd duplicates the "rd" field of bmp_chars as a new field "pd".
This is a priori unnecessary since the rd coming from bgp is not stored in `bmp_chars` but rather in the bgp attributes of the route. Additionally, this duplication may consume a lot of memory (8 bytes * number of routes) as bmp_chars are not deduped using interning.

This PR aims at fixing that by keeping a single field, now internally called "pd" to match the BMP protocol, and exports this field either as "pd" or "rd" in the json outputs depending on the bmp_daemon_set_pd config knob.

I could not test in depth that this implementation is fully sane since I do not have a pcap with bmp and bgp having different RDs/PDs. Maybe @MyLi2tlePony or @GeorgyKirichenko could help with that?
I can however confirm that the BMP field is correctly renamed when bmp_daemon_set_pd=true and that BGP RDs are still exported correctly when BMP does not have a peer distinguisher, regardless of the config knob (BGP takes precedence over BMP for RDs).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
