### PR TITLE
bmp: fix conflicting-types error under GCC 15 / C23

### DIFF
--- a/src/bmp/bmp_logdump.h
+++ b/src/bmp/bmp_logdump.h
@@ -86,7 +86,7 @@ struct bmp_dump_se_ll {
 };
 
 /* prototypes */
-extern void bmp_daemon_msglog_init_amqp_host();
+extern void bmp_daemon_msglog_init_amqp_host(void *);
 extern void bmp_dump_init_peer(struct bgp_peer *);
 extern void bmp_dump_close_peer(struct bgp_peer *);
 


### PR DESCRIPTION
### Problem

Building current master with GCC 15 fails to compile the BMP daemon:
```bash
src/bmp/bmp_logdump.h:108: error: conflicting types for
'bmp_daemon_msglog_init_amqp_host'; have 'void(void *)'
src/bmp/bmp_logdump.h:89: note: previous declaration with type 'void(void)'
```
### Cause

`bmp_logdump.h` forward-declares `bmp_daemon_msglog_init_amqp_host` with
empty parentheses:

```c
extern void bmp_daemon_msglog_init_amqp_host();
```

Before C23, empty parentheses denoted an unprototyped declaration
("unspecified arguments"), which older compilers accepted alongside the
real prototype. C23 — the default language mode in GCC 15 — redefines
`()` to be equivalent to `(void)`, i.e. *no* arguments. That now
conflicts with the function's actual definition in `src/bmp/bmp_logdump.c`,
which takes a `void *`:

```c
void bmp_daemon_msglog_init_amqp_host(void *bdmah) { ... }
```

The mirror declaration in the other conditional-compilation branch already
uses `(void *)`; only this one was left with the stale empty-parens form,
so it went unnoticed until the C23 default made it an error.

### Fix

Give the declaration the correct prototype so it matches both the
definition and the sibling declaration. This is valid on all supported
GCC versions and changes no behaviour.

```diff
-extern void bmp_daemon_msglog_init_amqp_host();
+extern void bmp_daemon_msglog_init_amqp_host(void *);
```

### Testing

Compiles cleanly with GCC 15 (C23 default). No functional change.