### PR TITLE
fix, JSON/Avro plugins: encode tcp_flags as an integer instead of a string

### DIFF
--- a/src/plugin_cmn_avro.c
+++ b/src/plugin_cmn_avro.c
@@ -327,7 +327,7 @@ avro_schema_t p_avro_schema_build_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_in
       compose_tcpflags_avro_schema(schema);
     }
     else {
-      avro_schema_record_field_append(schema, "tcp_flags", avro_schema_string());
+      avro_schema_record_field_append(schema, "tcp_flags", avro_schema_long());
     }
   }
 
@@ -1068,14 +1068,12 @@ avro_value_t compose_avro_acct_data(u_int64_t wtc, u_int64_t wtc_2, u_int64_t wt
 #endif
 
   if (wtc & COUNT_TCPFLAGS) {
-    sprintf(misc_str, "%u", tcp_flags);
-
     if (config.tcpflags_encode_as_array) {
       compose_tcpflags_avro_data(tcp_flags, value);
     }
     else {
       pm_avro_check(avro_value_get_by_name(&value, "tcp_flags", &field, NULL));
-      pm_avro_check(avro_value_set_string(&field, misc_str));
+      pm_avro_check(avro_value_set_long(&field, tcp_flags));
     }
   }
 

--- a/src/plugin_cmn_json.c
+++ b/src/plugin_cmn_json.c
@@ -1036,10 +1036,7 @@ void compose_json_dst_host_coords(json_t *obj, struct chained_cache *cc)
 
 void compose_json_tcp_flags(json_t *obj, struct chained_cache *cc)
 {
-  char misc_str[VERYSHORTBUFLEN];
-
-  sprintf(misc_str, "%u", cc->tcp_flags);
-  json_object_set_new_nocheck(obj, "tcp_flags", json_string(misc_str));
+  json_object_set_new_nocheck(obj, "tcp_flags", json_integer((json_int_t)cc->tcp_flags));
 }
 
 void compose_json_fwd_status(json_t *obj, struct chained_cache *cc)


### PR DESCRIPTION
### Short description

**tcp_flags** is emitted as a string in both the JSON and Avro output plugins, instead of an integer/long, with no apparent reason. tcp_flags is a ``u_int8_t`` bitmask (e.g. SYN+ACK = 18) — not a symbolic string — so this forces every consumer to parse a stringified number back into an integer for no benefit.

This appears to be a long-standing inconsistency rather than an intentional design choice:

- Neighboring numeric primitives in the exact same functions (``ip_tos``, ``sampling_rate``) are already correctly emitted as json_integer/avro_schema_long.
- The formatted/CSV print plugin (``print_plugin.c``) and the SQL output (``sql_common.c``) already treat tcp_flags as a plain numeric value (%u, unquoted).
- Only the JSON and Avro composers stringify it, via ``sprintf(misc_str, "%u", tcp_flags)`` followed by ``json_string()``/``avro_value_set_string()``.
- Traced the git history back to when JSON/Avro output for tcp_flags was first introduced (~2016-2017) — no commit message, comment, or existing issue documents a rationale for the string type.

This PR changes tcp_flags to be emitted as json_integer/avro_schema_long (and avro_value_set_long) in the default (non-array) encoding path, matching how ip_tos/sampling_rate are already handled. The opt-in ``tcpflags_encode_as_array`` encoding (symbolic flag names) is untouched.


### Checklist

I have:
  - [x] compiled & tested this code (built pmacct with this patch applied, ran nfacctd, and separately verified the exact compose_json_tcp_flags function against a real jansson build before/after: {"tcp_flags":"18"} → {"tcp_flags":18})
  - [x] added the LICENSE template to new files (n/a — no new files)
  - [ ] included documentation (behavior change noted above; let me know if a docs update is expected elsewhere, e.g. CONFIG-KEYS)
