### PR TITLE
fix(nfacctd): replace stale vrf_name_map entry on VRF ID reassignment

### DIFF
--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -2353,10 +2353,16 @@ void process_v9_packet(unsigned char *pkt, u_int16_t len, struct packet_ptrs_vec
 	      memset(vrf_name, 0, MAX_VRF_NAME_STR_LEN);
 	      memcpy(vrf_name, (const char *)pkt + tpl->fld[NF9_VRF_NAME].off[0], MIN(tpl->fld[NF9_VRF_NAME].len[0], (MAX_VRF_NAME - 1)));
 
-	      ret = cdada_map_insert(entry->vrf_name_map, &ingress_vrfid, vrf_name);
-              if (ret != CDADA_SUCCESS && ret != CDADA_E_EXISTS) {
-                Log(LOG_ERR, "ERROR ( %s/core ): Unable to insert in entry->vrf_name_map. Exiting.\n", config.name);
+              char *old_vrf_name = NULL;
+              /* Insert or replace the vrf_id -> vrf_name mapping, freeing any
+                 previously stored name for this vrf_id */
+              ret = cdada_map_insert_replace(entry->vrf_name_map, &ingress_vrfid, vrf_name, (void **) &old_vrf_name);
+              if (ret != CDADA_SUCCESS) {
+                Log(LOG_ERR, "ERROR ( %s/core ): Unable to insert/replace in entry->vrf_name_map. Exiting.\n", config.name);
                 exit_gracefully(1);
+              }
+              else {
+                if (old_vrf_name) free(old_vrf_name);
               }
 
               Log(LOG_DEBUG, "DEBUG ( %s/core ): Mapped ingress vrf id %d, to vrf_name %s\n", config.name, ingress_vrfid, vrf_name);


### PR DESCRIPTION
### Short description
cdada_map_insert() silently ignores updates to existing keys (returns CDADA_E_EXISTS) leaving the old mapping in place permanently.

When a router reassigns its internal VRF IDs, both the old and new mappings coexist in vrf_name_map indefinitely. Consider the following before/after state on the router:

Before:  ID_1 -> NAME_A,  ID_X -> NAME_B
After:   ID_1 -> NAME_B,  ID_2 -> NAME_A

The router sends both new option records. ID_2 -> NAME_A is a fresh key and inserts correctly. ID_1 -> NAME_B hits an existing key and the update is silently dropped. nfacctd then permanently holds:

ID_1 -> NAME_A  (stale — should be NAME_B)
ID_2 -> NAME_A  (correct)

All flows arriving with ID_1 are enriched with NAME_A instead of NAME_B, causing flows from one customer to appear under another customer's VRF context in the output. The daemon retains this wrong state until restarted, which explains why a restart temporarily resolves the issue.

Replace cdada_map_insert() with cdada_map_insert_replace(), which atomically updates existing keys and returns the old pointer for freeing, handling both insert and update in a single call.

### Checklist
I have:
- [X] added the [LICENSE template](https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files
- [X] compiled & tested this code
- [X] included documentation (including possible behaviour changes)
