### PR TITLE
fix, nfacctd: flatten IPFIX (v10) timestamp start/end handler conditions

### DIFF
--- a/src/pkt_handlers.c
+++ b/src/pkt_handlers.c
@@ -3858,13 +3858,11 @@ void NF_timestamp_start_handler(struct channels_list_entry *chptr, struct packet
       pnat->timestamp_start.tv_sec = ntohl(((struct struct_header_v9 *) pptrs->f_header)->unix_secs)-
         ((int32_t)(ntohl(((struct struct_header_v9 *) pptrs->f_header)->SysUptime)-ntohl(fstime))/1000);
     }
-    else if (tpl->fld[NF9_FIRST_SWITCHED].count && hdr->version == 10) {
-      if (OTPL_LAST_LEN(NF9_SYS_UPTIME_MSEC) == 8) {
-        OTPL_CP_LAST(&fstime, NF9_FIRST_SWITCHED);
-        OTPL_CP_LAST(&t64, NF9_SYS_UPTIME_MSEC);
-	t32 = pm_ntohll(t64)/1000;
-        pnat->timestamp_start.tv_sec = t32+(ntohl(fstime)/1000);
-      }
+    else if (tpl->fld[NF9_FIRST_SWITCHED].count && hdr->version == 10 && OTPL_LAST_LEN(NF9_SYS_UPTIME_MSEC) == 8) {
+      OTPL_CP_LAST(&fstime, NF9_FIRST_SWITCHED);
+      OTPL_CP_LAST(&t64, NF9_SYS_UPTIME_MSEC);
+      t32 = pm_ntohll(t64)/1000;
+      pnat->timestamp_start.tv_sec = t32+(ntohl(fstime)/1000);
     }
     else if (tpl->fld[NF9_FIRST_SWITCHED_MSEC].count) {
       OTPL_CP_LAST(&t64, NF9_FIRST_SWITCHED_MSEC);
@@ -3957,13 +3955,11 @@ void NF_timestamp_end_handler(struct channels_list_entry *chptr, struct packet_p
       pnat->timestamp_end.tv_sec = ntohl(((struct struct_header_v9 *) pptrs->f_header)->unix_secs)-
         ((int32_t)(ntohl(((struct struct_header_v9 *) pptrs->f_header)->SysUptime)-ntohl(fstime))/1000);
     }
-    else if (tpl->fld[NF9_LAST_SWITCHED].count && hdr->version == 10) {
-      if (OTPL_LAST_LEN(NF9_SYS_UPTIME_MSEC) == 8) {
-        OTPL_CP_LAST(&fstime, NF9_LAST_SWITCHED);
-        OTPL_CP_LAST(&t64, NF9_SYS_UPTIME_MSEC);
-        t32 = pm_ntohll(t64)/1000;
-        pnat->timestamp_end.tv_sec = t32+(ntohl(fstime)/1000);
-      }
+    else if (tpl->fld[NF9_LAST_SWITCHED].count && hdr->version == 10 && OTPL_LAST_LEN(NF9_SYS_UPTIME_MSEC) == 8) {
+      OTPL_CP_LAST(&fstime, NF9_LAST_SWITCHED);
+      OTPL_CP_LAST(&t64, NF9_SYS_UPTIME_MSEC);
+      t32 = pm_ntohll(t64)/1000;
+      pnat->timestamp_end.tv_sec = t32+(ntohl(fstime)/1000);
     }
     else if (tpl->fld[NF9_LAST_SWITCHED_MSEC].count) {
       OTPL_CP_LAST(&t64, NF9_LAST_SWITCHED_MSEC);


### PR DESCRIPTION
### Short description

When collecting IPFIX (NetFlow v10) from an exporter that sends the uptime‑relative flow times ``flowStartSysUpTime (22)`` / ``flowEndSysUpTime (21)`` but does not send ``systemInitTimeMilliseconds (160)``, nfacctd fails to resolve flow times:

- ``timestamp_end`` comes out as 0 on every record.
- ``timestamp_start`` is wrong too. It silently falls back to the packet/header export time instead of the real flow start.

This happens even though the same templates also carry the absolute millisecond fields ``flowStartMilliseconds (152)`` / ``flowEndMilliseconds (153)``, which nfacctd supports and should have used.

#### Root cause

In ``NF_timestamp_start_handler()`` and ``NF_timestamp_end_handler()`` (``src/pkt_handlers.c``), the resolution logic is an else if chain:

```c

else if (tpl->fld[NF9_LAST_SWITCHED].count && hdr->version == 10) {   // (A)
  if (OTPL_LAST_LEN(NF9_SYS_UPTIME_MSEC) == 8) {                      // (B)
    ... compute end from sysUpTime ...
  }
  /* else: nothing is set */
}
else if (tpl->fld[NF9_LAST_SWITCHED_MSEC].count) {                    // (C)
  ... set end from flowEndMilliseconds ...
}

```

Branch (A) matches whenever the template contains LAST_SWITCHED (21) on a v10 packet. But it can only actually produce a value when SYS_UPTIME_MSEC (160) is present (inner if (B)). When 160 is absent, (A) still matches, the inner if is false, and nothing is set — yet because (A) is an else if that matched, it consumes the chain, so branch (C) (LAST_SWITCHED_MSEC, which is present) is never reached. The result is timestamp_end == 0.

The start handler has the same structure but additionally has a "fallback to header unix_secs" block, so timestamp_start gets a value (the export time) rather than 0 — masking the same bug as merely-inaccurate rather than missing.

#### Fix

Fold the SYS_UPTIME_MSEC length check into the else if condition itself, in both handlers, so the branch only claims the chain when it can actually compute a value:

```c
else if (tpl->fld[NF9_LAST_SWITCHED].count && hdr->version == 10 && OTPL_LAST_LEN(NF9_SYS_UPTIME_MSEC) == 8) {
  ... compute end from sysUpTime ...
}
else if (tpl->fld[NF9_LAST_SWITCHED_MSEC].count) {
  ... set end from flowEndMilliseconds ...
}
```

Now, when systemInitTimeMilliseconds is absent, the branch no longer matches and control falls through to the *_SWITCHED_MSEC branch, which resolves the flow time from the absolute millisecond fields.

#### Testing

I have tested this patch with IPFIX v10 capture (CISCO exporter; templates carry field types 21/22/152/153 but not 160) through ``nfacctd -I``, aggregating on timestamp_start, timestamp_end, timestamp_arrival.




### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added the [LICENSE template]
(https://github.com/pmacct/pmacct/blob/master/LICENSE.template) to new files -- No new file N/A
- [x] compiled & tested this code
- [ ] included documentation (including possible behaviour changes). Please let me know which document I should contribute to. 

Thank you!
