### PR TITLE
Allow to configure syslog's ident

### DIFF
--- a/CONFIG-KEYS
+++ b/CONFIG-KEYS
@@ -589,7 +589,14 @@ VALUES:		[ auth | mail | daemon | kern | user | local[0-7] ]
 DESC:		Enables syslog logging, using the specified facility.
 DEFAULT:	none (logging to stderr)
 
-KEY:		logfile [GLOBAL] 
+KEY:		syslog_ident [GLOBAL]
+DESC:		Defines the identity string (openlog()'s ident argument) prepended to every syslog
+		message. Only relevant when syslog is enabled. When unspecified, NULL is given to the ident
+		argument. For some implementations of openlog, e.g., musl's, if ident is NULL, an empty
+		string is used; different than glibc's where the program name is used.
+DEFAULT:	none (NULL ident given to openlog())
+
+KEY:		logfile [GLOBAL]
 DESC:           Enables logging to a file (bypassing syslog); expected value is a pathname. The target
 		file can be re-opened by sending a SIGHUP to the daemon so that, for example, logs can
 		be rotated. 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -30,6 +30,7 @@ static const struct _dictionary_line dictionary[] = {
   {"debug_internal_msg", cfg_key_debug_internal_msg},
   {"dry_run", cfg_key_dry_run},
   {"syslog", cfg_key_syslog},
+  {"syslog_ident", cfg_key_syslog_ident},
   {"logfile", cfg_key_logfile},
   {"log_stderr_tstamp", cfg_key_log_stderr_tstamp},
   {"pidfile", cfg_key_pidfile},

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -583,6 +583,7 @@ struct configuration {
   int sampling_rate;
   char *sampling_map;
   char *syslog;
+  char *syslog_ident;
   int debug;
   int debug_internal_msg;
   int dry_run;

--- a/src/cfg_handlers.c
+++ b/src/cfg_handlers.c
@@ -143,6 +143,25 @@ int cfg_key_syslog(char *filename, char *name, char *value_ptr)
   return changes;
 }
 
+int cfg_key_syslog_ident(char *filename, char *name, char *value_ptr)
+{
+  struct plugins_list_entry *list = plugins_list;
+  int changes = 0;
+
+  if (!name) for (; list; list = list->next, changes++) list->cfg.syslog_ident = value_ptr;
+  else {
+    for (; list; list = list->next) {
+      if (!strcmp(name, list->name)) {
+        list->cfg.syslog_ident = value_ptr;
+        changes++;
+        break;
+      }
+    }
+  }
+
+  return changes;
+}
+
 int cfg_key_logfile(char *filename, char *name, char *value_ptr)
 {
   struct plugins_list_entry *list = plugins_list;

--- a/src/cfg_handlers.h
+++ b/src/cfg_handlers.h
@@ -32,6 +32,7 @@ extern int cfg_key_debug(char *, char *, char *);
 extern int cfg_key_debug_internal_msg(char *, char *, char *);
 extern int cfg_key_dry_run(char *, char *, char *);
 extern int cfg_key_syslog(char *, char *, char *);
+extern int cfg_key_syslog_ident(char *, char *, char *);
 extern int cfg_key_logfile(char *, char *, char *);
 extern int cfg_key_log_stderr_tstamp(char *, char *, char *);
 extern int cfg_key_pidfile(char *, char *, char *);

--- a/src/nfacctd.c
+++ b/src/nfacctd.c
@@ -453,7 +453,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/pmacctd.c
+++ b/src/pmacctd.c
@@ -599,7 +599,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/pmbgpd.c
+++ b/src/pmbgpd.c
@@ -231,7 +231,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/pmbmpd.c
+++ b/src/pmbmpd.c
@@ -243,7 +243,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/pmtelemetryd.c
+++ b/src/pmtelemetryd.c
@@ -223,7 +223,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/sfacctd.c
+++ b/src/sfacctd.c
@@ -435,7 +435,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/uacctd.c
+++ b/src/uacctd.c
@@ -457,7 +457,7 @@ int main(int argc,char **argv, char **envp)
       config.syslog = NULL;
       printf("WARN ( %s/core ): specified syslog facility is not supported. Logging to standard error (stderr).\n", config.name);
     }
-    else openlog(NULL, LOG_PID, logf);
+    else openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/core ): Start logging ...\n", config.name);
   }
 

--- a/src/util.c
+++ b/src/util.c
@@ -3711,7 +3711,7 @@ void reload_logs(char *header)
       config.syslog = NULL;
       Log(LOG_WARNING, "WARN ( %s/%s ): specified syslog facility is not supported; logging to console.\n", config.name, config.type);
     }
-    openlog(NULL, LOG_PID, logf);
+    openlog(config.syslog_ident, LOG_PID, logf);
     Log(LOG_INFO, "INFO ( %s/%s ): Start logging ...\n", config.name, config.type);
   }
 


### PR DESCRIPTION
Some openlog() implementations like musl assume an empty string instead of the program name. This patch will not break backwards compatibility for cases where a symlink is used to change the program name.

- [X] compiled & tested this code
- [X] included documentation
