### PR TITLE
fix(bgp): fix memory leaks in BGP-LS and UPDATE attribute parsing

### DIFF
--- a/src/bgp/bgp_ls.c
+++ b/src/bgp/bgp_ls.c
@@ -108,7 +108,7 @@ int bgp_ls_nlri_parse(struct bgp_msg_data *bmd, struct bgp_attr *attr, struct bg
   char bgp_peer_str[INET6_ADDRSTRLEN];
   u_char *pnt;
   int rem_len, rem_nlri_len, ret, idx, log_type = 0;
-  u_int16_t tmp16, nlri_len, tlv_type, tlv_len;
+  u_int16_t tmp16, nlri_len, tlv_type = 0, tlv_len;
 
   /* RIB vars */
   struct bgp_node *route = NULL;
@@ -214,6 +214,8 @@ int bgp_ls_nlri_parse(struct bgp_msg_data *bmd, struct bgp_attr *attr, struct bg
 	    if (ret != CDADA_SUCCESS) {
 	      bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
 	      Log(LOG_WARNING, "WARN ( %s/%s/BGP ): [%s] BGP-LS failed NLRI Insert/Replace\n", config.name, config.type, bgp_peer_str);
+	      if (attr_aux) free(attr_aux);
+          free(attr_hdr);
 	    }
 	    else {
 	      if (attr_hdr_prev) {

--- a/src/bgp/bgp_msg.c
+++ b/src/bgp/bgp_msg.c
@@ -722,6 +722,14 @@ int bgp_parse_update_msg(struct bgp_msg_data *bmd, char *pkt)
   if (attribute_len > 0) {
     ret = bgp_attr_parse(peer, &attr, &attr_extra, pkt, attribute_len, &mp_update, &mp_withdraw);
     if (ret < 0) {
+      if (attr.aspath)
+        aspath_unintern(peer, attr.aspath);
+      if (attr.community)
+        community_unintern(peer, attr.community);
+      if (attr.ecommunity)
+        ecommunity_unintern(peer, attr.ecommunity);
+      if (attr.lcommunity)
+        lcommunity_unintern(peer, attr.lcommunity);
       return ret;
     }
     pkt += attribute_len;
@@ -876,7 +884,8 @@ int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, struct bgp_attr
     if (to_the_end < BGP_ATTR_MIN_LEN) {
       bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
       Log(LOG_DEBUG, "DEBUG ( %s/%s ): [%s] bgp_attr_parse() failed: to_the_end < BGP_ATTR_MIN_LEN\n", config.name, bms->log_str, bgp_peer_str);
-      return ERR;
+      ret = ERR;
+      goto attr_parse_end;
     }
 
     tmp = (u_int8_t *) ptr++; to_the_end--; flag = *tmp;
@@ -888,7 +897,8 @@ int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, struct bgp_attr
       if (attr_len > to_the_end) {
 	bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
 	Log(LOG_DEBUG, "DEBUG ( %s/%s ): [%s] bgp_attr_parse() failed: attr_len > to_the_end (1)\n", config.name, bms->log_str, bgp_peer_str);
-        return ERR;
+        ret = ERR;
+        goto attr_parse_end;
       }
     }
     else {
@@ -896,7 +906,8 @@ int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, struct bgp_attr
       if (attr_len > to_the_end) {
 	bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
 	Log(LOG_DEBUG, "DEBUG ( %s/%s ): [%s] bgp_attr_parse() failed: attr_len > to_the_end (2)\n", config.name, bms->log_str, bgp_peer_str);
-	return ERR;
+	ret = ERR;
+	goto attr_parse_end;
       }
     }
 
@@ -953,7 +964,7 @@ int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, struct bgp_attr
     if (ret < 0) {
       bgp_peer_print(peer, bgp_peer_str, INET6_ADDRSTRLEN);
       Log(LOG_DEBUG, "DEBUG ( %s/%s ): [%s] bgp_attr_parse() failed: type=%d\n", config.name, bms->log_str, bgp_peer_str, type);
-      return ret; 
+      goto attr_parse_end;
     }
 
     ptr += attr_len;
@@ -967,11 +978,16 @@ int bgp_attr_parse(struct bgp_peer *peer, struct bgp_attr *attr, struct bgp_attr
     /* AS_PATH and AS4_PATH info are now fully merged;
        hence we can free up temporary structures. */
     aspath_unintern(peer, as4_path);
-  
+
     if (ret < 0) return ret;
   }
 
   return SUCCESS;
+
+attr_parse_end:
+  if (as4_path)
+    aspath_unintern(peer, as4_path);
+  return ret;
 }
 
 int bgp_attr_parse_aspath(struct bgp_peer *peer, u_int16_t len, struct bgp_attr *attr, char *ptr, u_int8_t flag)


### PR DESCRIPTION
### Short description
- bgp_parse_update_msg: unintern partially-parsed attr components (aspath, community, ecommunity, lcommunity) when bgp_attr_parse() returns an error, preventing leaks on malformed UPDATE messages

- bgp_attr_parse: use goto cleanup label so as4_path is always uninterned on all early-return error paths inside the parse loop

- bgp_ls_nlri_parse: initialize tlv_type to 0 to prevent undefined behaviour when the inner TLV loop does not execute, which could cause phantom RIB insertions

- bgp_ls_nlri_parse: free attr_hdr and attr_aux when cdada_map_insert_replace fails to avoid leaking both allocations

### Checklist
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
