### PR TITLE
feat(exec): introducing boolean option that enable async triggers exec

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -1524,6 +1524,16 @@ NOTES:		* When running in Docker, to avoid the accumulation of zombie processes,
 		  can then output to a file, named differently, that is input for a 3rd party processor.
 DEFAULT:	none
 
+KEY:		[ sql_trigger_exec_async | print_trigger_exec_async | amqp_trigger_exec_async | kafka_trigger_exec_async ]
+VALUES:		[ true | false ]
+DESC:		When set to true, trigger commands are executed asynchronously, allowing multiple triggers
+		to run in parallel without blocking each other. When false (default), triggers execute
+		synchronously one at a time. This is particularly useful when multiple plugins process data
+		in parallel and each needs to execute trigger commands, as it prevents triggers from blocking
+		each other. In async mode, the parent process returns immediately after spawning the trigger
+		command, which is completely detached using a double-fork pattern to avoid zombie processes.
+DEFAULT:	false
+
 KEY:		sql_trigger_time
 VALUES:		#[s|m|h|d|w|M]
 DESC:		Specifies time interval at which the executable specified by 'sql_trigger_exec' has to

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -125,6 +125,7 @@ static const struct _dictionary_line dictionary[] = {
   {"sql_delimiter", cfg_key_sql_delimiter},
   {"sql_max_writers", cfg_key_dump_max_writers},
   {"sql_trigger_exec", cfg_key_sql_trigger_exec},
+  {"sql_trigger_exec_async", cfg_key_sql_trigger_exec_async},
   {"sql_trigger_time", cfg_key_sql_trigger_time},
   {"sql_cache_entries", cfg_key_sql_cache_entries},
   {"sql_dont_try_update", cfg_key_sql_dont_try_update},
@@ -149,6 +150,7 @@ static const struct _dictionary_line dictionary[] = {
   {"print_latest_file", cfg_key_print_latest_file},
   {"print_num_protos", cfg_key_num_protos},
   {"print_trigger_exec", cfg_key_sql_trigger_exec},
+  {"print_trigger_exec_async", cfg_key_sql_trigger_exec_async},
   {"print_history", cfg_key_sql_history},
   {"print_history_offset", cfg_key_sql_history_offset},
   {"print_history_roundoff", cfg_key_sql_history_roundoff},
@@ -187,6 +189,7 @@ static const struct _dictionary_line dictionary[] = {
   {"amqp_avro_schema_routing_key", cfg_key_amqp_avro_schema_routing_key}, /* Legacy feature */
   {"amqp_avro_schema_refresh_time", cfg_key_amqp_avro_schema_refresh_time}, /* Legacy feature */
   {"amqp_trigger_exec", cfg_key_sql_trigger_exec},
+  {"amqp_trigger_exec_async", cfg_key_sql_trigger_exec_async},
   {"kafka_refresh_time", cfg_key_sql_refresh_time},
   {"kafka_history", cfg_key_sql_history},
   {"kafka_history_offset", cfg_key_sql_history_offset},
@@ -210,6 +213,7 @@ static const struct _dictionary_line dictionary[] = {
   {"kafka_avro_schema_registry", cfg_key_kafka_avro_schema_registry},
   {"kafka_config_file", cfg_key_kafka_config_file},
   {"kafka_trigger_exec", cfg_key_sql_trigger_exec},
+  {"kafka_trigger_exec_async", cfg_key_sql_trigger_exec_async},
   {"nfacctd_proc_name", cfg_key_proc_name},
   {"nfacctd_port", cfg_key_nfacctd_port},
   {"nfacctd_ip", cfg_key_nfacctd_ip},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -153,6 +153,7 @@ struct configuration {
   int sql_trigger_time;
   int sql_trigger_time_howmany; /* internal */
   char *sql_trigger_exec;
+  int sql_trigger_exec_async;
   int sql_max_queries;
   char *sql_preprocess;
   int sql_preprocess_type;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -1642,6 +1642,28 @@ int cfg_key_sql_trigger_exec(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_sql_trigger_exec_async(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int value, changes = 0;
+
+  value = parse_truefalse(value_ptr);
+  if (value < 0) return ERR;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.sql_trigger_exec_async = value;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.sql_trigger_exec_async = value;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_sql_trigger_time(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -95,6 +95,7 @@ extern int cfg_key_sql_history_offset(char *, char *, char *);
 extern int cfg_key_sql_history_roundoff(char *, char *, char *);
 extern int cfg_key_sql_recovery_backup_host(char *, char *, char *);
 extern int cfg_key_sql_trigger_exec(char *, char *, char *);
+extern int cfg_key_sql_trigger_exec_async(char *, char *, char *);
 extern int cfg_key_sql_trigger_time(char *, char *, char *);
 extern int cfg_key_sql_cache_entries(char *, char *, char *);
 extern int cfg_key_sql_dont_try_update(char *, char *, char *);


### PR DESCRIPTION
### Short description

This PR introduces a new configuration option `*_trigger_exec_async `(e.g., `sql_trigger_exec_async`, `print_trigger_exec_async`) to allow trigger commands to be executed asynchronously.
Currently, triggers defined by trigger_exec are executed synchronously, which blocks the plugin's main loop until the external command completes. This option improves throughput and prevents processing delays, ensuring the main loop remains unblocked even when trigger scripts handle complex/heavy tasks.

### Checklist

* Built image locally without issues:
````
$  docker build -t pmacct-trigger-exec --no-cache --progress=plain -f docker/base/Dockerfile .  2>&1 | tee build.log
#0 building with "default" instance using docker driver
...
#16 naming to docker.io/library/pmacct-trigger-exec
#16 naming to docker.io/library/pmacct-trigger-exec 0.2s done
#16 DONE 2.8s
````
Build logs:  [build.log.tgz](https://github.com/user-attachments/files/23810445/build.log.tgz)

* I'm using this branch/image in production, and it's been running without any issues for the past few weeks.
````
$ docker inspect --format='Image: {{.Config.Image}} - Up since: {{.State.StartedAt}}' nflow-collector1
Image: pmacct-trigger-exec - Up since: 2025-11-18T00:36:30.61360175Z
````

````
$ docker exec -it nflow-collector1 /bin/sh
# pmacctd -V
Promiscuous Mode Accounting Daemon, pmacctd 1.7.10-git [20251117-0 (4906e159)]

Arguments:
 '--enable-mysql' '--enable-pgsql' '--enable-sqlite3' '--enable-kafka' '--enable-geoipv2' '--enable-jansson' '--enable-rabbitmq' '--enable-nflog' '--enable-ndpi' '--enable-zmq' '--enable-avro' '--enable-serdes' '--enable-redis' '--enable-gnutls' '--enable-unyte-udp-notif' 'AVRO_CFLAGS=-I/usr/local/avro/include' 'AVRO_LIBS=-L/usr/local/avro/lib -lavro' '--enable-l2' '--enable-traffic-bins' '--enable-bgp-bins' '--enable-bmp-bins' '--enable-st-bins'

Libs:
cdada 0.6.2
libpcap version 1.10.5 (with TPACKET_V3)
MariaDB 11.8.3
PostgreSQL 170006
sqlite3 3.46.1
rabbimq-c 0.13.0
rdkafka 2.11.1
jansson 2.14.1
MaxmindDB 1.11.0
ZeroMQ 4.3.5
Redis 1.2.0
GnuTLS 3.8.9
avro-c
serdes
unyte-udp-notif
nDPI 4.14.0
netfilter_log

Plugins:
memory
print
nfprobe
sfprobe
tee
mysql
postgresql
sqlite
amqp
kafka

System:
Linux 5.15.0-157-generic #167-Ubuntu SMP Wed Sep 17 21:35:53 UTC 2025 x86_64

Compiler:
gcc 14.2.0

For suggestions, critics, bugs, contact me: Paolo Lucente <paolo@pmacct.net>.
````

I have:
- [ ] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
