### PR TITLE
initialize result to NULL

### DIFF
--- a/src/bgp/bgp_ls.c
+++ b/src/bgp/bgp_ls.c
@@ -1305,7 +1305,7 @@ void bgp_ls_srcdst_lookup(struct packet_ptrs *pptrs, int type)
   struct in6_addr pref6;
   safi_t safi = SAFI_UNICAST;
 
-  struct bgp_node *result;
+  struct bgp_node *result = NULL;
   struct bgp_info *info = NULL;
 
   pptrs->igp_src = NULL;


### PR DESCRIPTION
### Short description
Hey Paolo!
This result pointer is not initialized to NULL. When the bgp lookup exits prematurely because of an early return, the pointer is not always set to NULL by the `bgp_node_match` function called. This result pointer may then have any value that lingered there on the stack. I had some issues where sfacctd would crash because this result was 0x06. Since it was not NULL, it would pass the `if (result)` check line 1322 and then segfault on access `result->info`. Sometimes this was also fine based on previous calls, for instance if you print the address to debug before that, nothing crashes for some reason :smile: 

Cheers
Max

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
