### PR TITLE
collect core dumps from test-framework daemons

### DIFF
--- a/test-framework/library/sh/pmacct_docker/docker-compose-template.yml
+++ b/test-framework/library/sh/pmacct_docker/docker-compose-template.yml
@@ -12,6 +12,9 @@ services:
     volumes:
       - ${PMACCT_CONF}:/etc/pmacct/${PMACCT_DAEMON}.conf
       - ${PMACCT_MOUNT}:/var/log/pmacct
+      - ${PMACCT_MOUNT}/cores:/tmp/cores
+    ulimits:
+      core: -1
     networks:
       pmacct_test_network:
         ipv4_address: 172.21.1.13


### PR DESCRIPTION
### Short description
This PR sets up the test-framework pmacct docker images to dump cores and adds a directory bind to the pmacct mount point. The dumped cores are found in each test's pmacct_mount/cores directory.

Docker images inherit the `/proc/sys/kernel/core_pattern` value from the host. The bind point in the test-framework for cores dumps in `/tmp/cores` inside the containers. This means that, to collect core dumps, the host must have a `/proc/sys/kernel/core_pattern` set to target `/tmp/cores`. Something like `/tmp/cores/core_%e.%p` does the job.

This seemed to be already documented for the docker images, even though no cores were actually collected automatically for test-results.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [x] compiled & tested this code
- [x] included documentation (including possible behaviour changes)
